### PR TITLE
fix(transaction): keep transfer recipient amount in sync when editing

### DIFF
--- a/internal/account/read.go
+++ b/internal/account/read.go
@@ -41,6 +41,17 @@ func (s *Service) AccountOwner(ctx context.Context, accountID vo.Id) (vo.Id, err
 	return acct.UserID, nil
 }
 
+// AccountCurrency returns an account's currency id (for cross-module use, e.g.
+// transaction's transfer amount normalization). Missing -> *errs.NotFoundError
+// (from the repo).
+func (s *Service) AccountCurrency(ctx context.Context, accountID vo.Id) (vo.Id, error) {
+	acct, err := s.accounts.GetByID(ctx, accountID)
+	if err != nil {
+		return vo.Id{}, err
+	}
+	return acct.CurrencyID, nil
+}
+
 // VisibleAccountIDs returns the ids of the user's available (non-deleted)
 // accounts that are NOT in a hidden folder — the set whose transactions the user
 // may list.

--- a/internal/transaction/access_test.go
+++ b/internal/transaction/access_test.go
@@ -25,6 +25,10 @@ func (s stubAccountResolver) AccountListForUser(ctx context.Context, userID vo.I
 	return nil, nil
 }
 
+func (s stubAccountResolver) AccountCurrency(ctx context.Context, accountID vo.Id) (vo.Id, error) {
+	return vo.Id{}, s.ownerErr
+}
+
 // stubAccountGrants is a minimal AccountGrants whose HasWriteGrant result is
 // controlled per test.
 type stubAccountGrants struct {

--- a/internal/transaction/api/transfer_normalize_test.go
+++ b/internal/transaction/api/transfer_normalize_test.go
@@ -1,0 +1,155 @@
+package api_test
+
+// Transfer amount_recipient integrity: the recipient account's balance is
+// SUM(amount_recipient), and the reporting queries classify a transfer leg as a
+// currency exchange via amount != amount_recipient. The server therefore
+// normalizes what clients send: a same-currency transfer always stores
+// amount_recipient = amount (stale/missing client values would silently corrupt
+// the recipient balance), and a cross-currency transfer must carry an explicit
+// amountRecipient (defaulting would fabricate an exchange rate).
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/econumo/econumo/internal/infra/storage/backend"
+	"github.com/econumo/econumo/internal/test/dbtest"
+	"github.com/econumo/econumo/internal/test/fixture"
+)
+
+const (
+	usd2AcctID = "aaaa3333-0000-0000-0000-0000000000a3"
+	eurAcctID  = "aaaa4444-0000-0000-0000-0000000000a4"
+)
+
+// seedTransferAccounts adds two more seed-user accounts: a second USD account
+// and a EUR one, both in the main folder.
+func (h *harness) seedTransferAccounts(t *testing.T) {
+	t.Helper()
+	txm := backend.NewTxManager(h.db)
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite", TX: txm}).WithCrypto(testDataSalt)
+	f.Account(fixture.Account{ID: usd2AcctID, UserID: seedUserID, CurrencyID: usdID, Name: "Bank"})
+	f.AccountInFolder(folderID, usd2AcctID)
+	f.AccountOption(usd2AcctID, seedUserID, 1)
+	eurID := f.Currency(fixture.Currency{Code: "EUR", Symbol: "€", Name: "Euro"})
+	f.Account(fixture.Account{ID: eurAcctID, UserID: seedUserID, CurrencyID: eurID, Name: "Euro Stash"})
+	f.AccountInFolder(folderID, eurAcctID)
+	f.AccountOption(eurAcctID, seedUserID, 2)
+}
+
+// transferReq builds a create/update-transaction transfer body; amountRecipient
+// is included only when non-nil.
+func transferReq(id, from, to, amount string, amountRecipient any) map[string]any {
+	m := map[string]any{
+		"id": id, "type": "transfer", "amount": amount, "accountId": from,
+		"accountRecipientId": to, "date": "2024-03-01 10:00:00", "description": "move",
+	}
+	if amountRecipient != nil {
+		m["amountRecipient"] = amountRecipient
+	}
+	return m
+}
+
+func balanceOf(t *testing.T, res writeResult, accountID string) string {
+	t.Helper()
+	for _, a := range res.Accounts {
+		if a.ID == accountID {
+			return a.Balance
+		}
+	}
+	t.Fatalf("account %s not in embed: %+v", accountID, res.Accounts)
+	return ""
+}
+
+func TestCreateTransfer_SameCurrency_MismatchedRecipientAmountNormalized(t *testing.T) {
+	h := newHarness(t)
+	h.seedTransferAccounts(t)
+	tok := h.token(t)
+	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok,
+		transferReq(txID1, accountID, usd2AcctID, "100", "50"))
+	if status != http.StatusOK {
+		t.Fatalf("status=%d want 200; body: %s", status, env.raw)
+	}
+	res := mustUnmarshal[writeResult](t, env.Data)
+	if res.Item.AmountRecipient == nil || *res.Item.AmountRecipient != "100" {
+		t.Fatalf("amountRecipient = %v, want 100 (normalized to amount)", res.Item.AmountRecipient)
+	}
+	if got := balanceOf(t, res, usd2AcctID); got != "100" {
+		t.Fatalf("recipient balance = %q, want 100", got)
+	}
+	if got := balanceOf(t, res, accountID); got != "-100" {
+		t.Fatalf("source balance = %q, want -100", got)
+	}
+}
+
+func TestCreateTransfer_SameCurrency_MissingRecipientAmountDefaults(t *testing.T) {
+	h := newHarness(t)
+	h.seedTransferAccounts(t)
+	tok := h.token(t)
+	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok,
+		transferReq(txID1, accountID, usd2AcctID, "100", nil))
+	if status != http.StatusOK {
+		t.Fatalf("status=%d want 200; body: %s", status, env.raw)
+	}
+	res := mustUnmarshal[writeResult](t, env.Data)
+	if got := balanceOf(t, res, usd2AcctID); got != "100" {
+		t.Fatalf("recipient balance = %q, want 100 (NULL amount_recipient credits nothing)", got)
+	}
+}
+
+func TestCreateTransfer_CrossCurrency_MissingRecipientAmount400(t *testing.T) {
+	h := newHarness(t)
+	h.seedTransferAccounts(t)
+	tok := h.token(t)
+	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok,
+		transferReq(txID1, accountID, eurAcctID, "100", nil))
+	if status != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400; body: %s", status, env.raw)
+	}
+	msgs := env.errorsMap()["amountRecipient"]
+	if len(msgs) != 1 || msgs[0] != "This value should not be blank." {
+		t.Fatalf("errors.amountRecipient = %v, want the blank-value message", msgs)
+	}
+}
+
+func TestCreateTransfer_CrossCurrency_ClientRecipientAmountPreserved(t *testing.T) {
+	h := newHarness(t)
+	h.seedTransferAccounts(t)
+	tok := h.token(t)
+	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok,
+		transferReq(txID1, accountID, eurAcctID, "100", "90"))
+	if status != http.StatusOK {
+		t.Fatalf("status=%d want 200; body: %s", status, env.raw)
+	}
+	res := mustUnmarshal[writeResult](t, env.Data)
+	if res.Item.AmountRecipient == nil || *res.Item.AmountRecipient != "90" {
+		t.Fatalf("amountRecipient = %v, want 90 (client value kept cross-currency)", res.Item.AmountRecipient)
+	}
+	if got := balanceOf(t, res, eurAcctID); got != "90" {
+		t.Fatalf("recipient balance = %q, want 90", got)
+	}
+}
+
+// The reported production bug: editing a same-currency transfer's amount while
+// the client re-sends the stale recipient amount must not freeze the recipient
+// account's balance at the old value.
+func TestUpdateTransfer_SameCurrency_StaleRecipientAmountNormalized(t *testing.T) {
+	h := newHarness(t)
+	h.seedTransferAccounts(t)
+	tok := h.token(t)
+	_, cEnv := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok,
+		transferReq(txID1, accountID, usd2AcctID, "10", "10"))
+	created := mustUnmarshal[writeResult](t, cEnv.Data)
+	upd := transferReq(created.Item.ID, accountID, usd2AcctID, "25", "10")
+	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/update-transaction", tok, upd)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d want 200; body: %s", status, env.raw)
+	}
+	res := mustUnmarshal[writeResult](t, env.Data)
+	if res.Item.AmountRecipient == nil || *res.Item.AmountRecipient != "25" {
+		t.Fatalf("amountRecipient = %v, want 25 (normalized to amount)", res.Item.AmountRecipient)
+	}
+	if got := balanceOf(t, res, usd2AcctID); got != "25" {
+		t.Fatalf("recipient balance = %q, want 25 (stale 10 must not survive)", got)
+	}
+}

