### PR TITLE
feat: brute-force protection (rate limiting) for auth endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,8 @@ ECONUMO_ALLOW_REGISTRATION=true
 # SQLITE_BUSY_TIMEOUT=5000
 
 # Brute-force protection for the public auth endpoints. Counts are attempts
-# per username/email per window; 0 disables a check. Defaults shown.
+# per username/email per window; 0 on a count disables that check. WINDOW must
+# be a positive Go duration (it has no "disabled" value). Defaults shown.
 # ECONUMO_RATE_LIMIT_LOGIN=5
 # ECONUMO_RATE_LIMIT_RESET=5
 # ECONUMO_RATE_LIMIT_REMIND=3

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,15 @@ ECONUMO_ALLOW_REGISTRATION=true
 # writes hit "database is locked" errors. Ignored for PostgreSQL.
 # SQLITE_BUSY_TIMEOUT=5000
 
+# Brute-force protection for the public auth endpoints. Counts are attempts
+# per username/email per window; 0 disables a check. Defaults shown.
+# ECONUMO_RATE_LIMIT_LOGIN=5
+# ECONUMO_RATE_LIMIT_RESET=5
+# ECONUMO_RATE_LIMIT_REMIND=3
+# ECONUMO_RATE_LIMIT_REGISTER=5
+# ECONUMO_RATE_LIMIT_WINDOW=15m
+# ECONUMO_RATE_LIMIT_GLOBAL=60
+
 # JWT keypair: auto-generated on first boot at var/jwt (in Docker: /app/var/jwt,
 # backed by the `jwt` volume — persist it to keep existing tokens valid). The
 # passphrase is generated alongside the keys and stored next to them (in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,15 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `RESEND_API_KEY` / `ECONUMO_MAIL_FROM` / `ECONUMO_MAIL_REPLY_TO`.
 - `OPEN_EXCHANGE_RATES_TOKEN` — currency-rate updates.
 - `SQLITE_BUSY_TIMEOUT` — SQLite `busy_timeout` PRAGMA in ms (default `0`); bare name mirrors the engine pragma.
+- `ECONUMO_RATE_LIMIT_LOGIN` / `ECONUMO_RATE_LIMIT_RESET` / `ECONUMO_RATE_LIMIT_REMIND` /
+  `ECONUMO_RATE_LIMIT_REGISTER` — brute-force protection for the public auth endpoints:
+  max attempts per username/email per window (defaults 5/5/3/5; login and reset count
+  only FAILED attempts and clear on success, remind and register count every request).
+  `ECONUMO_RATE_LIMIT_WINDOW` — sliding window (Go duration, default `15m`).
+  `ECONUMO_RATE_LIMIT_GLOBAL` — per-endpoint cap per minute across all keys (default `60`).
+  `0` disables a check. Over-limit requests get HTTP 429 with the standard error envelope
+  (message `"Too many attempts. Try again later."`, frozen). State is in-memory (resets on
+  restart); a malformed value fails at boot.
 - `ECONUMO_WEB_DIST` — path to the built SPA the binary serves.
 - `ECONUMO_LOG_LEVEL` — base slog level `debug|info|warn|error` (default `info`). Every command
   (`serve` and all resource:action commands) also accepts `-v`/`-vv`/`-vvv` (force DEBUG; `-vvv` adds source)
@@ -348,6 +357,7 @@ data unreadable. Most are also asserted by the test suite.
 - Error (handled, default 400): `{"success": false, "message": <string>, "code": <int>, "errors": <object>}` — `errors` maps field → `[messages]`, always present (`{}` when none).
 - Exception (500): `{"success": false, "message": <string>, "code": 0, "exceptionType": <string>}` — no `errors` key; `stackTrace` only when `ECONUMO_DEBUG=true`.
 - Not implemented (501): `{"success": false, "message": <string>, "code": 0, "errors": []}` — here `errors` is an array `[]` (the lone exception to the object rule).
+- Rate-limited (429): `{"success": false, "message": "Too many attempts. Try again later.", "code": 429, "errors": {}}` — same shape as the handled-error envelope.
 - JSON is encoded with HTML escaping disabled (`/`, `<`, `>` appear literally).
 
 ### Auth crypto (`internal/infra/auth/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   only FAILED attempts and clear on success, remind and register count every request).
   `ECONUMO_RATE_LIMIT_WINDOW` — sliding window (Go duration, default `15m`).
   `ECONUMO_RATE_LIMIT_GLOBAL` — per-endpoint cap per minute across all keys (default `60`).
-  `0` disables a check. Over-limit requests get HTTP 429 with the standard error envelope
+  `0` on a count disables that check (the window must be positive). Over-limit requests get HTTP 429 with the standard error envelope
   (message `"Too many attempts. Try again later."`, frozen). State is in-memory (resets on
   restart); a malformed value fails at boot.
 - `ECONUMO_WEB_DIST` — path to the built SPA the binary serves.

--- a/docs/superpowers/plans/2026-07-09-auth-rate-limiting.md
+++ b/docs/superpowers/plans/2026-07-09-auth-rate-limiting.md
@@ -1,0 +1,1533 @@
+# Auth Brute-Force Protection (Rate Limiting) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Per-username attempt limiting (plus a per-endpoint global backstop) on login-user, reset-password, remind-password, and register-user, returning HTTP 429 with the standard error envelope; limits configurable via `ECONUMO_RATE_LIMIT_*` env vars.
+
+**Architecture:** New in-memory `internal/infra/ratelimit` limiter (mutex + map of sliding-window timestamps, `port.Clock`-driven), consumed by the `user` feature through an `AttemptLimiter` interface in `internal/user/ports.go` and wired in `server.BuildAPI` from six new `config.Config` fields. New `errs.TooManyRequestsError` maps to 429 in `httpx.WriteError`.
+
+**Tech Stack:** Go stdlib only (sync, time, maps). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-auth-rate-limiting-design.md`
+
+## Global Constraints
+
+- **Frozen wire contract:** every EXISTING response must stay byte-identical. The 429 path is new; its message `"Too many attempts. Try again later."` becomes frozen once shipped. Envelope: `{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}`.
+- **Dependency rule:** `internal/user` consumes the limiter via its own interface; `internal/shared/*` may not import features or infra. `internal/infra/ratelimit` may import only `internal/shared/*`. (Enforced by `internal/test/archtest`.)
+- **No PII in logs or limiter output:** the limiter never logs; keys (usernames/emails) must not appear in any log line.
+- **Comments policy (CLAUDE.md):** comment only non-obvious rationale; keep swag `@…` blocks intact.
+- **Formatting/verification:** `gofmt` clean; `make go-test` green (includes OpenAPI-freshness check + coverage gate 78%); regenerate goldens ONLY for the new scenario and inspect the diff; never hand-edit a golden.
+- Env defaults (from the spec): LOGIN=5, RESET=5, REMIND=3, REGISTER=5, WINDOW=15m, GLOBAL=60/min; `0` disables that check.
+- Run all commands from the worktree root: `/home/dmitry/dev/econumo/econumo/.claude/worktrees/graceful-soaring-pony`.
+
+---
+
+### Task 1: `errs.TooManyRequestsError`
+
+**Files:**
+- Modify: `internal/shared/errs/errs.go`
+- Test: `internal/shared/errs/errs_test.go` (create if absent)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `errs.NewTooManyRequests(msg string) *TooManyRequestsError`, `errs.AsTooManyRequests(err error) (*TooManyRequestsError, bool)` — used by Tasks 2 and 3.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/shared/errs/errs_test.go` (if a file with this name already exists, append the test function):
+
+```go
+package errs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/econumo/econumo/internal/shared/errs"
+)
+
+func TestTooManyRequests(t *testing.T) {
+	e := errs.NewTooManyRequests("Too many attempts. Try again later.")
+	if e.Error() != "Too many attempts. Try again later." {
+		t.Fatalf("Error() = %q", e.Error())
+	}
+	if _, ok := errs.AsTooManyRequests(e); !ok {
+		t.Fatal("AsTooManyRequests(e) = false, want true")
+	}
+	if _, ok := errs.AsTooManyRequests(fmt.Errorf("wrap: %w", e)); !ok {
+		t.Fatal("AsTooManyRequests(wrapped) = false, want true")
+	}
+	if _, ok := errs.AsTooManyRequests(fmt.Errorf("other")); ok {
+		t.Fatal("AsTooManyRequests(other) = true, want false")
+	}
+	empty := &errs.TooManyRequestsError{}
+	if empty.Error() != "too many requests" {
+		t.Fatalf("zero-value Error() = %q, want %q", empty.Error(), "too many requests")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shared/errs/ -run TestTooManyRequests -v`
+Expected: FAIL (compile error: `NewTooManyRequests` undefined)
+
+- [ ] **Step 3: Implement**
+
+Append to `internal/shared/errs/errs.go` (style mirrors `UnauthorizedError`):
+
+```go
+// TooManyRequestsError maps to HTTP 429 (a rate-limited auth attempt).
+type TooManyRequestsError struct {
+	Msg string
+}
+
+func (e *TooManyRequestsError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "too many requests"
+}
+
+// NewTooManyRequests builds a TooManyRequestsError.
+func NewTooManyRequests(msg string) *TooManyRequestsError { return &TooManyRequestsError{Msg: msg} }
+
+// AsTooManyRequests reports whether err is (or wraps) a *TooManyRequestsError.
+func AsTooManyRequests(err error) (*TooManyRequestsError, bool) {
+	var v *TooManyRequestsError
+	if errors.As(err, &v) {
+		return v, true
+	}
+	return nil, false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shared/errs/ -run TestTooManyRequests -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shared/errs/
+git commit -m "feat(errs): add TooManyRequestsError (HTTP 429 taxonomy entry)"
+```
+
+---
+
+### Task 2: `httpx.WriteError` 429 mapping
+
+**Files:**
+- Modify: `internal/web/httpx/errors.go` (insert into `WriteError`, after the `AsUnauthorized` block at line ~42)
+- Test: `internal/web/httpx/envelope_test.go` (extend `TestWriteError_StatusMappingMatrix`)
+
+**Interfaces:**
+- Consumes: `errs.AsTooManyRequests` (Task 1).
+- Produces: any handler returning `*errs.TooManyRequestsError` now yields `429 {"success":false,"message":<msg>,"code":429,"errors":{}}`. Tasks 5–7 rely on this.
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/web/httpx/envelope_test.go`, find `TestWriteError_StatusMappingMatrix` (line ~149) and add a case following the existing table's row shape (read the existing rows first and copy their exact field names). The new row:
+
+```go
+{
+	name:       "too many requests -> 429 envelope",
+	err:        errs.NewTooManyRequests("Too many attempts. Try again later."),
+	wantStatus: http.StatusTooManyRequests,
+	wantBody:   `{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}` + "\n",
+},
+```
+
+(Adapt field names to the existing table struct; the existing rows show whether bodies are compared as full strings or decoded. If the matrix asserts on decoded fields, assert: status 429, `success` false, `message` exact, `code` 429, `errors` `{}`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/web/httpx/ -run TestWriteError_StatusMappingMatrix -v`
+Expected: FAIL — the 429 case currently falls through to the 500 exception envelope.
+
+- [ ] **Step 3: Implement**
+
+In `internal/web/httpx/errors.go`, insert after the `AsUnauthorized` block (before `AsNotFound`):
+
+```go
+	if v, ok := errs.AsTooManyRequests(err); ok {
+		Err(w, v.Error(), http.StatusTooManyRequests, nil, http.StatusTooManyRequests)
+		return
+	}
+```
+
+Also extend the mapping list in the `WriteError` doc comment with:
+`//   - *errs.TooManyRequestsError -> 429, code 429, empty errors`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/web/httpx/ -v`
+Expected: PASS (all envelope tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/web/httpx/
+git commit -m "feat(httpx): map TooManyRequestsError to the 429 error envelope"
+```
+
+---
+
+### Task 3: `internal/infra/ratelimit` limiter
+
+**Files:**
+- Create: `internal/infra/ratelimit/ratelimit.go`
+- Test: `internal/infra/ratelimit/ratelimit_test.go`
+
+**Interfaces:**
+- Consumes: `port.Clock` (`internal/shared/port`), `errs.NewTooManyRequests` (Task 1).
+- Produces (used by Task 9's wiring; satisfies Task 4's `user.AttemptLimiter`):
+  - `ratelimit.Config{Limits map[string]int; Window time.Duration; Global int; MaxKeys int}`
+  - `ratelimit.New(cfg Config, clk port.Clock) *Limiter`
+  - `(*Limiter).Allow(scope, key string) error`, `(*Limiter).Fail(scope, key string)`, `(*Limiter).Clear(scope, key string)`
+  - `ratelimit.Message = "Too many attempts. Try again later."`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/infra/ratelimit/ratelimit_test.go`:
+
+```go
+package ratelimit_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/econumo/econumo/internal/infra/ratelimit"
+	"github.com/econumo/econumo/internal/shared/errs"
+)
+
+// fakeClock is a mutable clock so tests can slide the window.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+func newLimiter(cfg ratelimit.Config) (*ratelimit.Limiter, *fakeClock) {
+	clk := &fakeClock{t: time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)}
+	return ratelimit.New(cfg, clk), clk
+}
+
+func cfgLogin(limit int) ratelimit.Config {
+	return ratelimit.Config{Limits: map[string]int{"login": limit}, Window: 15 * time.Minute}
+}
+
+func mustAllowed(t *testing.T, l *ratelimit.Limiter, scope, key string) {
+	t.Helper()
+	if err := l.Allow(scope, key); err != nil {
+		t.Fatalf("Allow(%s,%s) = %v, want nil", scope, key, err)
+	}
+}
+
+func mustBlocked(t *testing.T, l *ratelimit.Limiter, scope, key string) {
+	t.Helper()
+	err := l.Allow(scope, key)
+	if err == nil {
+		t.Fatalf("Allow(%s,%s) = nil, want TooManyRequestsError", scope, key)
+	}
+	if _, ok := errs.AsTooManyRequests(err); !ok {
+		t.Fatalf("Allow(%s,%s) = %T, want *errs.TooManyRequestsError", scope, key, err)
+	}
+	if err.Error() != ratelimit.Message {
+		t.Fatalf("message = %q, want %q", err.Error(), ratelimit.Message)
+	}
+}
+
+func TestAllow_UnderLimit(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(3))
+	for i := 0; i < 2; i++ {
+		mustAllowed(t, l, "login", "user@example.test")
+		l.Fail("login", "user@example.test")
+	}
+	mustAllowed(t, l, "login", "user@example.test") // 2 failures < 3
+}
+
+func TestAllow_BlocksAtLimit(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(3))
+	for i := 0; i < 3; i++ {
+		mustAllowed(t, l, "login", "user@example.test")
+		l.Fail("login", "user@example.test")
+	}
+	mustBlocked(t, l, "login", "user@example.test")
+}
+
+func TestAllow_KeysAreIndependent(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	l.Fail("login", "a@example.test")
+	mustBlocked(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+}
+
+func TestAllow_ScopesAreIndependent(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 1, "reset": 1}, Window: 15 * time.Minute,
+	})
+	l.Fail("login", "u@example.test")
+	mustBlocked(t, l, "login", "u@example.test")
+	mustAllowed(t, l, "reset", "u@example.test")
+}
+
+func TestAllow_WindowSlides(t *testing.T) {
+	l, clk := newLimiter(cfgLogin(2))
+	l.Fail("login", "u@example.test")
+	clk.t = clk.t.Add(10 * time.Minute)
+	l.Fail("login", "u@example.test")
+	mustBlocked(t, l, "login", "u@example.test")
+	clk.t = clk.t.Add(6 * time.Minute) // first failure now 16m old -> expired
+	mustAllowed(t, l, "login", "u@example.test")
+	clk.t = clk.t.Add(10 * time.Minute) // second failure now expired too
+	mustAllowed(t, l, "login", "u@example.test")
+}
+
+func TestClear_ResetsCounter(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	l.Fail("login", "u@example.test")
+	mustBlocked(t, l, "login", "u@example.test")
+	l.Clear("login", "u@example.test")
+	mustAllowed(t, l, "login", "u@example.test")
+}
+
+func TestZeroLimit_Disables(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(0))
+	for i := 0; i < 100; i++ {
+		l.Fail("login", "u@example.test")
+		mustAllowed(t, l, "login", "u@example.test")
+	}
+}
+
+func TestUnknownScope_Disabled(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	for i := 0; i < 10; i++ {
+		l.Fail("nope", "u@example.test")
+		mustAllowed(t, l, "nope", "u@example.test")
+	}
+}
+
+func TestGlobalCap_BlocksAcrossKeys(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 100}, Window: 15 * time.Minute, Global: 3,
+	})
+	mustAllowed(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+	mustAllowed(t, l, "login", "c@example.test")
+	mustBlocked(t, l, "login", "d@example.test") // 4th request, distinct key
+}
+
+func TestGlobalCap_SlidesOnItsOwnMinuteWindow(t *testing.T) {
+	l, clk := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 100}, Window: 15 * time.Minute, Global: 2,
+	})
+	mustAllowed(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+	mustBlocked(t, l, "login", "c@example.test")
+	clk.t = clk.t.Add(61 * time.Second)
+	mustAllowed(t, l, "login", "c@example.test")
+}
+
+func TestGlobalCap_ZeroDisables(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 100}, Window: 15 * time.Minute, Global: 0,
+	})
+	for i := 0; i < 200; i++ {
+		mustAllowed(t, l, "login", "u@example.test")
+	}
+}
+
+// A key already over its per-key limit must be rejected WITHOUT consuming the
+// global budget — an attack on one account must not starve everyone else.
+func TestBlockedKey_DoesNotConsumeGlobal(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 1}, Window: 15 * time.Minute, Global: 3,
+	})
+	l.Fail("login", "victim@example.test")
+	for i := 0; i < 50; i++ {
+		mustBlocked(t, l, "login", "victim@example.test")
+	}
+	// Global budget (3) untouched by the blocked calls above.
+	mustAllowed(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+	mustAllowed(t, l, "login", "c@example.test")
+	mustBlocked(t, l, "login", "d@example.test")
+}
+
+func TestEviction_CapsKeyCount(t *testing.T) {
+	l, clk := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 5}, Window: 15 * time.Minute, MaxKeys: 3,
+	})
+	l.Fail("login", "a@example.test")
+	clk.t = clk.t.Add(time.Second)
+	l.Fail("login", "b@example.test")
+	clk.t = clk.t.Add(time.Second)
+	l.Fail("login", "c@example.test")
+	clk.t = clk.t.Add(time.Second)
+	// Map full (3 keys); inserting a 4th evicts the stalest key (a).
+	l.Fail("login", "d@example.test")
+	// a's counter was evicted: 5 fresh failures needed again to block it.
+	mustAllowed(t, l, "login", "a@example.test")
+	// d's failure was recorded.
+	for i := 0; i < 4; i++ {
+		l.Fail("login", "d@example.test")
+	}
+	mustBlocked(t, l, "login", "d@example.test")
+}
+
+func TestEviction_PrefersExpiredEntries(t *testing.T) {
+	l, clk := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 2}, Window: time.Minute, MaxKeys: 2,
+	})
+	l.Fail("login", "old@example.test")
+	clk.t = clk.t.Add(2 * time.Minute) // old@ expires
+	l.Fail("login", "fresh@example.test")
+	l.Fail("login", "fresh@example.test")
+	// Map at cap; the expired old@ entry is dropped, fresh@ keeps its 2 failures.
+	l.Fail("login", "new@example.test")
+	mustBlocked(t, l, "login", "fresh@example.test")
+	mustAllowed(t, l, "login", "new@example.test")
+}
+
+// go test -race exercises the mutex.
+func TestConcurrentAccess(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 3}, Window: 15 * time.Minute, Global: 1000,
+	})
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			keys := []string{"a@example.test", "b@example.test", "c@example.test"}
+			for i := 0; i < 200; i++ {
+				k := keys[(g+i)%len(keys)]
+				_ = l.Allow("login", k)
+				l.Fail("login", k)
+				if i%10 == 0 {
+					l.Clear("login", k)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/infra/ratelimit/ -v`
+Expected: FAIL (package does not exist / does not compile)
+
+- [ ] **Step 3: Implement**
+
+Create `internal/infra/ratelimit/ratelimit.go`:
+
+```go
+// Package ratelimit is the in-memory brute-force limiter for the public auth
+// endpoints: per-key sliding-window attempt counters plus a per-scope global
+// backstop. State is process-local and resets on restart by design (single
+// binary; see the 2026-07-09 auth-rate-limiting spec).
+package ratelimit
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/econumo/econumo/internal/shared/errs"
+	"github.com/econumo/econumo/internal/shared/port"
+)
+
+// Message is the frozen 429 envelope message.
+const Message = "Too many attempts. Try again later."
+
+const (
+	defaultMaxKeys = 10000
+	defaultWindow  = 15 * time.Minute
+	// The global backstop counts every request in its own fixed window so a
+	// spray of unique keys is caught quickly, independent of the per-key window.
+	globalWindow = time.Minute
+)
+
+// Config holds the limiter policy. A limit of 0 (or an absent scope) disables
+// that check.
+type Config struct {
+	Limits  map[string]int // per-scope max attempts per key per Window
+	Window  time.Duration  // per-key sliding window (default 15m)
+	Global  int            // per-scope cap per minute across ALL keys; 0 disables
+	MaxKeys int            // per-key map size cap (default 10000)
+}
+
+type Limiter struct {
+	mu       sync.Mutex
+	cfg      Config
+	clock    port.Clock
+	attempts map[string][]time.Time
+}
+
+func New(cfg Config, clk port.Clock) *Limiter {
+	if cfg.MaxKeys <= 0 {
+		cfg.MaxKeys = defaultMaxKeys
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = defaultWindow
+	}
+	return &Limiter{cfg: cfg, clock: clk, attempts: map[string][]time.Time{}}
+}
+
+// Key layouts: per-key entries are "k\x00<scope>\x00<key>", global counters are
+// "g\x00<scope>". The prefixes keep a caller-supplied key from ever colliding
+// with a global counter.
+func attemptKey(scope, key string) string { return "k\x00" + scope + "\x00" + key }
+func globalKey(scope string) string       { return "g\x00" + scope }
+
+// Allow reports whether another attempt may proceed. The per-key check runs
+// first and rejects without consuming the global budget, so an attack on one
+// key cannot starve every other caller of the endpoint.
+func (l *Limiter) Allow(scope, key string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.clock.Now()
+
+	if limit := l.cfg.Limits[scope]; limit > 0 {
+		k := attemptKey(scope, key)
+		hits := prune(l.attempts[k], now, l.cfg.Window)
+		l.store(k, hits)
+		if len(hits) >= limit {
+			return errs.NewTooManyRequests(Message)
+		}
+	}
+	if l.cfg.Global > 0 {
+		k := globalKey(scope)
+		hits := prune(l.attempts[k], now, globalWindow)
+		if len(hits) >= l.cfg.Global {
+			l.attempts[k] = hits
+			return errs.NewTooManyRequests(Message)
+		}
+		l.attempts[k] = append(hits, now)
+	}
+	return nil
+}
+
+// Fail records a failed attempt against the key.
+func (l *Limiter) Fail(scope, key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cfg.Limits[scope] <= 0 {
+		return
+	}
+	now := l.clock.Now()
+	k := attemptKey(scope, key)
+	if _, exists := l.attempts[k]; !exists && len(l.attempts) >= l.cfg.MaxKeys {
+		l.evict(now)
+	}
+	l.attempts[k] = append(prune(l.attempts[k], now, l.cfg.Window), now)
+}
+
+// Clear wipes the key's counter (called after a successful attempt).
+func (l *Limiter) Clear(scope, key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.attempts, attemptKey(scope, key))
+}
+
+func (l *Limiter) store(k string, hits []time.Time) {
+	if len(hits) == 0 {
+		delete(l.attempts, k)
+		return
+	}
+	l.attempts[k] = hits
+}
+
+// prune drops timestamps older than the window. Slices are append-only, so
+// they are already sorted ascending.
+func prune(hits []time.Time, now time.Time, window time.Duration) []time.Time {
+	cutoff := now.Add(-window)
+	i := 0
+	for ; i < len(hits); i++ {
+		if hits[i].After(cutoff) {
+			break
+		}
+	}
+	return hits[i:]
+}
+
+// evict makes room under MaxKeys: drop fully-expired per-key entries; if the
+// map is still full, drop the entry with the oldest most-recent attempt.
+// Global counters (a handful, one per scope) are never evicted.
+func (l *Limiter) evict(now time.Time) {
+	var stalest string
+	var stalestAt time.Time
+	for k, hits := range l.attempts {
+		if strings.HasPrefix(k, "g\x00") {
+			continue
+		}
+		pruned := prune(hits, now, l.cfg.Window)
+		if len(pruned) == 0 {
+			delete(l.attempts, k)
+			continue
+		}
+		l.attempts[k] = pruned
+		newest := pruned[len(pruned)-1]
+		if stalest == "" || newest.Before(stalestAt) {
+			stalest, stalestAt = k, newest
+		}
+	}
+	if len(l.attempts) >= l.cfg.MaxKeys && stalest != "" {
+		delete(l.attempts, stalest)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass (with race detector)**
+
+Run: `go test ./internal/infra/ratelimit/ -race -v`
+Expected: PASS, all tests
+
+- [ ] **Step 5: Verify the arch rule still holds**
+
+Run: `go test ./internal/test/archtest/`
+Expected: PASS (ratelimit imports only shared packages)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/infra/ratelimit/
+git commit -m "feat(ratelimit): in-memory sliding-window attempt limiter"
+```
+
+---
+
+### Task 4: `user.AttemptLimiter` seam (interface + Service wiring, no enforcement yet)
+
+**Files:**
+- Modify: `internal/user/ports.go` (interface + scope constants)
+- Modify: `internal/user/usecase.go` (Service field, `NewService` param, nil-safe helpers)
+- Modify: `internal/server/server.go:73` (pass `nil` for now; real wiring in Task 9)
+- Modify: `internal/cli/container.go:74` (pass `nil` — CLI commands are not rate-limited)
+- Modify: `internal/user/api/harness_test.go:110` (thread a limiter param, default `nil`)
+- Modify: `internal/user/admin_integration_test.go:33`, `internal/user/migrate_test.go:37` (pass `nil`)
+
+**Interfaces:**
+- Consumes: nothing from Task 3 (interface-only; structural typing matches later).
+- Produces (used by Tasks 5–7 and 9):
+  - `user.AttemptLimiter` interface: `Allow(scope, key string) error; Fail(scope, key string); Clear(scope, key string)`
+  - Scope constants: `user.RateScopeLogin = "login"`, `user.RateScopeReset = "reset"`, `user.RateScopeRemind = "remind"`, `user.RateScopeRegister = "register"`
+  - `NewService(repo, tx, encode, hasher, jwtSvc, currency, budgets, passwordRequests, mailer, clock, limiter, allowRegistration)` — limiter inserted between `clock` and `allowRegistration`
+  - Unexported nil-safe helpers on `Service`: `allowAttempt(scope, key string) error`, `failAttempt(scope, key string)`, `clearAttempt(scope, key string)`
+  - Test helper `newHarnessWithLimiter(t *testing.T, limiter appuser.AttemptLimiter) *harness` in `internal/user/api/harness_test.go`
+
+- [ ] **Step 1: Add the interface and scope constants to `internal/user/ports.go`**
+
+Append:
+
+```go
+// AttemptLimiter is the brute-force-protection seam for the public auth use
+// cases. Keys are the lowercased+trimmed submitted username/email; scopes are
+// the RateScope* constants. A nil limiter disables protection (CLI, tests).
+type AttemptLimiter interface {
+	// Allow reports whether another attempt may proceed; over-limit yields an
+	// *errs.TooManyRequestsError (HTTP 429).
+	Allow(scope, key string) error
+	// Fail records a failed attempt.
+	Fail(scope, key string)
+	// Clear wipes the key's failure counter after a successful attempt.
+	Clear(scope, key string)
+}
+
+// Rate-limit scopes; the same strings key the limiter config in internal/server.
+const (
+	RateScopeLogin    = "login"
+	RateScopeReset    = "reset"
+	RateScopeRemind   = "remind"
+	RateScopeRegister = "register"
+)
+```
+
+- [ ] **Step 2: Thread the field through `internal/user/usecase.go`**
+
+Add `limiter AttemptLimiter` to the `Service` struct (after `clock`), add the parameter to `NewService` between `clock port.Clock` and `allowRegistration bool`, set it in the constructor body, and append the nil-safe helpers at the end of the file:
+
+```go
+// allowAttempt / failAttempt / clearAttempt guard the optional limiter (nil in
+// the CLI and most tests), mirroring the nil-mailer pattern in RemindPassword.
+func (s *Service) allowAttempt(scope, key string) error {
+	if s.limiter == nil {
+		return nil
+	}
+	return s.limiter.Allow(scope, key)
+}
+
+func (s *Service) failAttempt(scope, key string) {
+	if s.limiter != nil {
+		s.limiter.Fail(scope, key)
+	}
+}
+
+func (s *Service) clearAttempt(scope, key string) {
+	if s.limiter != nil {
+		s.limiter.Clear(scope, key)
+	}
+}
+```
+
+- [ ] **Step 3: Update every `NewService` call site**
+
+All six call sites gain an argument in position 11 (between the clock and the bool):
+
+- `internal/server/server.go:73-76`: pass `nil` for now (Task 9 replaces it with the real limiter).
+- `internal/cli/container.go:74`: pass `nil` (management commands are trusted local operations).
+- `internal/user/admin_integration_test.go:33` and `internal/user/migrate_test.go:37`: pass `nil`.
+- `internal/user/api/harness_test.go`: split the constructor —
+
+```go
+func newHarness(t *testing.T) *harness { return newHarnessWithLimiter(t, nil) }
+
+// newHarnessWithLimiter lets rate-limit tests inject a tight limiter; every
+// other test keeps the nil (disabled) default.
+func newHarnessWithLimiter(t *testing.T, limiter appuser.AttemptLimiter) *harness {
+	// ... existing newHarness body, with the svc line becoming:
+	// svc := appuser.NewService(repo, txm, encode, hasher, jwtSvc, currency, budgets, passwordReqs, resetMailer, clk, limiter, cfg.AllowRegistration)
+}
+```
+
+- [ ] **Step 4: Build + run the affected packages**
+
+Run: `go build ./... && go test ./internal/user/... ./internal/server/... ./internal/cli/...`
+Expected: PASS — behavior is unchanged (nil limiter everywhere).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/user/ internal/server/ internal/cli/
+git commit -m "feat(user): AttemptLimiter seam on the user service (nil = disabled)"
+```
+
+---
+
+### Task 5: Enforce in Login + API-level tests
+
+**Files:**
+- Modify: `internal/user/login.go`
+- Test: create `internal/user/api/ratelimit_test.go`
+
+**Interfaces:**
+- Consumes: `s.allowAttempt`/`s.failAttempt`/`s.clearAttempt`, `user.RateScopeLogin` (Task 4); `ratelimit.New` (Task 3) in tests; 429 envelope (Task 2).
+- Produces: rate-limited `Login`. The test file's `newLimitedHarness` helper is reused by Tasks 6–7.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/user/api/ratelimit_test.go`:
+
+```go
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/econumo/econumo/internal/infra/ratelimit"
+	appuser "github.com/econumo/econumo/internal/user"
+)
+
+// tight per-key limits so a handful of calls trips the 429; global generous so
+// only the per-key path is under test here.
+func newLimitedHarness(t *testing.T) *harness {
+	t.Helper()
+	limiter := ratelimit.New(ratelimit.Config{
+		Limits: map[string]int{
+			appuser.RateScopeLogin:    2,
+			appuser.RateScopeReset:    2,
+			appuser.RateScopeRemind:   2,
+			appuser.RateScopeRegister: 2,
+		},
+		Window: 15 * time.Minute,
+		Global: 1000,
+	}, realClock{})
+	return newHarnessWithLimiter(t, limiter)
+}
+
+// realClock: the limiter needs a monotonic-ish clock; the harness fixedClock
+// would also work (all attempts land in one window), but real time matches
+// production wiring.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+func assert429(t *testing.T, status int, env envelope) {
+	t.Helper()
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (body: %s)", status, env.raw)
+	}
+	if env.Success || env.Code != 429 || env.Message != "Too many attempts. Try again later." {
+		t.Fatalf("envelope = %+v, want success=false code=429 frozen message", env)
+	}
+	if string(env.Errors) != "{}" {
+		t.Fatalf("errors = %s, want {}", env.Errors)
+	}
+}
+
+func login(h *harness, t *testing.T, username, password string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/login-user", "", map[string]any{
+		"username": username, "password": password,
+	})
+}
+
+func TestLogin_RateLimitedAfterFailures(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401", i+1, status)
+		}
+	}
+	// Third attempt is blocked even with the CORRECT password: lockout is by
+	// attempt count, not credential.
+	status, env := login(h, t, seedEmail, seedPassword)
+	assert429(t, status, env)
+}
+
+func TestLogin_UnknownUserAlsoRateLimited(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := login(h, t, "ghost@example.test", "x"); status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401", i+1, status)
+		}
+	}
+	status, env := login(h, t, "ghost@example.test", "x")
+	assert429(t, status, env) // anti-enumeration: same behavior as an existing user
+}
+
+func TestLogin_SuccessClearsCounter(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	if status, _ := login(h, t, seedEmail, seedPassword); status != http.StatusOK {
+		t.Fatal("expected 200 (1 failure < limit 2)")
+	}
+	// Counter was cleared: two more failures allowed before a block.
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	status, env := login(h, t, seedEmail, seedPassword)
+	assert429(t, status, env)
+}
+
+func TestLogin_KeyIsCaseAndSpaceInsensitive(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	if status, _ := login(h, t, "  "+upperFirst(seedEmail)+" ", "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	// Both failures hit the same bucket -> third attempt blocked.
+	status, env := login(h, t, seedEmail, seedPassword)
+	assert429(t, status, env)
+}
+
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return string(s[0]-32) + s[1:] // seedEmail starts with a lowercase ASCII letter
+}
+
+func TestLogin_NilLimiterUnlimited(t *testing.T) {
+	h := newHarness(t) // nil limiter
+	for i := 0; i < 10; i++ {
+		if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401 (never 429)", i+1, status)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/user/api/ -run "TestLogin_RateLimited|TestLogin_UnknownUser|TestLogin_SuccessClears|TestLogin_KeyIs|TestLogin_NilLimiter" -v`
+Expected: the RateLimited/UnknownUser/SuccessClears/KeyIs tests FAIL (429 never returned); NilLimiter passes.
+
+- [ ] **Step 3: Implement in `internal/user/login.go`**
+
+Replace the `Login` body's opening and the two failure paths:
+
+```go
+func (s *Service) Login(ctx context.Context, req model.LoginRequest, now time.Time) (*model.LoginResult, error) {
+	limitKey := strings.ToLower(strings.TrimSpace(req.Username))
+	if err := s.allowAttempt(RateScopeLogin, limitKey); err != nil {
+		return nil, err
+	}
+	identifier := s.encode.Hash(strings.ToLower(req.Username))
+	u, err := s.repo.GetByIdentifier(ctx, identifier)
+	if err != nil {
+		if _, ok := errs.AsNotFound(err); ok {
+			s.failAttempt(RateScopeLogin, limitKey)
+			return nil, errs.NewUnauthorized("Invalid credentials.")
+		}
+		return nil, err
+	}
+	if !u.IsActive || !s.hasher.Verify(u.Password, req.Password, u.Salt) {
+		s.failAttempt(RateScopeLogin, limitKey)
+		return nil, errs.NewUnauthorized("Invalid credentials.")
+	}
+
+	email, derr := s.encode.Decode(u.Email)
+	if derr != nil {
+		return nil, derr
+	}
+	token, terr := s.jwt.Issue(u.ID.String(), email, now)
+	if terr != nil {
+		return nil, terr
+	}
+	cur, cerr := s.toCurrentUserWithEmail(ctx, u, email)
+	if cerr != nil {
+		return nil, cerr
+	}
+	s.clearAttempt(RateScopeLogin, limitKey)
+	return &model.LoginResult{Token: token, User: cur}, nil
+}
+```
+
+(The identifier hash deliberately keeps the frozen un-trimmed `strings.ToLower(req.Username)`; only the limiter key trims.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/user/... -v`
+Expected: PASS — including all pre-existing login/user tests (nil limiter).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/user/
+git commit -m "feat(user): rate-limit login attempts per username"
+```
+
+---
+
+### Task 6: Enforce in RemindPassword + ResetPassword + tests
+
+**Files:**
+- Modify: `internal/user/password.go` (`RemindPassword` line ~55, `ResetPassword` line ~91)
+- Test: append to `internal/user/api/ratelimit_test.go`
+
+**Interfaces:**
+- Consumes: Task 4 helpers + `RateScopeRemind`/`RateScopeReset`; `newLimitedHarness` (Task 5).
+- Produces: rate-limited remind/reset.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/user/api/ratelimit_test.go`:
+
+```go
+func remind(h *harness, t *testing.T, username string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/remind-password", "", map[string]any{"username": username})
+}
+
+func reset(h *harness, t *testing.T, username, code, password string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/reset-password", "", map[string]any{
+		"username": username, "code": code, "password": password,
+	})
+}
+
+// Remind counts EVERY request (each one sends an email), success included.
+func TestRemindPassword_RateLimited(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := remind(h, t, seedEmail); status != http.StatusOK {
+			t.Fatalf("attempt %d: expected 200", i+1)
+		}
+	}
+	status, env := remind(h, t, seedEmail)
+	assert429(t, status, env)
+}
+
+// Anti-enumeration holds under limiting: unknown users return the same 200s
+// then the same 429.
+func TestRemindPassword_UnknownUserSameShape(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := remind(h, t, "ghost@example.test"); status != http.StatusOK {
+			t.Fatalf("attempt %d: expected 200 (anti-enumeration)", i+1)
+		}
+	}
+	status, env := remind(h, t, "ghost@example.test")
+	assert429(t, status, env)
+}
+
+func TestResetPassword_RateLimitedOnBadCodes(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := reset(h, t, seedEmail, "000000000000", "new-pw-123"); status != http.StatusBadRequest {
+			t.Fatalf("attempt %d: expected 400", i+1)
+		}
+	}
+	status, env := reset(h, t, seedEmail, "000000000000", "new-pw-123")
+	assert429(t, status, env)
+}
+
+// A successful reset clears the counter; look up the real code in the DB the
+// same way internal/user/api/reset_password_test.go does (read that file and
+// reuse its query helper/pattern verbatim).
+func TestResetPassword_SuccessClearsCounter(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := reset(h, t, seedEmail, "000000000000", "new-pw-123"); status != http.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+	if status, _ := remind(h, t, seedEmail); status != http.StatusOK {
+		t.Fatal("expected 200 remind")
+	}
+	code := fetchResetCode(t, h)
+	if status, _ := reset(h, t, seedEmail, code, "new-pw-123"); status != http.StatusOK {
+		t.Fatal("expected 200 reset")
+	}
+	// Counter cleared: two more bad attempts before a block.
+	if status, _ := reset(h, t, seedEmail, "000000000000", "x-pw-123"); status != http.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+	if status, _ := reset(h, t, seedEmail, "000000000000", "x-pw-123"); status != http.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+	status, env := reset(h, t, seedEmail, "000000000000", "x-pw-123")
+	assert429(t, status, env)
+}
+```
+
+Also add the code-lookup helper (same DB read `reset_password_test.go:25` does inline):
+
+```go
+// fetchResetCode reads the emailed reset code for the seed user straight from
+// the DB (the test mailer is a no-op).
+func fetchResetCode(t *testing.T, h *harness) string {
+	t.Helper()
+	var code string
+	if err := h.db.QueryRow(`SELECT code FROM users_password_requests WHERE user_id = ?`, seedUserID).Scan(&code); err != nil {
+		t.Fatalf("read reset code: %v", err)
+	}
+	return code
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/user/api/ -run "TestRemindPassword_|TestResetPassword_" -v`
+Expected: new tests FAIL (no 429); pre-existing reset tests still PASS.
+
+- [ ] **Step 3: Implement in `internal/user/password.go`**
+
+`RemindPassword` — the lowered username already exists at the top; add limiting immediately after it (every request counts, before the user lookup so anti-enumeration is airtight):
+
+```go
+	lowered := strings.ToLower(strings.TrimSpace(req.Username))
+	if err := s.allowAttempt(RateScopeRemind, lowered); err != nil {
+		return nil, err
+	}
+	s.failAttempt(RateScopeRemind, lowered) // every remind sends an email, so every request counts
+```
+
+`ResetPassword` — add at the top (after `lowered := …`), then `failAttempt` on each of the three failure paths and `clearAttempt` on success:
+
+```go
+	lowered := strings.ToLower(strings.TrimSpace(req.Username))
+	if err := s.allowAttempt(RateScopeReset, lowered); err != nil {
+		return nil, err
+	}
+	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
+	if err != nil {
+		if isNotFound(err) {
+			s.failAttempt(RateScopeReset, lowered)
+			return nil, errs.NewValidation("Reset password error")
+		}
+		return nil, err
+	}
+
+	pr, err := s.passwordRequests.GetByUserAndCode(ctx, u.ID, strings.TrimSpace(req.Code))
+	if err != nil {
+		if isNotFound(err) {
+			s.failAttempt(RateScopeReset, lowered)
+			return nil, errs.NewValidation("Reset password error")
+		}
+		return nil, err
+	}
+	if pr.IsExpired(s.clock.Now()) {
+		s.failAttempt(RateScopeReset, lowered)
+		return nil, errs.NewValidation("The code is expired")
+	}
+```
+
+…and just before the final `return &model.ResetPasswordResult{}, nil`:
+
+```go
+	s.clearAttempt(RateScopeReset, lowered)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/user/... -v`
+Expected: PASS (new + all pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/user/
+git commit -m "feat(user): rate-limit remind-password and reset-password"
+```
+
+---
+
+### Task 7: Enforce in Register + tests
+
+**Files:**
+- Modify: `internal/user/register.go:16`
+- Test: append to `internal/user/api/ratelimit_test.go`
+
+**Interfaces:**
+- Consumes: Task 4 helpers + `RateScopeRegister`; `newLimitedHarness` (Task 5).
+- Produces: rate-limited `Register`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/user/api/ratelimit_test.go`:
+
+```go
+func registerUser(h *harness, t *testing.T, email string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/register-user", "", map[string]any{
+		"email": email, "password": "brand-new-pw", "name": "New User",
+	})
+}
+
+// Register counts EVERY attempt (mass-creation protection), success included.
+func TestRegister_RateLimited(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := registerUser(h, t, "fresh@example.test"); status != http.StatusOK {
+		t.Fatal("expected 200 first register")
+	}
+	if status, _ := registerUser(h, t, "fresh@example.test"); status != http.StatusBadRequest {
+		t.Fatal("expected 400 duplicate")
+	}
+	status, env := registerUser(h, t, "fresh@example.test")
+	assert429(t, status, env)
+}
+
+func TestRegister_KeysIndependent(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		registerUser(h, t, "a@example.test")
+	}
+	if status, env := registerUser(h, t, "a@example.test"); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for exhausted key, got %d: %s", status, env.raw)
+	}
+	if status, _ := registerUser(h, t, "b@example.test"); status != http.StatusOK {
+		t.Fatal("expected 200 for a different email")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/user/api/ -run "TestRegister_" -v`
+Expected: FAIL (third attempt returns 400, not 429).
+
+- [ ] **Step 3: Implement in `internal/user/register.go`**
+
+Add at the very top of `Register` (before the `allowRegistration` gate, so even disabled-registration probing is counted; needs `"strings"` added to the imports):
+
+```go
+	limitKey := strings.ToLower(strings.TrimSpace(req.Email))
+	if err := s.allowAttempt(RateScopeRegister, limitKey); err != nil {
+		return nil, err
+	}
+	s.failAttempt(RateScopeRegister, limitKey) // every attempt counts toward the cap
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/user/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/user/
+git commit -m "feat(user): rate-limit register-user attempts per email"
+```
+
+---
+
+### Task 8: Config env vars + `.env.example`
+
+**Files:**
+- Modify: `internal/config/config.go` (six fields, strict parse helpers, `Load` wiring)
+- Modify: `.env.example`
+- Test: `internal/config/config_test.go` (append)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (used by Task 9): `Config.RateLimitLogin`, `.RateLimitReset`, `.RateLimitRemind`, `.RateLimitRegister` (int), `.RateLimitWindow` (`time.Duration`), `.RateLimitGlobal` (int).
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `internal/config/config_test.go` first and match its existing style for setting env vars (likely `t.Setenv`) and for the minimum valid environment (`DATABASE_URL` is required). Append:
+
+```go
+func TestLoad_RateLimitDefaults(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+	c, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.RateLimitLogin != 5 || c.RateLimitReset != 5 || c.RateLimitRemind != 3 || c.RateLimitRegister != 5 {
+		t.Fatalf("per-endpoint defaults = %d/%d/%d/%d, want 5/5/3/5",
+			c.RateLimitLogin, c.RateLimitReset, c.RateLimitRemind, c.RateLimitRegister)
+	}
+	if c.RateLimitWindow != 15*time.Minute {
+		t.Fatalf("window = %v, want 15m", c.RateLimitWindow)
+	}
+	if c.RateLimitGlobal != 60 {
+		t.Fatalf("global = %d, want 60", c.RateLimitGlobal)
+	}
+}
+
+func TestLoad_RateLimitOverridesAndDisable(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+	t.Setenv("ECONUMO_RATE_LIMIT_LOGIN", "10")
+	t.Setenv("ECONUMO_RATE_LIMIT_RESET", "0") // 0 = disabled
+	t.Setenv("ECONUMO_RATE_LIMIT_REMIND", "7")
+	t.Setenv("ECONUMO_RATE_LIMIT_REGISTER", "8")
+	t.Setenv("ECONUMO_RATE_LIMIT_WINDOW", "1h30m")
+	t.Setenv("ECONUMO_RATE_LIMIT_GLOBAL", "0")
+	c, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.RateLimitLogin != 10 || c.RateLimitReset != 0 || c.RateLimitRemind != 7 || c.RateLimitRegister != 8 {
+		t.Fatalf("overrides not applied: %+v", c)
+	}
+	if c.RateLimitWindow != 90*time.Minute || c.RateLimitGlobal != 0 {
+		t.Fatalf("window/global overrides not applied: %v / %d", c.RateLimitWindow, c.RateLimitGlobal)
+	}
+}
+
+func TestLoad_RateLimitBadValuesFailBoot(t *testing.T) {
+	cases := map[string]string{
+		"ECONUMO_RATE_LIMIT_LOGIN":  "five",
+		"ECONUMO_RATE_LIMIT_GLOBAL": "-1",
+		"ECONUMO_RATE_LIMIT_WINDOW": "15minutes",
+	}
+	for key, bad := range cases {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+			t.Setenv(key, bad)
+			if _, err := config.Load(); err == nil {
+				t.Fatalf("Load() with %s=%q succeeded, want boot error", key, bad)
+			}
+		})
+	}
+}
+```
+
+(Add `"time"` to the test file's imports if absent.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run TestLoad_RateLimit -v`
+Expected: FAIL (fields undefined).
+
+- [ ] **Step 3: Implement in `internal/config/config.go`**
+
+Add to the `Config` struct (after `SQLiteBusyTimeout`):
+
+```go
+	// Auth brute-force protection (see the 2026-07-09 auth-rate-limiting spec).
+	// Counts are attempts per key per RateLimitWindow; 0 disables a check.
+	RateLimitLogin    int           // ECONUMO_RATE_LIMIT_LOGIN: failed logins per username
+	RateLimitReset    int           // ECONUMO_RATE_LIMIT_RESET: failed reset attempts per username
+	RateLimitRemind   int           // ECONUMO_RATE_LIMIT_REMIND: remind requests per username
+	RateLimitRegister int           // ECONUMO_RATE_LIMIT_REGISTER: register attempts per email
+	RateLimitWindow   time.Duration // ECONUMO_RATE_LIMIT_WINDOW: sliding window (Go duration)
+	RateLimitGlobal   int           // ECONUMO_RATE_LIMIT_GLOBAL: per-endpoint cap per minute
+```
+
+Add `"time"` to the imports. In `Load`, after the MAILER_DSN block:
+
+```go
+	// Rate-limit values fail at boot on a malformed value (unlike the lenient
+	// getInt), because a typo here would silently disable brute-force protection.
+	for _, p := range []struct {
+		dst *int
+		key string
+		def int
+	}{
+		{&c.RateLimitLogin, "ECONUMO_RATE_LIMIT_LOGIN", 5},
+		{&c.RateLimitReset, "ECONUMO_RATE_LIMIT_RESET", 5},
+		{&c.RateLimitRemind, "ECONUMO_RATE_LIMIT_REMIND", 3},
+		{&c.RateLimitRegister, "ECONUMO_RATE_LIMIT_REGISTER", 5},
+		{&c.RateLimitGlobal, "ECONUMO_RATE_LIMIT_GLOBAL", 60},
+	} {
+		n, err := getIntStrict(p.key, p.def)
+		if err != nil {
+			return Config{}, err
+		}
+		*p.dst = n
+	}
+	window, werr := getDurationStrict("ECONUMO_RATE_LIMIT_WINDOW", 15*time.Minute)
+	if werr != nil {
+		return Config{}, werr
+	}
+	c.RateLimitWindow = window
+```
+
+Add the helpers next to `getInt`:
+
+```go
+// getIntStrict is getInt with a hard failure on malformed or negative input,
+// for settings where a silent fallback would be a security downgrade.
+func getIntStrict(key string, def int) (int, error) {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("%s %q is not a non-negative integer", key, v)
+	}
+	return n, nil
+}
+
+func getDurationStrict(key string, def time.Duration) (time.Duration, error) {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("%s %q is not a positive Go duration (e.g. \"15m\")", key, v)
+	}
+	return d, nil
+}
+```
+
+- [ ] **Step 4: Add to `.env.example`**
+
+Read `.env.example` first and match its comment style. Append near the other `ECONUMO_*` behavior vars:
+
+```bash
+# Brute-force protection for the public auth endpoints. Counts are attempts
+# per username/email per window; 0 disables a check. Defaults shown.
+#ECONUMO_RATE_LIMIT_LOGIN=5
+#ECONUMO_RATE_LIMIT_RESET=5
+#ECONUMO_RATE_LIMIT_REMIND=3
+#ECONUMO_RATE_LIMIT_REGISTER=5
+#ECONUMO_RATE_LIMIT_WINDOW=15m
+#ECONUMO_RATE_LIMIT_GLOBAL=60
+```
+
+(If the file lists vars uncommented with defaults, follow that convention instead.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/ .env.example
+git commit -m "feat(config): ECONUMO_RATE_LIMIT_* env vars (strict-parsed, 0 disables)"
+```
+
+---
+
+### Task 9: Wire in BuildAPI + swagger annotations + apiparity 429 scenario
+
+**Files:**
+- Modify: `internal/server/server.go` (construct the limiter, replace Task 4's `nil`)
+- Modify: `internal/user/api/user.go` (four `@Failure 429` annotations)
+- Modify: `internal/test/apiparity/harness.go:72` (production-default limits in the harness cfg)
+- Create: `internal/test/apiparity/catalogue_ratelimit.go`
+- Create (generated): `internal/test/apiparity/testdata/golden/auth_rate_limit.golden`
+- Regenerate: `internal/web/apidoc/docs/*` via `make swagger`
+
+**Interfaces:**
+- Consumes: `ratelimit.New`/`Config` (Task 3), `user.RateScope*` (Task 4), config fields (Task 8).
+- Produces: production wiring; frozen 429 golden.
+
+- [ ] **Step 1: Wire the limiter in `internal/server/server.go`**
+
+Above the `userSvc := appuser.NewService(` call insert:
+
+```go
+	authLimiter := ratelimit.New(ratelimit.Config{
+		Limits: map[string]int{
+			appuser.RateScopeLogin:    cfg.RateLimitLogin,
+			appuser.RateScopeReset:    cfg.RateLimitReset,
+			appuser.RateScopeRemind:   cfg.RateLimitRemind,
+			appuser.RateScopeRegister: cfg.RateLimitRegister,
+		},
+		Window: cfg.RateLimitWindow,
+		Global: cfg.RateLimitGlobal,
+	}, clk)
+```
+
+Replace the `nil` limiter argument with `authLimiter`, and add `"github.com/econumo/econumo/internal/infra/ratelimit"` to the imports.
+
+- [ ] **Step 2: Add swagger annotations**
+
+In `internal/user/api/user.go`, add to the `@Failure` blocks of `LoginUser`, `RegisterUser`, `RemindPassword`, and `ResetPassword` (after the 401 line in each):
+
+```go
+// @Failure     429     {object} apidoc.JsonResponseError
+```
+
+Then regenerate: `make swagger` — the committed docs under `internal/web/apidoc/docs/` change; commit them (the `make go-test` freshness check requires it).
+
+- [ ] **Step 3: Set explicit limits in the apiparity harness**
+
+In `internal/test/apiparity/harness.go`, extend the `cfg := config.Config{…}` literal (add `"time"` to imports if absent):
+
+```go
+		// Production-default auth rate limits: existing auth scenarios stay far
+		// under them (1 bad login / 1 remind / 1 bad reset per fresh-DB scenario),
+		// and the auth_rate_limit scenario deliberately exceeds them to freeze the
+		// 429 envelope.
+		RateLimitLogin:    5,
+		RateLimitReset:    5,
+		RateLimitRemind:   3,
+		RateLimitRegister: 5,
+		RateLimitWindow:   15 * time.Minute,
+		RateLimitGlobal:   60,
+```
+
+- [ ] **Step 4: Add the scenario**
+
+Create `internal/test/apiparity/catalogue_ratelimit.go`:
+
+```go
+package apiparity
+
+import "fmt"
+
+// Auth brute-force protection: the harness wires the production-default limits
+// (5 login / 5 reset / 3 remind / 5 register per 15m window), so this scenario
+// freezes the over-limit 429 envelope for each protected endpoint. Each
+// scenario runs on a fresh DB + fresh in-memory limiter, keeping counts
+// deterministic; total calls (22) stay under the global 60/min backstop.
+func init() {
+	register(Scenario{Name: "auth_rate_limit", Calls: func() []Call {
+		var calls []Call
+		for i := 1; i <= 5; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("err:login-bad-%d", i), Method: "POST", Path: "/api/v1/user/login-user", Auth: "",
+				Body: map[string]any{"username": OwnerEmail, "password": "wrong"}})
+		}
+		// Correct password, but over the failure limit: lockout is by attempt
+		// count, not credential.
+		calls = append(calls, Call{Label: "err:login-limited", Method: "POST", Path: "/api/v1/user/login-user", Auth: "",
+			Body: map[string]any{"username": OwnerEmail, "password": SeedPassword}})
+
+		for i := 1; i <= 5; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("err:reset-bad-%d", i), Method: "POST", Path: "/api/v1/user/reset-password", Auth: "",
+				Body: map[string]any{"username": GuestEmail, "code": "00000000-0000-0000-0000-000000000000", "password": "irrelevant-pw"}})
+		}
+		calls = append(calls, Call{Label: "err:reset-limited", Method: "POST", Path: "/api/v1/user/reset-password", Auth: "",
+			Body: map[string]any{"username": GuestEmail, "code": "00000000-0000-0000-0000-000000000000", "password": "irrelevant-pw"}})
+
+		// Remind counts every request (each sends an email via the console
+		// transport), so three 200s then a 429.
+		for i := 1; i <= 3; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("remind-%d", i), Method: "POST", Path: "/api/v1/user/remind-password", Auth: "",
+				Body: map[string]any{"username": GuestEmail}})
+		}
+		calls = append(calls, Call{Label: "err:remind-limited", Method: "POST", Path: "/api/v1/user/remind-password", Auth: "",
+			Body: map[string]any{"username": GuestEmail}})
+
+		// Register counts every attempt: one success, four duplicate-email 400s,
+		// then the cap.
+		calls = append(calls, Call{Label: "register-1", Method: "POST", Path: "/api/v1/user/register-user", Auth: "",
+			Body: map[string]any{"email": "ratelimit@example.test", "password": SeedPassword, "name": "RL"}})
+		for i := 2; i <= 5; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("err:register-dup-%d", i), Method: "POST", Path: "/api/v1/user/register-user", Auth: "",
+				Body: map[string]any{"email": "ratelimit@example.test", "password": SeedPassword, "name": "RL"}})
+		}
+		calls = append(calls, Call{Label: "err:register-limited", Method: "POST", Path: "/api/v1/user/register-user", Auth: "",
+			Body: map[string]any{"email": "ratelimit@example.test", "password": SeedPassword, "name": "RL"}})
+		return calls
+	}})
+}
+```
+
+- [ ] **Step 5: Generate the new golden, then verify NOTHING else changed**
+
+```bash
+UPDATE_GOLDEN=1 go test ./internal/test/apiparity/ -run "TestSmoke_Catalogue/auth_rate_limit" -v
+git status --short internal/test/apiparity/testdata/
+```
+
+Expected: exactly ONE new file `testdata/golden/auth_rate_limit.golden`, zero modified goldens. INSPECT the new golden: every `*-limited` call must show `-> 429` with body `{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}`; the five `login-bad` calls show the frozen 401; `remind-*` show 200 success envelopes.
+
+If any EXISTING golden shows as modified: STOP — a production response changed; find and fix the regression before proceeding.
+
+- [ ] **Step 6: Run the full apiparity + server suites**
+
+Run: `go test ./internal/test/apiparity/ ./internal/server/... -v 2>&1 | tail -20`
+Expected: PASS, including the guard tests (scenario count grew by 1; no orphaned goldens).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/server/ internal/user/api/user.go internal/web/apidoc/ internal/test/apiparity/
+git commit -m "feat(server): wire auth rate limiter; freeze the 429 envelope in apiparity"
+```
+
+---
+
+### Task 10: Docs + full verification
+
+**Files:**
+- Modify: `CLAUDE.md` (Configuration section)
+- Verify: whole repo
+
+- [ ] **Step 1: Document the env vars in CLAUDE.md**
+
+In the Configuration list (after the `SQLITE_BUSY_TIMEOUT` entry), add:
+
+```markdown
+- `ECONUMO_RATE_LIMIT_LOGIN` / `ECONUMO_RATE_LIMIT_RESET` / `ECONUMO_RATE_LIMIT_REMIND` /
+  `ECONUMO_RATE_LIMIT_REGISTER` — brute-force protection for the public auth endpoints:
+  max attempts per username/email per window (defaults 5/5/3/5; login and reset count
+  only FAILED attempts and clear on success, remind and register count every request).
+  `ECONUMO_RATE_LIMIT_WINDOW` — sliding window (Go duration, default `15m`).
+  `ECONUMO_RATE_LIMIT_GLOBAL` — per-endpoint cap per minute across all keys (default `60`).
+  `0` disables a check. Over-limit requests get HTTP 429 with the standard error envelope
+  (message `"Too many attempts. Try again later."`, frozen). State is in-memory (resets on
+  restart); a malformed value fails at boot.
+```
+
+Also add one line to the "Wire & data contract (frozen)" envelope list:
+
+```markdown
+- Rate-limited (429): `{"success": false, "message": "Too many attempts. Try again later.", "code": 429, "errors": {}}` — same shape as the handled-error envelope.
+```
+
+- [ ] **Step 2: Full smoke verification**
+
+Run: `make go-test`
+Expected: PASS — build + vet + gofmt + OpenAPI-freshness + all tests + coverage gate (≥78%; the new packages are heavily tested, so coverage should not drop).
+
+- [ ] **Step 3: Engine-comparison + frontend tier (if Docker/PostgreSQL available)**
+
+Run: `make test`
+Expected: PASS — the enginecompare suite replays `auth_rate_limit` on both engines byte-identically. If Docker is unavailable, note it in the final report instead of skipping silently.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document ECONUMO_RATE_LIMIT_* configuration and the 429 envelope"
+```

--- a/docs/superpowers/specs/2026-07-09-auth-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-07-09-auth-rate-limiting-design.md
@@ -1,0 +1,124 @@
+# Brute-force protection for auth endpoints — design
+
+**Date:** 2026-07-09
+**Status:** Approved
+
+## Problem
+
+`POST /api/v1/user/login-user`, `reset-password`, `remind-password`, and
+`register-user` accept unlimited attempts. Combined with the fast frozen
+password hash (sha512 x500), this makes online password guessing and
+reset-code guessing cheap, and lets an attacker mail-bomb arbitrary addresses
+via remind-password or mass-create accounts via register-user.
+
+## Decision summary
+
+Per-username attempt limiting with a per-endpoint global backstop, enforced in
+the user use cases via a new in-memory `internal/infra/ratelimit` service.
+Over-limit requests get HTTP 429 with the standard handled-error envelope.
+Limits are configurable via `ECONUMO_RATE_LIMIT_*` env vars. No IP-based
+keying (spoofable/misconfigurable behind reverse proxies), no fixed sleep, no
+DB persistence (single-binary deployment; state resets on restart by design).
+
+## Architecture
+
+- **New package `internal/infra/ratelimit`** — in-memory limiter: mutex + map
+  of sliding-window attempt counters, constructed with `port.Clock` (tests
+  drive time). No engine or feature dependencies.
+- **Consumer-side interface** in `internal/user/ports.go` (dependency rule —
+  the feature never imports infra concretions directly beyond existing
+  precedent; wiring happens in `internal/server`):
+
+  ```go
+  type AttemptLimiter interface {
+      Allow(scope, key string) error // *errs.TooManyRequestsError when over limit
+      Fail(scope, key string)        // record a failed attempt
+      Clear(scope, key string)       // wipe the key after success
+  }
+  ```
+
+- **Enforcement points** — top of each use case (`Login`, `ResetPassword`,
+  `RemindPassword`, `Register`): `Allow` first; `Fail` after a failed
+  verify/lookup; `Clear` after successful login/reset. Keys are the
+  lowercased+trimmed submitted username/email. Scopes: `login`, `reset`,
+  `remind`, `register`, plus internal global scopes per endpoint.
+- **Wiring** — `server.BuildAPI` constructs the limiter from config values and
+  passes it to `user.NewService`. The apiparity harness constructs its own
+  (generous limits so existing goldens are unaffected; a dedicated scenario
+  uses the real path to freeze the 429).
+
+## Policy
+
+| Scope | Counted event | Default limit | On success |
+|---|---|---|---|
+| login | failed verify (unknown user or bad password) | 5 / window / username | `Clear` |
+| reset | failed attempt (unknown user, bad code, expired code) | 5 / window / username | `Clear` |
+| remind | every request (each sends an email) | 3 / window / username | — |
+| register | every attempt | 5 / window / email | — |
+| global (each endpoint) | every request to that endpoint | 60 / minute | — |
+
+- Window is shared and configurable (default 15 minutes), sliding.
+- Anti-enumeration is preserved: `Allow`/`Fail` behave identically whether the
+  username exists or not, so a 429 leaks nothing a 401/400 didn't.
+- The global cap catches username-spray attacks that per-key limits miss.
+
+## Configuration
+
+Parsed in `config.Load`; a bad value fails at boot (same posture as
+`MAILER_DSN`). `0` disables that particular check.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ECONUMO_RATE_LIMIT_LOGIN` | `5` | failed logins per username per window |
+| `ECONUMO_RATE_LIMIT_RESET` | `5` | failed reset attempts per username per window |
+| `ECONUMO_RATE_LIMIT_REMIND` | `3` | remind requests per username per window |
+| `ECONUMO_RATE_LIMIT_REGISTER` | `5` | register attempts per email per window |
+| `ECONUMO_RATE_LIMIT_WINDOW` | `15m` | shared sliding-window size (Go duration syntax) |
+| `ECONUMO_RATE_LIMIT_GLOBAL` | `60` | per-endpoint global cap per minute (`0` disables) |
+
+Documented in `.env.example` and CLAUDE.md's configuration list.
+
+## Wire contract
+
+New code path only; every existing response stays byte-identical.
+
+- Over-limit: HTTP **429** with the standard handled-error envelope:
+  `{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}`
+- New error type `errs.NewTooManyRequests` in `internal/shared/errs`, mapped
+  to 429 in `httpx.WriteError`. The message string above is frozen once
+  shipped.
+- Handlers gain `@Failure 429` swagger annotations; docs regenerated with
+  `make swagger`.
+
+## Memory hygiene
+
+Expired windows are pruned lazily on write, plus a hard size cap (10k keys):
+when exceeded, evict expired entries first, then oldest. A spray of unique
+usernames therefore cannot grow the map unbounded.
+
+## Observability
+
+The existing AccessLog operation line already logs 4xx at WARN with
+`err`/`err_type` — 429s are visible with no new logging code. The limiter
+never logs keys (usernames/emails are PII).
+
+## Testing
+
+- **Unit** (`internal/infra/ratelimit`): window slide, clear, global cap,
+  disable-on-zero, eviction/size cap — all on a fake clock.
+- **Use case** (`internal/user`): 6th bad login → 429; success clears the
+  counter; equivalent paths for reset/remind/register; disabled limiter
+  (0) passes everything.
+- **apiparity**: harness wires generous limits so all existing scenarios and
+  goldens are unchanged; one new scenario drives a real over-limit sequence
+  and freezes the 429 envelope as a golden. Scenario/route guard counts only
+  grow.
+- **enginecompare**: unaffected — the limiter is engine-agnostic and
+  deterministic per test server.
+
+## Out of scope
+
+- IP/proxy-aware limiting (`X-Forwarded-For` trust) — revisit only if
+  per-username + global proves insufficient.
+- Persistent lockout state across restarts.
+- Retry-After header (can be added later without breaking anything).

--- a/docs/superpowers/specs/2026-07-09-auth-rate-limiting-design.md
+++ b/docs/superpowers/specs/2026-07-09-auth-rate-limiting-design.md
@@ -122,3 +122,9 @@ never logs keys (usernames/emails are PII).
   per-username + global proves insufficient.
 - Persistent lockout state across restarts.
 - Retry-After header (can be added later without breaking anything).
+- Accepted tradeoff: 5 cheap bad logins lock a targeted victim's username out
+  for the window (sustainable by repetition) — an accepted consequence of
+  keying on username without IP data, revisit under the same clause above.
+- Accepted tradeoff: a 60-req/min flood trips the global backstop and 429s
+  the endpoint for everyone — accepted backstop behavior, also revisit if
+  per-username + global proves insufficient.

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -73,7 +73,7 @@ func newContainer(ctx context.Context) (*container, error) {
 	resetMailer := mailer.NewResetSender(mailer.New(cfg.MailProvider, cfg.MailAPIKey), cfg.MailFrom, cfg.MailReplyTo)
 	userSvc := appuser.NewService(
 		userRepo, txm, encodeSvc, hasher, nil, currencyLookup, budgetExistence,
-		passwordReqRepo, resetMailer, clk, cfg.AllowRegistration,
+		passwordReqRepo, resetMailer, clk, nil, cfg.AllowRegistration,
 	)
 
 	currencyWriteRepo := currencyrepo.NewWriteRepo(cfg.DatabaseDriver, txm)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Config is the fully-resolved application configuration.
@@ -23,6 +24,15 @@ type Config struct {
 	AllowRegistration bool
 	DataSalt          string // ECONUMO_DATA_SALT. DEPRECATED and IGNORED by the API/repositories (they run salt-free); consumed only by the data:remove-salt migration to decrypt existing data. Unset it after migrating.
 	SQLiteBusyTimeout int
+
+	// Auth brute-force protection (see the 2026-07-09 auth-rate-limiting spec).
+	// Counts are attempts per key per RateLimitWindow; 0 disables a check.
+	RateLimitLogin    int           // ECONUMO_RATE_LIMIT_LOGIN: failed logins per username
+	RateLimitReset    int           // ECONUMO_RATE_LIMIT_RESET: failed reset attempts per username
+	RateLimitRemind   int           // ECONUMO_RATE_LIMIT_REMIND: remind requests per username
+	RateLimitRegister int           // ECONUMO_RATE_LIMIT_REGISTER: register attempts per email
+	RateLimitWindow   time.Duration // ECONUMO_RATE_LIMIT_WINDOW: sliding window (Go duration)
+	RateLimitGlobal   int           // ECONUMO_RATE_LIMIT_GLOBAL: per-endpoint cap per minute
 
 	// Mail — all DERIVED from MAILER_DSN, whose scheme selects the transport
 	// (empty/console/log -> console to stdout; resend://<key> -> Resend).
@@ -99,6 +109,31 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	c.MailProvider, c.MailAPIKey, c.MailFrom, c.MailReplyTo = provider, apiKey, from, replyTo
+
+	// Rate-limit values fail at boot on a malformed value (unlike the lenient
+	// getInt), because a typo here would silently disable brute-force protection.
+	for _, p := range []struct {
+		dst *int
+		key string
+		def int
+	}{
+		{&c.RateLimitLogin, "ECONUMO_RATE_LIMIT_LOGIN", 5},
+		{&c.RateLimitReset, "ECONUMO_RATE_LIMIT_RESET", 5},
+		{&c.RateLimitRemind, "ECONUMO_RATE_LIMIT_REMIND", 3},
+		{&c.RateLimitRegister, "ECONUMO_RATE_LIMIT_REGISTER", 5},
+		{&c.RateLimitGlobal, "ECONUMO_RATE_LIMIT_GLOBAL", 60},
+	} {
+		n, err := getIntStrict(p.key, p.def)
+		if err != nil {
+			return Config{}, err
+		}
+		*p.dst = n
+	}
+	window, werr := getDurationStrict("ECONUMO_RATE_LIMIT_WINDOW", 15*time.Minute)
+	if werr != nil {
+		return Config{}, werr
+	}
+	c.RateLimitWindow = window
 
 	// PORT and the JWT public key are required by the HTTP server only and are
 	// validated at server startup; they are intentionally NOT required here because
@@ -240,4 +275,30 @@ func getInt(key string, def int) int {
 		return def
 	}
 	return n
+}
+
+// getIntStrict is getInt with a hard failure on malformed or negative input,
+// for settings where a silent fallback would be a security downgrade.
+func getIntStrict(key string, def int) (int, error) {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("%s %q is not a non-negative integer", key, v)
+	}
+	return n, nil
+}
+
+func getDurationStrict(key string, def time.Duration) (time.Duration, error) {
+	v, ok := os.LookupEnv(key)
+	if !ok || v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("%s %q is not a positive Go duration (e.g. \"15m\")", key, v)
+	}
+	return d, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,17 +169,23 @@ func TestLoad_RateLimitOverridesAndDisable(t *testing.T) {
 }
 
 func TestLoad_RateLimitBadValuesFailBoot(t *testing.T) {
-	cases := map[string]string{
-		"ECONUMO_RATE_LIMIT_LOGIN":  "five",
-		"ECONUMO_RATE_LIMIT_GLOBAL": "-1",
-		"ECONUMO_RATE_LIMIT_WINDOW": "15minutes",
+	cases := []struct {
+		name string
+		key  string
+		bad  string
+	}{
+		{"LOGIN_non-numeric", "ECONUMO_RATE_LIMIT_LOGIN", "five"},
+		{"GLOBAL_negative", "ECONUMO_RATE_LIMIT_GLOBAL", "-1"},
+		{"WINDOW_unparseable", "ECONUMO_RATE_LIMIT_WINDOW", "15minutes"},
+		{"WINDOW_zero", "ECONUMO_RATE_LIMIT_WINDOW", "0"},
+		{"WINDOW_negative", "ECONUMO_RATE_LIMIT_WINDOW", "-5m"},
 	}
-	for key, bad := range cases {
-		t.Run(key, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
-			t.Setenv(key, bad)
+			t.Setenv(tc.key, tc.bad)
 			if _, err := Load(); err == nil {
-				t.Fatalf("Load() with %s=%q succeeded, want boot error", key, bad)
+				t.Fatalf("Load() with %s=%q succeeded, want boot error", tc.key, tc.bad)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestDriverFromURL(t *testing.T) {
@@ -124,6 +125,61 @@ func TestGetStringList(t *testing.T) {
 				if got[i] != tc.want[i] {
 					t.Fatalf("getStringList(%q) = %v, want %v", tc.val, got, tc.want)
 				}
+			}
+		})
+	}
+}
+
+func TestLoad_RateLimitDefaults(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+	c, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.RateLimitLogin != 5 || c.RateLimitReset != 5 || c.RateLimitRemind != 3 || c.RateLimitRegister != 5 {
+		t.Fatalf("per-endpoint defaults = %d/%d/%d/%d, want 5/5/3/5",
+			c.RateLimitLogin, c.RateLimitReset, c.RateLimitRemind, c.RateLimitRegister)
+	}
+	if c.RateLimitWindow != 15*time.Minute {
+		t.Fatalf("window = %v, want 15m", c.RateLimitWindow)
+	}
+	if c.RateLimitGlobal != 60 {
+		t.Fatalf("global = %d, want 60", c.RateLimitGlobal)
+	}
+}
+
+func TestLoad_RateLimitOverridesAndDisable(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+	t.Setenv("ECONUMO_RATE_LIMIT_LOGIN", "10")
+	t.Setenv("ECONUMO_RATE_LIMIT_RESET", "0") // 0 = disabled
+	t.Setenv("ECONUMO_RATE_LIMIT_REMIND", "7")
+	t.Setenv("ECONUMO_RATE_LIMIT_REGISTER", "8")
+	t.Setenv("ECONUMO_RATE_LIMIT_WINDOW", "1h30m")
+	t.Setenv("ECONUMO_RATE_LIMIT_GLOBAL", "0")
+	c, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.RateLimitLogin != 10 || c.RateLimitReset != 0 || c.RateLimitRemind != 7 || c.RateLimitRegister != 8 {
+		t.Fatalf("overrides not applied: %+v", c)
+	}
+	if c.RateLimitWindow != 90*time.Minute || c.RateLimitGlobal != 0 {
+		t.Fatalf("window/global overrides not applied: %v / %d", c.RateLimitWindow, c.RateLimitGlobal)
+	}
+}
+
+func TestLoad_RateLimitBadValuesFailBoot(t *testing.T) {
+	cases := map[string]string{
+		"ECONUMO_RATE_LIMIT_LOGIN":  "five",
+		"ECONUMO_RATE_LIMIT_GLOBAL": "-1",
+		"ECONUMO_RATE_LIMIT_WINDOW": "15minutes",
+	}
+	for key, bad := range cases {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+			t.Setenv(key, bad)
+			if _, err := Load(); err == nil {
+				t.Fatalf("Load() with %s=%q succeeded, want boot error", key, bad)
 			}
 		})
 	}

--- a/internal/infra/ratelimit/ratelimit.go
+++ b/internal/infra/ratelimit/ratelimit.go
@@ -1,0 +1,154 @@
+// Package ratelimit is the in-memory brute-force limiter for the public auth
+// endpoints: per-key sliding-window attempt counters plus a per-scope global
+// backstop. State is process-local and resets on restart by design (single
+// binary; see the 2026-07-09 auth-rate-limiting spec).
+package ratelimit
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/econumo/econumo/internal/shared/errs"
+	"github.com/econumo/econumo/internal/shared/port"
+)
+
+// Message is the frozen 429 envelope message.
+const Message = "Too many attempts. Try again later."
+
+const (
+	defaultMaxKeys = 10000
+	defaultWindow  = 15 * time.Minute
+	// The global backstop counts every request in its own fixed window so a
+	// spray of unique keys is caught quickly, independent of the per-key window.
+	globalWindow = time.Minute
+)
+
+// Config holds the limiter policy. A limit of 0 (or an absent scope) disables
+// that check.
+type Config struct {
+	Limits  map[string]int // per-scope max attempts per key per Window
+	Window  time.Duration  // per-key sliding window (default 15m)
+	Global  int            // per-scope cap per minute across ALL keys; 0 disables
+	MaxKeys int            // per-key map size cap (default 10000)
+}
+
+type Limiter struct {
+	mu       sync.Mutex
+	cfg      Config
+	clock    port.Clock
+	attempts map[string][]time.Time
+}
+
+func New(cfg Config, clk port.Clock) *Limiter {
+	if cfg.MaxKeys <= 0 {
+		cfg.MaxKeys = defaultMaxKeys
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = defaultWindow
+	}
+	return &Limiter{cfg: cfg, clock: clk, attempts: map[string][]time.Time{}}
+}
+
+// Key layouts: per-key entries are "k\x00<scope>\x00<key>", global counters are
+// "g\x00<scope>". The prefixes keep a caller-supplied key from ever colliding
+// with a global counter.
+func attemptKey(scope, key string) string { return "k\x00" + scope + "\x00" + key }
+func globalKey(scope string) string       { return "g\x00" + scope }
+
+// Allow reports whether another attempt may proceed. The per-key check runs
+// first and rejects without consuming the global budget, so an attack on one
+// key cannot starve every other caller of the endpoint.
+func (l *Limiter) Allow(scope, key string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.clock.Now()
+
+	if limit := l.cfg.Limits[scope]; limit > 0 {
+		k := attemptKey(scope, key)
+		hits := prune(l.attempts[k], now, l.cfg.Window)
+		l.store(k, hits)
+		if len(hits) >= limit {
+			return errs.NewTooManyRequests(Message)
+		}
+	}
+	if l.cfg.Global > 0 {
+		k := globalKey(scope)
+		hits := prune(l.attempts[k], now, globalWindow)
+		if len(hits) >= l.cfg.Global {
+			l.attempts[k] = hits
+			return errs.NewTooManyRequests(Message)
+		}
+		l.attempts[k] = append(hits, now)
+	}
+	return nil
+}
+
+// Fail records a failed attempt against the key.
+func (l *Limiter) Fail(scope, key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cfg.Limits[scope] <= 0 {
+		return
+	}
+	now := l.clock.Now()
+	k := attemptKey(scope, key)
+	if _, exists := l.attempts[k]; !exists && len(l.attempts) >= l.cfg.MaxKeys {
+		l.evict(now)
+	}
+	l.attempts[k] = append(prune(l.attempts[k], now, l.cfg.Window), now)
+}
+
+// Clear wipes the key's counter (called after a successful attempt).
+func (l *Limiter) Clear(scope, key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.attempts, attemptKey(scope, key))
+}
+
+func (l *Limiter) store(k string, hits []time.Time) {
+	if len(hits) == 0 {
+		delete(l.attempts, k)
+		return
+	}
+	l.attempts[k] = hits
+}
+
+// prune drops timestamps older than the window. Slices are append-only, so
+// they are already sorted ascending.
+func prune(hits []time.Time, now time.Time, window time.Duration) []time.Time {
+	cutoff := now.Add(-window)
+	i := 0
+	for ; i < len(hits); i++ {
+		if hits[i].After(cutoff) {
+			break
+		}
+	}
+	return hits[i:]
+}
+
+// evict makes room under MaxKeys: drop fully-expired per-key entries; if the
+// map is still full, drop the entry with the oldest most-recent attempt.
+// Global counters (a handful, one per scope) are never evicted.
+func (l *Limiter) evict(now time.Time) {
+	var stalest string
+	var stalestAt time.Time
+	for k, hits := range l.attempts {
+		if strings.HasPrefix(k, "g\x00") {
+			continue
+		}
+		pruned := prune(hits, now, l.cfg.Window)
+		if len(pruned) == 0 {
+			delete(l.attempts, k)
+			continue
+		}
+		l.attempts[k] = pruned
+		newest := pruned[len(pruned)-1]
+		if stalest == "" || newest.Before(stalestAt) {
+			stalest, stalestAt = k, newest
+		}
+	}
+	if len(l.attempts) >= l.cfg.MaxKeys && stalest != "" {
+		delete(l.attempts, stalest)
+	}
+}

--- a/internal/infra/ratelimit/ratelimit.go
+++ b/internal/infra/ratelimit/ratelimit.go
@@ -5,6 +5,8 @@
 package ratelimit
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"sync"
 	"time"
@@ -53,8 +55,20 @@ func New(cfg Config, clk port.Clock) *Limiter {
 // Key layouts: per-key entries are "k\x00<scope>\x00<key>", global counters are
 // "g\x00<scope>". The prefixes keep a caller-supplied key from ever colliding
 // with a global counter.
-func attemptKey(scope, key string) string { return "k\x00" + scope + "\x00" + key }
-func globalKey(scope string) string       { return "g\x00" + scope }
+//
+// maxKeyLen bounds the bytes retained per attempt key: an attacker submitting
+// unique multi-megabyte usernames must not turn the failure map into a memory
+// sink. Longer keys are replaced by their sha256 so bucketing is preserved.
+const maxKeyLen = 128
+
+func attemptKey(scope, key string) string {
+	if len(key) > maxKeyLen {
+		sum := sha256.Sum256([]byte(key))
+		key = hex.EncodeToString(sum[:])
+	}
+	return "k\x00" + scope + "\x00" + key
+}
+func globalKey(scope string) string { return "g\x00" + scope }
 
 // Allow reports whether another attempt may proceed. The per-key check runs
 // first and rejects without consuming the global budget, so an attack on one

--- a/internal/infra/ratelimit/ratelimit_test.go
+++ b/internal/infra/ratelimit/ratelimit_test.go
@@ -1,6 +1,7 @@
 package ratelimit_test
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -194,6 +195,30 @@ func TestEviction_PrefersExpiredEntries(t *testing.T) {
 	l.Fail("login", "new@example.test")
 	mustBlocked(t, l, "login", "fresh@example.test")
 	mustAllowed(t, l, "login", "new@example.test")
+}
+
+// A key longer than the internal hashing threshold must be limited exactly
+// like a short one, proving Allow/Fail/Clear agree on the hashed form.
+func TestAllow_HugeKeyIsLimitedLikeShortKey(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(3))
+	huge := strings.Repeat("a", 5*1024*1024) + "@example.test"
+	for i := 0; i < 3; i++ {
+		mustAllowed(t, l, "login", huge)
+		l.Fail("login", huge)
+	}
+	mustBlocked(t, l, "login", huge)
+	l.Clear("login", huge)
+	mustAllowed(t, l, "login", huge)
+}
+
+// Two distinct huge keys must not collapse into the same bucket after hashing.
+func TestAllow_TwoHugeKeysAreIndependent(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	hugeA := strings.Repeat("a", 300*1024)
+	hugeB := strings.Repeat("b", 300*1024)
+	l.Fail("login", hugeA)
+	mustBlocked(t, l, "login", hugeA)
+	mustAllowed(t, l, "login", hugeB)
 }
 
 // go test -race exercises the mutex.

--- a/internal/infra/ratelimit/ratelimit_test.go
+++ b/internal/infra/ratelimit/ratelimit_test.go
@@ -1,0 +1,221 @@
+package ratelimit_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/econumo/econumo/internal/infra/ratelimit"
+	"github.com/econumo/econumo/internal/shared/errs"
+)
+
+// fakeClock is a mutable clock so tests can slide the window.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+func newLimiter(cfg ratelimit.Config) (*ratelimit.Limiter, *fakeClock) {
+	clk := &fakeClock{t: time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)}
+	return ratelimit.New(cfg, clk), clk
+}
+
+func cfgLogin(limit int) ratelimit.Config {
+	return ratelimit.Config{Limits: map[string]int{"login": limit}, Window: 15 * time.Minute}
+}
+
+func mustAllowed(t *testing.T, l *ratelimit.Limiter, scope, key string) {
+	t.Helper()
+	if err := l.Allow(scope, key); err != nil {
+		t.Fatalf("Allow(%s,%s) = %v, want nil", scope, key, err)
+	}
+}
+
+func mustBlocked(t *testing.T, l *ratelimit.Limiter, scope, key string) {
+	t.Helper()
+	err := l.Allow(scope, key)
+	if err == nil {
+		t.Fatalf("Allow(%s,%s) = nil, want TooManyRequestsError", scope, key)
+	}
+	if _, ok := errs.AsTooManyRequests(err); !ok {
+		t.Fatalf("Allow(%s,%s) = %T, want *errs.TooManyRequestsError", scope, key, err)
+	}
+	if err.Error() != ratelimit.Message {
+		t.Fatalf("message = %q, want %q", err.Error(), ratelimit.Message)
+	}
+}
+
+func TestAllow_UnderLimit(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(3))
+	for i := 0; i < 2; i++ {
+		mustAllowed(t, l, "login", "user@example.test")
+		l.Fail("login", "user@example.test")
+	}
+	mustAllowed(t, l, "login", "user@example.test") // 2 failures < 3
+}
+
+func TestAllow_BlocksAtLimit(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(3))
+	for i := 0; i < 3; i++ {
+		mustAllowed(t, l, "login", "user@example.test")
+		l.Fail("login", "user@example.test")
+	}
+	mustBlocked(t, l, "login", "user@example.test")
+}
+
+func TestAllow_KeysAreIndependent(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	l.Fail("login", "a@example.test")
+	mustBlocked(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+}
+
+func TestAllow_ScopesAreIndependent(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 1, "reset": 1}, Window: 15 * time.Minute,
+	})
+	l.Fail("login", "u@example.test")
+	mustBlocked(t, l, "login", "u@example.test")
+	mustAllowed(t, l, "reset", "u@example.test")
+}
+
+func TestAllow_WindowSlides(t *testing.T) {
+	l, clk := newLimiter(cfgLogin(2))
+	l.Fail("login", "u@example.test")
+	clk.t = clk.t.Add(10 * time.Minute)
+	l.Fail("login", "u@example.test")
+	mustBlocked(t, l, "login", "u@example.test")
+	clk.t = clk.t.Add(6 * time.Minute) // first failure now 16m old -> expired
+	mustAllowed(t, l, "login", "u@example.test")
+	clk.t = clk.t.Add(10 * time.Minute) // second failure now expired too
+	mustAllowed(t, l, "login", "u@example.test")
+}
+
+func TestClear_ResetsCounter(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	l.Fail("login", "u@example.test")
+	mustBlocked(t, l, "login", "u@example.test")
+	l.Clear("login", "u@example.test")
+	mustAllowed(t, l, "login", "u@example.test")
+}
+
+func TestZeroLimit_Disables(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(0))
+	for i := 0; i < 100; i++ {
+		l.Fail("login", "u@example.test")
+		mustAllowed(t, l, "login", "u@example.test")
+	}
+}
+
+func TestUnknownScope_Disabled(t *testing.T) {
+	l, _ := newLimiter(cfgLogin(1))
+	for i := 0; i < 10; i++ {
+		l.Fail("nope", "u@example.test")
+		mustAllowed(t, l, "nope", "u@example.test")
+	}
+}
+
+func TestGlobalCap_BlocksAcrossKeys(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 100}, Window: 15 * time.Minute, Global: 3,
+	})
+	mustAllowed(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+	mustAllowed(t, l, "login", "c@example.test")
+	mustBlocked(t, l, "login", "d@example.test") // 4th request, distinct key
+}
+
+func TestGlobalCap_SlidesOnItsOwnMinuteWindow(t *testing.T) {
+	l, clk := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 100}, Window: 15 * time.Minute, Global: 2,
+	})
+	mustAllowed(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+	mustBlocked(t, l, "login", "c@example.test")
+	clk.t = clk.t.Add(61 * time.Second)
+	mustAllowed(t, l, "login", "c@example.test")
+}
+
+func TestGlobalCap_ZeroDisables(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 100}, Window: 15 * time.Minute, Global: 0,
+	})
+	for i := 0; i < 200; i++ {
+		mustAllowed(t, l, "login", "u@example.test")
+	}
+}
+
+// A key already over its per-key limit must be rejected WITHOUT consuming the
+// global budget — an attack on one account must not starve everyone else.
+func TestBlockedKey_DoesNotConsumeGlobal(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 1}, Window: 15 * time.Minute, Global: 3,
+	})
+	l.Fail("login", "victim@example.test")
+	for i := 0; i < 50; i++ {
+		mustBlocked(t, l, "login", "victim@example.test")
+	}
+	// Global budget (3) untouched by the blocked calls above.
+	mustAllowed(t, l, "login", "a@example.test")
+	mustAllowed(t, l, "login", "b@example.test")
+	mustAllowed(t, l, "login", "c@example.test")
+	mustBlocked(t, l, "login", "d@example.test")
+}
+
+func TestEviction_CapsKeyCount(t *testing.T) {
+	l, clk := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 5}, Window: 15 * time.Minute, MaxKeys: 3,
+	})
+	l.Fail("login", "a@example.test")
+	clk.t = clk.t.Add(time.Second)
+	l.Fail("login", "b@example.test")
+	clk.t = clk.t.Add(time.Second)
+	l.Fail("login", "c@example.test")
+	clk.t = clk.t.Add(time.Second)
+	// Map full (3 keys); inserting a 4th evicts the stalest key (a).
+	l.Fail("login", "d@example.test")
+	// a's counter was evicted: 5 fresh failures needed again to block it.
+	mustAllowed(t, l, "login", "a@example.test")
+	// d's failure was recorded.
+	for i := 0; i < 4; i++ {
+		l.Fail("login", "d@example.test")
+	}
+	mustBlocked(t, l, "login", "d@example.test")
+}
+
+func TestEviction_PrefersExpiredEntries(t *testing.T) {
+	l, clk := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 2}, Window: time.Minute, MaxKeys: 2,
+	})
+	l.Fail("login", "old@example.test")
+	clk.t = clk.t.Add(2 * time.Minute) // old@ expires
+	l.Fail("login", "fresh@example.test")
+	l.Fail("login", "fresh@example.test")
+	// Map at cap; the expired old@ entry is dropped, fresh@ keeps its 2 failures.
+	l.Fail("login", "new@example.test")
+	mustBlocked(t, l, "login", "fresh@example.test")
+	mustAllowed(t, l, "login", "new@example.test")
+}
+
+// go test -race exercises the mutex.
+func TestConcurrentAccess(t *testing.T) {
+	l, _ := newLimiter(ratelimit.Config{
+		Limits: map[string]int{"login": 3}, Window: 15 * time.Minute, Global: 1000,
+	})
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			keys := []string{"a@example.test", "b@example.test", "c@example.test"}
+			for i := 0; i < 200; i++ {
+				k := keys[(g+i)%len(keys)]
+				_ = l.Allow("login", k)
+				l.Fail("login", k)
+				if i%10 == 0 {
+					l.Clear("login", k)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/econumo/econumo/internal/infra/auth"
 	"github.com/econumo/econumo/internal/infra/mailer"
 	operationrepo "github.com/econumo/econumo/internal/infra/operation"
+	"github.com/econumo/econumo/internal/infra/ratelimit"
 	"github.com/econumo/econumo/internal/infra/storage/backend"
 	apppayee "github.com/econumo/econumo/internal/payee"
 	handlerpayee "github.com/econumo/econumo/internal/payee/api"
@@ -70,9 +71,19 @@ func BuildAPI(cfg config.Config, db *sql.DB, jwtSvc *jwt.JWT, clk port.Clock) ht
 
 	passwordReqRepo := userrepo.NewPasswordRequestRepo(cfg.DatabaseDriver, txm)
 	resetMailer := mailer.NewResetSender(mailer.New(cfg.MailProvider, cfg.MailAPIKey), cfg.MailFrom, cfg.MailReplyTo)
+	authLimiter := ratelimit.New(ratelimit.Config{
+		Limits: map[string]int{
+			appuser.RateScopeLogin:    cfg.RateLimitLogin,
+			appuser.RateScopeReset:    cfg.RateLimitReset,
+			appuser.RateScopeRemind:   cfg.RateLimitRemind,
+			appuser.RateScopeRegister: cfg.RateLimitRegister,
+		},
+		Window: cfg.RateLimitWindow,
+		Global: cfg.RateLimitGlobal,
+	}, clk)
 	userSvc := appuser.NewService(
 		userRepo, txm, encodeSvc, hasher, jwtSvc, currencyLookup, budgetExistence,
-		passwordReqRepo, resetMailer, clk, nil, cfg.AllowRegistration,
+		passwordReqRepo, resetMailer, clk, authLimiter, cfg.AllowRegistration,
 	)
 	userReadSvc := appuser.NewReadService(userReadRepo, encodeSvc)
 	userHandlers := handleruser.NewHandlers(userSvc, userReadSvc, cfg.IsDev(), clk)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,7 +72,7 @@ func BuildAPI(cfg config.Config, db *sql.DB, jwtSvc *jwt.JWT, clk port.Clock) ht
 	resetMailer := mailer.NewResetSender(mailer.New(cfg.MailProvider, cfg.MailAPIKey), cfg.MailFrom, cfg.MailReplyTo)
 	userSvc := appuser.NewService(
 		userRepo, txm, encodeSvc, hasher, jwtSvc, currencyLookup, budgetExistence,
-		passwordReqRepo, resetMailer, clk, cfg.AllowRegistration,
+		passwordReqRepo, resetMailer, clk, nil, cfg.AllowRegistration,
 	)
 	userReadSvc := appuser.NewReadService(userReadRepo, encodeSvc)
 	userHandlers := handleruser.NewHandlers(userSvc, userReadSvc, cfg.IsDev(), clk)

--- a/internal/shared/errs/errs.go
+++ b/internal/shared/errs/errs.go
@@ -125,3 +125,27 @@ func AsUnauthorized(err error) (*UnauthorizedError, bool) {
 	}
 	return nil, false
 }
+
+// TooManyRequestsError maps to HTTP 429 (a rate-limited auth attempt).
+type TooManyRequestsError struct {
+	Msg string
+}
+
+func (e *TooManyRequestsError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "too many requests"
+}
+
+// NewTooManyRequests builds a TooManyRequestsError.
+func NewTooManyRequests(msg string) *TooManyRequestsError { return &TooManyRequestsError{Msg: msg} }
+
+// AsTooManyRequests reports whether err is (or wraps) a *TooManyRequestsError.
+func AsTooManyRequests(err error) (*TooManyRequestsError, bool) {
+	var v *TooManyRequestsError
+	if errors.As(err, &v) {
+		return v, true
+	}
+	return nil, false
+}

--- a/internal/shared/errs/errs_test.go
+++ b/internal/shared/errs/errs_test.go
@@ -1,0 +1,28 @@
+package errs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/econumo/econumo/internal/shared/errs"
+)
+
+func TestTooManyRequests(t *testing.T) {
+	e := errs.NewTooManyRequests("Too many attempts. Try again later.")
+	if e.Error() != "Too many attempts. Try again later." {
+		t.Fatalf("Error() = %q", e.Error())
+	}
+	if _, ok := errs.AsTooManyRequests(e); !ok {
+		t.Fatal("AsTooManyRequests(e) = false, want true")
+	}
+	if _, ok := errs.AsTooManyRequests(fmt.Errorf("wrap: %w", e)); !ok {
+		t.Fatal("AsTooManyRequests(wrapped) = false, want true")
+	}
+	if _, ok := errs.AsTooManyRequests(fmt.Errorf("other")); ok {
+		t.Fatal("AsTooManyRequests(other) = true, want false")
+	}
+	empty := &errs.TooManyRequestsError{}
+	if empty.Error() != "too many requests" {
+		t.Fatalf("zero-value Error() = %q, want %q", empty.Error(), "too many requests")
+	}
+}

--- a/internal/test/apiparity/catalogue_ratelimit.go
+++ b/internal/test/apiparity/catalogue_ratelimit.go
@@ -1,0 +1,50 @@
+package apiparity
+
+import "fmt"
+
+// Auth brute-force protection: the harness wires the production-default limits
+// (5 login / 5 reset / 3 remind / 5 register per 15m window), so this scenario
+// freezes the over-limit 429 envelope for each protected endpoint. Each
+// scenario runs on a fresh DB + fresh in-memory limiter, keeping counts
+// deterministic; total calls (22) stay under the global 60/min backstop.
+func init() {
+	register(Scenario{Name: "auth_rate_limit", Calls: func() []Call {
+		var calls []Call
+		for i := 1; i <= 5; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("err:login-bad-%d", i), Method: "POST", Path: "/api/v1/user/login-user", Auth: "",
+				Body: map[string]any{"username": OwnerEmail, "password": "wrong"}})
+		}
+		// Correct password, but over the failure limit: lockout is by attempt
+		// count, not credential.
+		calls = append(calls, Call{Label: "err:login-limited", Method: "POST", Path: "/api/v1/user/login-user", Auth: "",
+			Body: map[string]any{"username": OwnerEmail, "password": SeedPassword}})
+
+		for i := 1; i <= 5; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("err:reset-bad-%d", i), Method: "POST", Path: "/api/v1/user/reset-password", Auth: "",
+				Body: map[string]any{"username": GuestEmail, "code": "00000000-0000-0000-0000-000000000000", "password": "irrelevant-pw"}})
+		}
+		calls = append(calls, Call{Label: "err:reset-limited", Method: "POST", Path: "/api/v1/user/reset-password", Auth: "",
+			Body: map[string]any{"username": GuestEmail, "code": "00000000-0000-0000-0000-000000000000", "password": "irrelevant-pw"}})
+
+		// Remind counts every request (each sends an email via the console
+		// transport), so three 200s then a 429.
+		for i := 1; i <= 3; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("remind-%d", i), Method: "POST", Path: "/api/v1/user/remind-password", Auth: "",
+				Body: map[string]any{"username": GuestEmail}})
+		}
+		calls = append(calls, Call{Label: "err:remind-limited", Method: "POST", Path: "/api/v1/user/remind-password", Auth: "",
+			Body: map[string]any{"username": GuestEmail}})
+
+		// Register counts every attempt: one success, four duplicate-email 400s,
+		// then the cap.
+		calls = append(calls, Call{Label: "register-1", Method: "POST", Path: "/api/v1/user/register-user", Auth: "",
+			Body: map[string]any{"email": "ratelimit@example.test", "password": SeedPassword, "name": "RLU"}})
+		for i := 2; i <= 5; i++ {
+			calls = append(calls, Call{Label: fmt.Sprintf("err:register-dup-%d", i), Method: "POST", Path: "/api/v1/user/register-user", Auth: "",
+				Body: map[string]any{"email": "ratelimit@example.test", "password": SeedPassword, "name": "RLU"}})
+		}
+		calls = append(calls, Call{Label: "err:register-limited", Method: "POST", Path: "/api/v1/user/register-user", Auth: "",
+			Body: map[string]any{"email": "ratelimit@example.test", "password": SeedPassword, "name": "RLU"}})
+		return calls
+	}})
+}

--- a/internal/test/apiparity/harness.go
+++ b/internal/test/apiparity/harness.go
@@ -75,6 +75,16 @@ func NewHarness(t *testing.T, db *dbtest.DB) *Harness {
 		AllowRegistration:  true,
 		DataSalt:           ignoredDataSalt, // set on purpose; the API must ignore it
 		CORSAllowedOrigins: []string{"*"},
+		// Production-default auth rate limits: existing auth scenarios stay far
+		// under them (1 bad login / 1 remind / 1 bad reset per fresh-DB scenario),
+		// and the auth_rate_limit scenario deliberately exceeds them to freeze the
+		// 429 envelope.
+		RateLimitLogin:    5,
+		RateLimitReset:    5,
+		RateLimitRemind:   3,
+		RateLimitRegister: 5,
+		RateLimitWindow:   15 * time.Minute,
+		RateLimitGlobal:   60,
 	}
 
 	Seed(t, db)

--- a/internal/test/apiparity/testdata/golden/auth_rate_limit.golden
+++ b/internal/test/apiparity/testdata/golden/auth_rate_limit.golden
@@ -1,0 +1,66 @@
+== err:login-bad-1 POST /api/v1/user/login-user [] -> 401
+{"success":false,"message":"Invalid credentials.","code":0,"errors":{}}
+
+== err:login-bad-2 POST /api/v1/user/login-user [] -> 401
+{"success":false,"message":"Invalid credentials.","code":0,"errors":{}}
+
+== err:login-bad-3 POST /api/v1/user/login-user [] -> 401
+{"success":false,"message":"Invalid credentials.","code":0,"errors":{}}
+
+== err:login-bad-4 POST /api/v1/user/login-user [] -> 401
+{"success":false,"message":"Invalid credentials.","code":0,"errors":{}}
+
+== err:login-bad-5 POST /api/v1/user/login-user [] -> 401
+{"success":false,"message":"Invalid credentials.","code":0,"errors":{}}
+
+== err:login-limited POST /api/v1/user/login-user [] -> 429
+{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}
+
+== err:reset-bad-1 POST /api/v1/user/reset-password [] -> 400
+{"success":false,"message":"Reset password error","code":400,"errors":{}}
+
+== err:reset-bad-2 POST /api/v1/user/reset-password [] -> 400
+{"success":false,"message":"Reset password error","code":400,"errors":{}}
+
+== err:reset-bad-3 POST /api/v1/user/reset-password [] -> 400
+{"success":false,"message":"Reset password error","code":400,"errors":{}}
+
+== err:reset-bad-4 POST /api/v1/user/reset-password [] -> 400
+{"success":false,"message":"Reset password error","code":400,"errors":{}}
+
+== err:reset-bad-5 POST /api/v1/user/reset-password [] -> 400
+{"success":false,"message":"Reset password error","code":400,"errors":{}}
+
+== err:reset-limited POST /api/v1/user/reset-password [] -> 429
+{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}
+
+== remind-1 POST /api/v1/user/remind-password [] -> 200
+{"success":true,"message":"","data":{}}
+
+== remind-2 POST /api/v1/user/remind-password [] -> 200
+{"success":true,"message":"","data":{}}
+
+== remind-3 POST /api/v1/user/remind-password [] -> 200
+{"success":true,"message":"","data":{}}
+
+== err:remind-limited POST /api/v1/user/remind-password [] -> 429
+{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}
+
+== register-1 POST /api/v1/user/register-user [] -> 200
+{"success":true,"message":"","data":{"user":{"id":"<generated-uuid>","name":"RLU","email":"ratelimit@example.test","avatar":"https://www.gravatar.com/avatar/406a9d647ad697d12e8e51ab5b10813f","options":[{"name":"currency","value":"USD"},{"name":"report_period","value":"monthly"},{"name":"budget","value":null},{"name":"onboarding","value":"started"},{"name":"currency_id","value":"dffc2a06-6f29-4704-8575-31709adee926"}],"currency":"USD","reportPeriod":"monthly"}}}
+
+== err:register-dup-2 POST /api/v1/user/register-user [] -> 400
+{"success":false,"message":"User already exists","code":400,"errors":{}}
+
+== err:register-dup-3 POST /api/v1/user/register-user [] -> 400
+{"success":false,"message":"User already exists","code":400,"errors":{}}
+
+== err:register-dup-4 POST /api/v1/user/register-user [] -> 400
+{"success":false,"message":"User already exists","code":400,"errors":{}}
+
+== err:register-dup-5 POST /api/v1/user/register-user [] -> 400
+{"success":false,"message":"User already exists","code":400,"errors":{}}
+
+== err:register-limited POST /api/v1/user/register-user [] -> 429
+{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}
+

--- a/internal/user/admin_integration_test.go
+++ b/internal/user/admin_integration_test.go
@@ -30,7 +30,7 @@ func newUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.EncodeServ
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	lookup := currencyrepo.New(db.Engine, db.TX)
 	budgets := server.NewUserBudgetExistence(db.Engine, db.TX)
-	svc := appuser.NewService(repo, db.TX, enc, hasher, nil, lookup, budgets, nil, nil, clock.New(), false)
+	svc := appuser.NewService(repo, db.TX, enc, hasher, nil, lookup, budgets, nil, nil, clock.New(), nil, false)
 	return svc, enc, hasher
 }
 

--- a/internal/user/api/harness_test.go
+++ b/internal/user/api/harness_test.go
@@ -63,7 +63,11 @@ type harness struct {
 	clock  fixedClock
 }
 
-func newHarness(t *testing.T) *harness {
+func newHarness(t *testing.T) *harness { return newHarnessWithLimiter(t, nil) }
+
+// newHarnessWithLimiter lets rate-limit tests inject a tight limiter; every
+// other test keeps the nil (disabled) default.
+func newHarnessWithLimiter(t *testing.T, limiter appuser.AttemptLimiter) *harness {
 	t.Helper()
 	ctx := context.Background()
 
@@ -107,7 +111,7 @@ func newHarness(t *testing.T) *harness {
 	resetMailer := mailer.NewResetSender(discardMailer{}, "", "")
 
 	cfg := config.Config{CORSAllowedOrigins: []string{"*"}, AllowRegistration: true}
-	svc := appuser.NewService(repo, txm, encode, hasher, jwtSvc, currency, budgets, passwordReqs, resetMailer, clk, cfg.AllowRegistration)
+	svc := appuser.NewService(repo, txm, encode, hasher, jwtSvc, currency, budgets, passwordReqs, resetMailer, clk, limiter, cfg.AllowRegistration)
 	readSvc := appuser.NewReadService(readRepo, encode)
 	handlers := handleruser.NewHandlers(svc, readSvc, cfg.IsDev(), clk)
 

--- a/internal/user/api/ratelimit_test.go
+++ b/internal/user/api/ratelimit_test.go
@@ -206,3 +206,35 @@ func fetchResetCode(t *testing.T, h *harness) string {
 	}
 	return code
 }
+
+func registerUser(h *harness, t *testing.T, email string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/register-user", "", map[string]any{
+		"email": email, "password": "brand-new-pw", "name": "New User",
+	})
+}
+
+// Register counts EVERY attempt (mass-creation protection), success included.
+func TestRegister_RateLimited(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := registerUser(h, t, "fresh@example.test"); status != http.StatusOK {
+		t.Fatal("expected 200 first register")
+	}
+	if status, _ := registerUser(h, t, "fresh@example.test"); status != http.StatusBadRequest {
+		t.Fatal("expected 400 duplicate")
+	}
+	status, env := registerUser(h, t, "fresh@example.test")
+	assert429(t, status, env)
+}
+
+func TestRegister_KeysIndependent(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		registerUser(h, t, "a@example.test")
+	}
+	if status, env := registerUser(h, t, "a@example.test"); status != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for exhausted key, got %d: %s", status, env.raw)
+	}
+	if status, _ := registerUser(h, t, "b@example.test"); status != http.StatusOK {
+		t.Fatal("expected 200 for a different email")
+	}
+}

--- a/internal/user/api/ratelimit_test.go
+++ b/internal/user/api/ratelimit_test.go
@@ -123,3 +123,86 @@ func TestLogin_NilLimiterUnlimited(t *testing.T) {
 		}
 	}
 }
+
+func remind(h *harness, t *testing.T, username string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/remind-password", "", map[string]any{"username": username})
+}
+
+func reset(h *harness, t *testing.T, username, code, password string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/reset-password", "", map[string]any{
+		"username": username, "code": code, "password": password,
+	})
+}
+
+// Remind counts EVERY request (each one sends an email), success included.
+func TestRemindPassword_RateLimited(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := remind(h, t, seedEmail); status != http.StatusOK {
+			t.Fatalf("attempt %d: expected 200", i+1)
+		}
+	}
+	status, env := remind(h, t, seedEmail)
+	assert429(t, status, env)
+}
+
+// Anti-enumeration holds under limiting: unknown users return the same 200s
+// then the same 429.
+func TestRemindPassword_UnknownUserSameShape(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := remind(h, t, "ghost@example.test"); status != http.StatusOK {
+			t.Fatalf("attempt %d: expected 200 (anti-enumeration)", i+1)
+		}
+	}
+	status, env := remind(h, t, "ghost@example.test")
+	assert429(t, status, env)
+}
+
+func TestResetPassword_RateLimitedOnBadCodes(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := reset(h, t, seedEmail, "000000000000", "new-pw-123"); status != http.StatusBadRequest {
+			t.Fatalf("attempt %d: expected 400", i+1)
+		}
+	}
+	status, env := reset(h, t, seedEmail, "000000000000", "new-pw-123")
+	assert429(t, status, env)
+}
+
+// A successful reset clears the counter; look up the real code in the DB the
+// same way internal/user/api/reset_password_test.go does (read that file and
+// reuse its query helper/pattern verbatim).
+func TestResetPassword_SuccessClearsCounter(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := reset(h, t, seedEmail, "000000000000", "new-pw-123"); status != http.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+	if status, _ := remind(h, t, seedEmail); status != http.StatusOK {
+		t.Fatal("expected 200 remind")
+	}
+	code := fetchResetCode(t, h)
+	if status, _ := reset(h, t, seedEmail, code, "new-pw-123"); status != http.StatusOK {
+		t.Fatal("expected 200 reset")
+	}
+	// Counter cleared: two more bad attempts before a block.
+	if status, _ := reset(h, t, seedEmail, "000000000000", "x-pw-123"); status != http.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+	if status, _ := reset(h, t, seedEmail, "000000000000", "x-pw-123"); status != http.StatusBadRequest {
+		t.Fatal("expected 400")
+	}
+	status, env := reset(h, t, seedEmail, "000000000000", "x-pw-123")
+	assert429(t, status, env)
+}
+
+// fetchResetCode reads the emailed reset code for the seed user straight from
+// the DB (the test mailer is a no-op).
+func fetchResetCode(t *testing.T, h *harness) string {
+	t.Helper()
+	var code string
+	if err := h.db.QueryRow(`SELECT code FROM users_password_requests WHERE user_id = ?`, seedUserID).Scan(&code); err != nil {
+		t.Fatalf("read reset code: %v", err)
+	}
+	return code
+}

--- a/internal/user/api/ratelimit_test.go
+++ b/internal/user/api/ratelimit_test.go
@@ -1,0 +1,125 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/econumo/econumo/internal/infra/ratelimit"
+	appuser "github.com/econumo/econumo/internal/user"
+)
+
+// tight per-key limits so a handful of calls trips the 429; global generous so
+// only the per-key path is under test here.
+func newLimitedHarness(t *testing.T) *harness {
+	t.Helper()
+	limiter := ratelimit.New(ratelimit.Config{
+		Limits: map[string]int{
+			appuser.RateScopeLogin:    2,
+			appuser.RateScopeReset:    2,
+			appuser.RateScopeRemind:   2,
+			appuser.RateScopeRegister: 2,
+		},
+		Window: 15 * time.Minute,
+		Global: 1000,
+	}, realClock{})
+	return newHarnessWithLimiter(t, limiter)
+}
+
+// realClock: the limiter needs a monotonic-ish clock; the harness fixedClock
+// would also work (all attempts land in one window), but real time matches
+// production wiring.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+func assert429(t *testing.T, status int, env envelope) {
+	t.Helper()
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (body: %s)", status, env.raw)
+	}
+	if env.Success || env.Code != 429 || env.Message != "Too many attempts. Try again later." {
+		t.Fatalf("envelope = %+v, want success=false code=429 frozen message", env)
+	}
+	if string(env.Errors) != "{}" {
+		t.Fatalf("errors = %s, want {}", env.Errors)
+	}
+}
+
+func login(h *harness, t *testing.T, username, password string) (int, envelope) {
+	return h.do(t, "POST", "/api/v1/user/login-user", "", map[string]any{
+		"username": username, "password": password,
+	})
+}
+
+func TestLogin_RateLimitedAfterFailures(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401", i+1, status)
+		}
+	}
+	// Third attempt is blocked even with the CORRECT password: lockout is by
+	// attempt count, not credential.
+	status, env := login(h, t, seedEmail, seedPassword)
+	assert429(t, status, env)
+}
+
+func TestLogin_UnknownUserAlsoRateLimited(t *testing.T) {
+	h := newLimitedHarness(t)
+	for i := 0; i < 2; i++ {
+		if status, _ := login(h, t, "ghost@example.test", "x"); status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401", i+1, status)
+		}
+	}
+	status, env := login(h, t, "ghost@example.test", "x")
+	assert429(t, status, env) // anti-enumeration: same behavior as an existing user
+}
+
+func TestLogin_SuccessClearsCounter(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	if status, _ := login(h, t, seedEmail, seedPassword); status != http.StatusOK {
+		t.Fatal("expected 200 (1 failure < limit 2)")
+	}
+	// Counter was cleared: two more failures allowed before a block.
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	status, env := login(h, t, seedEmail, seedPassword)
+	assert429(t, status, env)
+}
+
+func TestLogin_KeyIsCaseAndSpaceInsensitive(t *testing.T) {
+	h := newLimitedHarness(t)
+	if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	if status, _ := login(h, t, "  "+upperFirst(seedEmail)+" ", "wrong-pw"); status != http.StatusUnauthorized {
+		t.Fatal("expected 401")
+	}
+	// Both failures hit the same bucket -> third attempt blocked.
+	status, env := login(h, t, seedEmail, seedPassword)
+	assert429(t, status, env)
+}
+
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return string(s[0]-32) + s[1:] // seedEmail starts with a lowercase ASCII letter
+}
+
+func TestLogin_NilLimiterUnlimited(t *testing.T) {
+	h := newHarness(t) // nil limiter
+	for i := 0; i < 10; i++ {
+		if status, _ := login(h, t, seedEmail, "wrong-pw"); status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401 (never 429)", i+1, status)
+		}
+	}
+}

--- a/internal/user/api/user.go
+++ b/internal/user/api/user.go
@@ -29,6 +29,7 @@ var _ = apidoc.JsonResponseError{}
 // @Success     200     {object} model.LoginResult "Raw {token,user} body — NOT wrapped in the standard envelope (matches PHP login)."
 // @Failure     400     {object} apidoc.JsonResponseError
 // @Failure     401     {object} apidoc.JsonResponseUnauthorized
+// @Failure     429     {object} apidoc.JsonResponseError
 // @Failure     500     {object} apidoc.JsonResponseException
 // @Router      /api/v1/user/login-user [post]
 func (h *Handlers) LoginUser(w http.ResponseWriter, r *http.Request) {
@@ -65,6 +66,7 @@ func (h *Handlers) LoginUser(w http.ResponseWriter, r *http.Request) {
 // @Success     200     {object} apidoc.JsonResponseOk{data=model.CurrentUserResult}
 // @Failure     400     {object} apidoc.JsonResponseError
 // @Failure     401     {object} apidoc.JsonResponseUnauthorized
+// @Failure     429     {object} apidoc.JsonResponseError
 // @Failure     500     {object} apidoc.JsonResponseException
 // @Router      /api/v1/user/register-user [post]
 func (h *Handlers) RegisterUser(w http.ResponseWriter, r *http.Request) {
@@ -103,6 +105,7 @@ func (h *Handlers) LogoutUser(w http.ResponseWriter, r *http.Request) {
 // @Success     200     {object} apidoc.JsonResponseOk{data=model.RemindPasswordResult}
 // @Failure     400     {object} apidoc.JsonResponseError
 // @Failure     401     {object} apidoc.JsonResponseUnauthorized
+// @Failure     429     {object} apidoc.JsonResponseError
 // @Failure     500     {object} apidoc.JsonResponseException
 // @Router      /api/v1/user/remind-password [post]
 func (h *Handlers) RemindPassword(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +124,7 @@ func (h *Handlers) RemindPassword(w http.ResponseWriter, r *http.Request) {
 // @Success     200     {object} apidoc.JsonResponseOk{data=model.ResetPasswordResult}
 // @Failure     400     {object} apidoc.JsonResponseError
 // @Failure     401     {object} apidoc.JsonResponseUnauthorized
+// @Failure     429     {object} apidoc.JsonResponseError
 // @Failure     500     {object} apidoc.JsonResponseException
 // @Router      /api/v1/user/reset-password [post]
 func (h *Handlers) ResetPassword(w http.ResponseWriter, r *http.Request) {

--- a/internal/user/login.go
+++ b/internal/user/login.go
@@ -15,15 +15,21 @@ import (
 // token + current user. A bad username or password yields an UnauthorizedError
 // (HTTP 401, "Invalid credentials.").
 func (s *Service) Login(ctx context.Context, req model.LoginRequest, now time.Time) (*model.LoginResult, error) {
+	limitKey := strings.ToLower(strings.TrimSpace(req.Username))
+	if err := s.allowAttempt(RateScopeLogin, limitKey); err != nil {
+		return nil, err
+	}
 	identifier := s.encode.Hash(strings.ToLower(req.Username))
 	u, err := s.repo.GetByIdentifier(ctx, identifier)
 	if err != nil {
 		if _, ok := errs.AsNotFound(err); ok {
+			s.failAttempt(RateScopeLogin, limitKey)
 			return nil, errs.NewUnauthorized("Invalid credentials.")
 		}
 		return nil, err
 	}
 	if !u.IsActive || !s.hasher.Verify(u.Password, req.Password, u.Salt) {
+		s.failAttempt(RateScopeLogin, limitKey)
 		return nil, errs.NewUnauthorized("Invalid credentials.")
 	}
 
@@ -39,5 +45,6 @@ func (s *Service) Login(ctx context.Context, req model.LoginRequest, now time.Ti
 	if cerr != nil {
 		return nil, cerr
 	}
+	s.clearAttempt(RateScopeLogin, limitKey)
 	return &model.LoginResult{Token: token, User: cur}, nil
 }

--- a/internal/user/migrate_test.go
+++ b/internal/user/migrate_test.go
@@ -34,7 +34,7 @@ func newSaltFreeUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.Pa
 	if err != nil {
 		t.Fatalf("NewJWT: %v", err)
 	}
-	svc := appuser.NewService(repo, db.TX, enc, hasher, jwtSvc, lookup, budgets, nil, nil, clock.New(), false)
+	svc := appuser.NewService(repo, db.TX, enc, hasher, jwtSvc, lookup, budgets, nil, nil, clock.New(), nil, false)
 	return svc, hasher
 }
 

--- a/internal/user/password.go
+++ b/internal/user/password.go
@@ -54,6 +54,11 @@ func (s *Service) UpdatePassword(ctx context.Context, userID vo.Id, req model.Up
 // (returns success) to avoid account enumeration.
 func (s *Service) RemindPassword(ctx context.Context, req model.RemindPasswordRequest) (*model.RemindPasswordResult, error) {
 	lowered := strings.ToLower(strings.TrimSpace(req.Username))
+	if err := s.allowAttempt(RateScopeRemind, lowered); err != nil {
+		return nil, err
+	}
+	s.failAttempt(RateScopeRemind, lowered) // every remind sends an email, so every request counts
+
 	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
 	if err != nil {
 		if isNotFound(err) {
@@ -90,9 +95,13 @@ func (s *Service) RemindPassword(ctx context.Context, req model.RemindPasswordRe
 // validation error; an expired code yields the frozen "The code is expired".
 func (s *Service) ResetPassword(ctx context.Context, req model.ResetPasswordRequest) (*model.ResetPasswordResult, error) {
 	lowered := strings.ToLower(strings.TrimSpace(req.Username))
+	if err := s.allowAttempt(RateScopeReset, lowered); err != nil {
+		return nil, err
+	}
 	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
 	if err != nil {
 		if isNotFound(err) {
+			s.failAttempt(RateScopeReset, lowered)
 			return nil, errs.NewValidation("Reset password error")
 		}
 		return nil, err
@@ -101,11 +110,13 @@ func (s *Service) ResetPassword(ctx context.Context, req model.ResetPasswordRequ
 	pr, err := s.passwordRequests.GetByUserAndCode(ctx, u.ID, strings.TrimSpace(req.Code))
 	if err != nil {
 		if isNotFound(err) {
+			s.failAttempt(RateScopeReset, lowered)
 			return nil, errs.NewValidation("Reset password error")
 		}
 		return nil, err
 	}
 	if pr.IsExpired(s.clock.Now()) {
+		s.failAttempt(RateScopeReset, lowered)
 		return nil, errs.NewValidation("The code is expired")
 	}
 
@@ -118,5 +129,6 @@ func (s *Service) ResetPassword(ctx context.Context, req model.ResetPasswordRequ
 	}); err != nil {
 		return nil, err
 	}
+	s.clearAttempt(RateScopeReset, lowered)
 	return &model.ResetPasswordResult{}, nil
 }

--- a/internal/user/ports.go
+++ b/internal/user/ports.go
@@ -27,3 +27,24 @@ type BudgetExistence interface {
 	// Exists reports whether a budget with the given id exists.
 	Exists(ctx context.Context, budgetID string) (bool, error)
 }
+
+// AttemptLimiter is the brute-force-protection seam for the public auth use
+// cases. Keys are the lowercased+trimmed submitted username/email; scopes are
+// the RateScope* constants. A nil limiter disables protection (CLI, tests).
+type AttemptLimiter interface {
+	// Allow reports whether another attempt may proceed; over-limit yields an
+	// *errs.TooManyRequestsError (HTTP 429).
+	Allow(scope, key string) error
+	// Fail records a failed attempt.
+	Fail(scope, key string)
+	// Clear wipes the key's failure counter after a successful attempt.
+	Clear(scope, key string)
+}
+
+// Rate-limit scopes; the same strings key the limiter config in internal/server.
+const (
+	RateScopeLogin    = "login"
+	RateScopeReset    = "reset"
+	RateScopeRemind   = "remind"
+	RateScopeRegister = "register"
+)

--- a/internal/user/register.go
+++ b/internal/user/register.go
@@ -14,6 +14,12 @@ import (
 // gated on ECONUMO_ALLOW_REGISTRATION; the actual creation is shared with the
 // ungated CLI admin path via createUser.
 func (s *Service) Register(ctx context.Context, req model.RegisterRequest) (*model.RegisterResult, error) {
+	limitKey := strings.ToLower(strings.TrimSpace(req.Email))
+	if err := s.allowAttempt(RateScopeRegister, limitKey); err != nil {
+		return nil, err
+	}
+	s.failAttempt(RateScopeRegister, limitKey) // every attempt counts toward the cap
+
 	if !s.allowRegistration {
 		return nil, errs.NewValidation("Registration disabled")
 	}

--- a/internal/user/usecase.go
+++ b/internal/user/usecase.go
@@ -35,6 +35,7 @@ type Service struct {
 	passwordRequests  PasswordRequests
 	mailer            *mailer.ResetSender
 	clock             port.Clock
+	limiter           AttemptLimiter
 	allowRegistration bool
 }
 
@@ -49,6 +50,7 @@ func NewService(
 	passwordRequests PasswordRequests,
 	mailer *mailer.ResetSender,
 	clock port.Clock,
+	limiter AttemptLimiter,
 	allowRegistration bool,
 ) *Service {
 	return &Service{
@@ -62,6 +64,7 @@ func NewService(
 		passwordRequests:  passwordRequests,
 		mailer:            mailer,
 		clock:             clock,
+		limiter:           limiter,
 		allowRegistration: allowRegistration,
 	}
 }
@@ -177,4 +180,25 @@ func newSalt() (string, error) {
 func md5Hex(v string) string {
 	sum := md5.Sum([]byte(v))
 	return hex.EncodeToString(sum[:])
+}
+
+// allowAttempt / failAttempt / clearAttempt guard the optional limiter (nil in
+// the CLI and most tests), mirroring the nil-mailer pattern in RemindPassword.
+func (s *Service) allowAttempt(scope, key string) error {
+	if s.limiter == nil {
+		return nil
+	}
+	return s.limiter.Allow(scope, key)
+}
+
+func (s *Service) failAttempt(scope, key string) {
+	if s.limiter != nil {
+		s.limiter.Fail(scope, key)
+	}
+}
+
+func (s *Service) clearAttempt(scope, key string) {
+	if s.limiter != nil {
+		s.limiter.Clear(scope, key)
+	}
 }

--- a/internal/web/apidoc/docs/docs.go
+++ b/internal/web/apidoc/docs/docs.go
@@ -4547,6 +4547,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
                         }
                     },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4660,6 +4666,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
                         }
                     },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4724,6 +4736,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
                         }
                     },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4786,6 +4804,12 @@ const docTemplate = `{
                         "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
                         }
                     },
                     "500": {

--- a/internal/web/apidoc/docs/swagger.json
+++ b/internal/web/apidoc/docs/swagger.json
@@ -4540,6 +4540,12 @@
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
                         }
                     },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4653,6 +4659,12 @@
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
                         }
                     },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4717,6 +4729,12 @@
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
                         }
                     },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -4779,6 +4797,12 @@
                         "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
                         }
                     },
                     "500": {

--- a/internal/web/apidoc/docs/swagger.yaml
+++ b/internal/web/apidoc/docs/swagger.yaml
@@ -4142,6 +4142,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
         "500":
           description: Internal Server Error
           schema:
@@ -4211,6 +4215,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
         "500":
           description: Internal Server Error
           schema:
@@ -4250,6 +4258,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
         "500":
           description: Internal Server Error
           schema:
@@ -4290,6 +4302,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
         "500":
           description: Internal Server Error
           schema:

--- a/internal/web/httpx/envelope_test.go
+++ b/internal/web/httpx/envelope_test.go
@@ -152,12 +152,19 @@ func TestWriteError_StatusMappingMatrix(t *testing.T) {
 		err        error
 		wantStatus int
 		wantMsg    string // "" = don't assert
+		wantBody   string // "" = don't assert; exact envelope match (success/message/code/errors)
 	}{
-		{"validation", errs.NewValidation("ignored", errs.FieldError{Key: "f", Message: "bad"}), http.StatusBadRequest, "Form validation error"},
-		{"access denied", errs.NewAccessDenied("nope"), http.StatusForbidden, "nope"},
-		{"unauthorized", errs.NewUnauthorized("no token"), http.StatusUnauthorized, "no token"},
-		{"not found", errs.NewNotFound("Plan not found"), http.StatusBadRequest, "Plan not found"},
-		{"unknown", errPlain("kaboom"), http.StatusInternalServerError, "Internal Server Error"}, // raw error suppressed in prod (dev=false)
+		{"validation", errs.NewValidation("ignored", errs.FieldError{Key: "f", Message: "bad"}), http.StatusBadRequest, "Form validation error", ""},
+		{"access denied", errs.NewAccessDenied("nope"), http.StatusForbidden, "nope", ""},
+		{"unauthorized", errs.NewUnauthorized("no token"), http.StatusUnauthorized, "no token", ""},
+		{"not found", errs.NewNotFound("Plan not found"), http.StatusBadRequest, "Plan not found", ""},
+		{"unknown", errPlain("kaboom"), http.StatusInternalServerError, "Internal Server Error", ""}, // raw error suppressed in prod (dev=false)
+		{
+			name:       "too many requests -> 429 envelope",
+			err:        errs.NewTooManyRequests("Too many attempts. Try again later."),
+			wantStatus: http.StatusTooManyRequests,
+			wantBody:   `{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}` + "\n",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -174,6 +181,9 @@ func TestWriteError_StatusMappingMatrix(t *testing.T) {
 				if probe.Message != c.wantMsg {
 					t.Fatalf("message=%q want %q", probe.Message, c.wantMsg)
 				}
+			}
+			if c.wantBody != "" && rec.Body.String() != c.wantBody {
+				t.Fatalf("body=%s want %s", rec.Body.String(), c.wantBody)
 			}
 		})
 	}

--- a/internal/web/httpx/errors.go
+++ b/internal/web/httpx/errors.go
@@ -11,6 +11,7 @@ import (
 //   - *errs.ValidationError  -> 400, errors{} populated (field -> messages)
 //   - *errs.AccessDeniedError -> 403, empty errors
 //   - *errs.UnauthorizedError -> 401, empty errors
+//   - *errs.TooManyRequestsError -> 429, code 429, empty errors
 //   - *errs.NotFoundError     -> 400 (domain not-found goes through the generic
 //     error envelope; revisit per-endpoint if a test expects 404)
 //   - anything else           -> 500 exception envelope
@@ -38,6 +39,10 @@ func WriteError(w http.ResponseWriter, err error, dev bool) {
 	}
 	if v, ok := errs.AsUnauthorized(err); ok {
 		Err(w, v.Error(), 0, nil, http.StatusUnauthorized)
+		return
+	}
+	if v, ok := errs.AsTooManyRequests(err); ok {
+		Err(w, v.Error(), http.StatusTooManyRequests, nil, http.StatusTooManyRequests)
 		return
 	}
 	if v, ok := errs.AsNotFound(err); ok {

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 allowBuilds:
   '@parcel/watcher': false
+  msw: false


### PR DESCRIPTION
## Summary

Adds brute-force protection to the four public auth endpoints (`login-user`, `reset-password`, `remind-password`, `register-user`), which previously accepted unlimited attempts:

- **New in-memory limiter** `internal/infra/ratelimit` — per-key sliding-window counters (attempt keys hashed above 128 bytes to bound memory) plus a per-endpoint global backstop on its own 1-minute window; per-key rejection never consumes global budget, so an attack on one account can't starve the endpoint. Capped at 10k keys with expired-first eviction.
- **Enforcement** in the user use cases via a consumer-side `AttemptLimiter` interface (`internal/user/ports.go`), wired in `server.BuildAPI`. Login/reset count only failed attempts and clear on success; remind/register count every request (email spam / mass-creation protection). Anti-enumeration is preserved — unknown and known usernames behave identically. The CLI passes a nil limiter (trusted local ops).
- **Wire contract**: over-limit requests get HTTP 429 with the standard error envelope `{"success":false,"message":"Too many attempts. Try again later.","code":429,"errors":{}}` (new `errs.TooManyRequestsError` + `httpx` mapping; frozen in a new apiparity golden `auth_rate_limit` — all pre-existing goldens byte-identical). Swagger docs regenerated with `@Failure 429` on the four handlers.
- **Config**: `ECONUMO_RATE_LIMIT_LOGIN/RESET/REMIND/REGISTER` (defaults 5/5/3/5), `ECONUMO_RATE_LIMIT_WINDOW` (default `15m`, must be positive), `ECONUMO_RATE_LIMIT_GLOBAL` (default 60/min). `0` on a count disables that check; malformed values fail at boot (strict parsing — a typo must not silently disable protection). Documented in `.env.example` and CLAUDE.md.
- Design spec and implementation plan included under `docs/superpowers/` (accepted tradeoffs — victim-username lockout and global-backstop flooding — are recorded there).
- Ride-along: one-line `web/pnpm-workspace.yaml` build-allow decision (`msw: false`) so `make web-test` runs on fresh checkouts under pnpm 11 (own commit, no runtime effect).

## Testing

- `internal/infra/ratelimit`: 17 unit tests on a fake clock (window slide, clear, global cap and its independence from blocked keys, zero-disables, eviction/size cap, huge-key hashing, `-race` concurrency smoke)
- `internal/user/api`: 11 HTTP-level tests (429 lockout even with the correct password, anti-enumeration for unknown users, success-clears-counter incl. a full DB-code reset flow, key case/whitespace normalization, per-email register independence, nil-limiter unlimited)
- `internal/config`: defaults / overrides+disable / bad-values-fail-boot (incl. zero and negative window)
- apiparity: new 22-call `auth_rate_limit` golden scenario freezing the 429 envelope for all four endpoints; guard tests confirm no golden drift
- Full tiers green: `make go-test` (coverage 79.4%, gate 78) and `make test` (sqlite-vs-PostgreSQL enginecompare byte-identical, repo suite on PostgreSQL). Frontend: 354/355 — the one failure (ImportCsvDialog) reproduces identically on clean `main` and this branch touches no `web/` source; needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kWSZGcrPBk7BHDJrKMGp5