--- a/internal/transaction/create.go
+++ b/internal/transaction/create.go
@@ -55,6 +55,9 @@ func (s *Service) CreateTransaction(ctx context.Context, userID vo.Id, req model
 		if berr != nil {
 			return berr
 		}
+		if nerr := s.normalizeTransferAmounts(ctx, &st); nerr != nil {
+			return nerr
+		}
 		t := model.New(st)
 		if serr := s.repo.Save(ctx, t); serr != nil {
 			return serr

--- a/internal/transaction/ports.go
+++ b/internal/transaction/ports.go
@@ -24,6 +24,9 @@ type AccountResolver interface {
 	// AccountOwner returns the owner user id of an account (for the access
 	// check). Missing -> *errs.NotFoundError.
 	AccountOwner(ctx context.Context, accountID vo.Id) (vo.Id, error)
+	// AccountCurrency returns the account's currency id (for transfer
+	// amount-recipient normalization). Missing -> *errs.NotFoundError.
+	AccountCurrency(ctx context.Context, accountID vo.Id) (vo.Id, error)
 	// AccountListForUser returns the user's available accounts in the wire shape
 	// (reverse order), for the create/update/delete result embed.
 	AccountListForUser(ctx context.Context, userID vo.Id) ([]model.AccountResult, error)

--- a/internal/transaction/update.go
+++ b/internal/transaction/update.go
@@ -60,6 +60,9 @@ func (s *Service) UpdateTransaction(ctx context.Context, userID vo.Id, req model
 		if berr != nil {
 			return berr
 		}
+		if nerr := s.normalizeTransferAmounts(ctx, &st); nerr != nil {
+			return nerr
+		}
 		t.Update(st, now)
 		if serr := s.repo.Save(ctx, t); serr != nil {
 			return serr

--- a/internal/transaction/usecase.go
+++ b/internal/transaction/usecase.go
@@ -201,6 +201,39 @@ func buildState(
 	return st, nil
 }
 
+// normalizeTransferAmounts enforces the transfer amount-recipient invariants
+// before persisting. The recipient account's balance is SUM(amount_recipient)
+// and the reporting queries classify an exchange leg via
+// amount != amount_recipient, so a stale or missing client value silently
+// corrupts both. Same-currency transfers therefore always store
+// amount_recipient = amount; cross-currency transfers must carry an explicit
+// amountRecipient (the received amount is client-authoritative — the user's
+// actual rate, not ours — so defaulting would fabricate it). No-op for
+// non-transfers and for transfers without a recipient account.
+func (s *Service) normalizeTransferAmounts(ctx context.Context, st *model.NewState) error {
+	if !st.Type.IsTransfer() || st.AccountRecipID == nil {
+		return nil
+	}
+	srcCur, err := s.accounts.AccountCurrency(ctx, st.AccountID)
+	if err != nil {
+		return err
+	}
+	dstCur, err := s.accounts.AccountCurrency(ctx, *st.AccountRecipID)
+	if err != nil {
+		return errs.NewValidation("account.account.not_available")
+	}
+	if srcCur.Equal(dstCur) {
+		amount := st.Amount
+		st.AmountRecipient = &amount
+		return nil
+	}
+	if st.AmountRecipient == nil {
+		return errs.NewValidation("Validation failed",
+			errs.FieldError{Key: "amountRecipient", Message: "This value should not be blank.", Code: "IS_BLANK_ERROR"})
+	}
+	return nil
+}
+
 // parseType maps the wire alias to the domain TransactionType.
 func parseType(alias string) (model.TransactionType, error) {
 	switch alias {

--- a/web/src/features/transactions/TransactionDialog.test.tsx
+++ b/web/src/features/transactions/TransactionDialog.test.tsx
@@ -157,6 +157,59 @@ it('editing a transfer allows changing the sender account', async () => {
   expect(body!.accountRecipientId).toBe('a3')
 })
 
+it('editing a same-currency transfer amount re-syncs the recipient amount', async () => {
+  let body: Record<string, unknown> | undefined
+  server.use(
+    http.post('*/api/v1/transaction/update-transaction', async ({ request }) => {
+      body = (await request.json()) as Record<string, unknown>
+      return HttpResponse.json({
+        success: true, message: '',
+        data: { item: wireTxEcho({ type: 'transfer', accountId: 'a1', accountRecipientId: 'a2' }), accounts: fixtureAccounts },
+      })
+    }),
+  )
+  const user = userEvent.setup()
+  renderDialog()
+  useUiStore.getState().openTransactionModal({
+    transaction: wireTxEcho({ type: 'transfer', accountId: 'a1', accountRecipientId: 'a2', amount: '9.99', amountRecipient: '9.99', categoryId: null }) as unknown as TransactionDto,
+  })
+  await screen.findByRole('heading', { name: 'Edit transaction' })
+  const amount = screen.getByLabelText('Amount')
+  await user.clear(amount)
+  await user.type(amount, '25')
+  await user.click(screen.getByRole('button', { name: 'Update' }))
+  await waitFor(() => expect(body).toBeDefined())
+  expect(body!.amount).toBe(25)
+  // the recipient side must follow the edited amount, not keep the old one
+  expect(body!.amountRecipient).toBe(25)
+})
+
+it('editing a transfer re-syncs the recipient amount when the destination account changes', async () => {
+  let body: Record<string, unknown> | undefined
+  server.use(
+    http.post('*/api/v1/transaction/update-transaction', async ({ request }) => {
+      body = (await request.json()) as Record<string, unknown>
+      return HttpResponse.json({
+        success: true, message: '',
+        data: { item: wireTxEcho({ type: 'transfer', accountId: 'a1', accountRecipientId: 'a3' }), accounts: fixtureAccounts },
+      })
+    }),
+  )
+  const user = userEvent.setup()
+  renderDialog()
+  useUiStore.getState().openTransactionModal({
+    transaction: wireTxEcho({ type: 'transfer', accountId: 'a1', accountRecipientId: 'a2', amount: '10', amountRecipient: '10', categoryId: null }) as unknown as TransactionDto,
+  })
+  await screen.findByRole('heading', { name: 'Edit transaction' })
+  // USD -> EUR at rate 0.9: the old same-currency recipient amount must not survive
+  await user.click(screen.getByRole('combobox', { name: 'to account' }))
+  await user.click(await screen.findByText(/Euro Stash/))
+  await user.click(screen.getByRole('button', { name: 'Update' }))
+  await waitFor(() => expect(body).toBeDefined())
+  expect(body!.accountRecipientId).toBe('a3')
+  expect(body!.amountRecipient).toBe(9)
+})
+
 it('cross-currency transfer prefills the converted recipient amount and prompts to switch', async () => {
   let body: Record<string, unknown> | undefined
   server.use(

--- a/web/src/features/transactions/TransactionDialog.tsx
+++ b/web/src/features/transactions/TransactionDialog.tsx
@@ -103,7 +103,9 @@ function TransactionForm({ params, onDone }: { params: OpenTransactionParams; on
   const crossCurrency = isTransfer && account && accountRecipient && account.currency.id !== accountRecipient.currency.id
 
   const setAmount = (amount: string) => {
-    if (isTransfer && form.isNew) {
+    if (isTransfer) {
+      // also when editing: a stale recipient amount would silently keep the
+      // recipient account's balance unchanged (Vue recomputed unconditionally)
       patch({ amount, amountRecipient: recomputeRecipientAmount(amount, account, accountRecipient, exchangeFn) })
     } else {
       patch({ amount })
@@ -114,7 +116,9 @@ function TransactionForm({ params, onDone }: { params: OpenTransactionParams; on
     const recipient = accounts.find((a) => a.id === id)
     patch({
       accountRecipientId: id,
-      amountRecipient: form.isNew ? recomputeRecipientAmount(form.amount, account, recipient, exchangeFn) : form.amountRecipient,
+      // also when editing: the saved recipient amount is for the OLD
+      // destination (and possibly its currency), so re-derive it
+      amountRecipient: recomputeRecipientAmount(form.amount, account, recipient, exchangeFn),
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes the reported bug: after updating a transfer's amount, the destination account kept showing the old balance.

- **Frontend (root cause, a Vue-parity regression):** `TransactionDialog` only recomputed `amountRecipient` for *new* transactions (`form.isNew` gates in `setAmount` and `setRecipientAccount`); the old Vue modal recomputed unconditionally. For same-currency transfers the recipient-amount field isn't rendered, so the stale seeded value silently round-tripped on every edit. Both gates are removed: same-currency edits mirror the amount, cross-currency edits convert at the current rate (the visible field stays user-editable).
- **Backend (defense-in-depth for all clients):** `CreateTransaction`/`UpdateTransaction` now normalize transfer amounts before persisting:
  - same-currency transfer → `amount_recipient` is forced to `amount` (the recipient balance is `SUM(amount_recipient)`, and reports classify exchange legs via `amount != amount_recipient`, so stale/missing values corrupt both);
  - cross-currency transfer without `amountRecipient` → 400 with the standard blank-field error, instead of silently storing NULL and crediting the recipient nothing;
  - a client-supplied cross-currency value is preserved untouched (the received amount is client-authoritative).

  Wiring: the transaction feature's `AccountResolver` port gains `AccountCurrency`, implemented by the account service — no new glue needed.

## Test plan

- [x] New dialog tests: editing a same-currency transfer's amount re-syncs the recipient amount; switching the destination account re-derives it (USD→EUR at the fixture rate). Both watched fail first.
- [x] New API tests (`internal/transaction/api/transfer_normalize_test.go`, real handler + sqlite): mismatch normalized, NULL defaulted, cross-currency missing → 400 with exact field error, cross-currency client value preserved, and the reported update scenario end-to-end. All watched fail first.
- [x] `make go-test` passes (coverage 79.2% ≥ 78%); **no apiparity golden changes** (the catalogue has no transfer scenarios).
- [x] Frontend suite: 356 passed; the single failure (`ImportCsvDialog` happy path) is pre-existing and reproduces on pristine `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MUcbGWMuByweN6hM9TsSZ