### PR TITLE
fix(transaction): keyboard navigation in the transaction dialog

### DIFF
--- a/web/src/components/CalculatorInput.tsx
+++ b/web/src/components/CalculatorInput.tsx
@@ -71,6 +71,9 @@ export function CalculatorInput({ value, onChange, ...inputProps }: CalculatorIn
             type="button"
             variant="secondary"
             size="sm"
+            // pointer/tap targets only: keyboard users type the operator directly,
+            // and Tab must reach the next form field, not walk the keypad
+            tabIndex={-1}
             className="flex-1 h-10"
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => pressKey(key.op)}

--- a/web/src/features/transactions/TransactionDialog.test.tsx
+++ b/web/src/features/transactions/TransactionDialog.test.tsx
@@ -61,6 +61,37 @@ it('clicking anywhere on a select card (label/padding) opens the picker', async 
   expect(await screen.findByPlaceholderText('Search or enter a new name')).toBeInTheDocument()
 })
 
+it('Tab from the amount goes to the next field, not the calculator keypad', async () => {
+  const user = userEvent.setup()
+  renderDialog()
+  useUiStore.getState().openTransactionModal({ type: 'expense' })
+  await screen.findByRole('heading', { name: 'Add transaction' })
+
+  const amount = await screen.findByLabelText('Amount')
+  amount.focus()
+  await user.tab()
+  expect(screen.getByRole('combobox', { name: 'Category' })).toHaveFocus()
+  await user.tab({ shift: true })
+  expect(amount).toHaveFocus()
+})
+
+it('tag chips are keyboard-reachable and toggle with Enter and Space', async () => {
+  const user = userEvent.setup()
+  renderDialog()
+  useUiStore.getState().openTransactionModal({ type: 'expense' })
+  await screen.findByRole('heading', { name: 'Add transaction' })
+
+  const chip = await screen.findByRole('checkbox', { name: 'vacation' })
+  screen.getByRole('combobox', { name: 'Recipient' }).focus()
+  await user.tab()
+  expect(chip).toHaveFocus()
+
+  await user.keyboard('{Enter}')
+  expect(chip).toHaveAttribute('aria-checked', 'true')
+  await user.keyboard(' ')
+  expect(chip).toHaveAttribute('aria-checked', 'false')
+})
+
 it('creates an expense with the exact payload shape', async () => {
   let body: Record<string, unknown> | undefined
   server.use(

--- a/web/src/features/transactions/TransactionDialog.tsx
+++ b/web/src/features/transactions/TransactionDialog.tsx
@@ -401,19 +401,29 @@ function TransactionForm({ params, onDone }: { params: OpenTransactionParams; on
             <CardField label={t('pages.account.preview_transaction_modal.tags.label')}>
               <div className="flex items-center gap-2">
                 <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 py-0.5">
-                  {tagRow.map((tag) => (
-                    <Badge
-                      key={tag.id}
-                      role="checkbox"
-                      aria-checked={form.tagId === tag.id}
-                      aria-label={tag.name}
-                      variant={form.tagId === tag.id ? 'default' : 'secondary'}
-                      className="cursor-pointer"
-                      onClick={() => patch({ tagId: form.tagId === tag.id ? null : tag.id })}
-                    >
-                      {tag.name}
-                    </Badge>
-                  ))}
+                  {tagRow.map((tag) => {
+                    const toggleTag = () => patch({ tagId: form.tagId === tag.id ? null : tag.id })
+                    return (
+                      <Badge
+                        key={tag.id}
+                        role="checkbox"
+                        aria-checked={form.tagId === tag.id}
+                        aria-label={tag.name}
+                        tabIndex={0}
+                        variant={form.tagId === tag.id ? 'default' : 'secondary'}
+                        className="cursor-pointer"
+                        onClick={toggleTag}
+                        onKeyDown={(e) => {
+                          if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) {
+                            e.preventDefault()
+                            toggleTag()
+                          }
+                        }}
+                      >
+                        {tag.name}
+                      </Badge>
+                    )
+                  })}
                 </div>
                 {canEditData ? (
                   <button


### PR DESCRIPTION
## What

Two keyboard-navigation fixes in the add/edit transaction dialog (desktop report, applies everywhere):

- **Calculator keypad is out of the Tab order** (`CalculatorInput`, also used by the budget limit editors). The five `+ − × ÷ =` buttons sat between the amount input and the rest of the form, so Tab from the amount landed on a low-affordance `+` button and it took six presses to reach the category. They are pointer/tap targets; keyboard users type operators directly into the input, so they now carry `tabIndex={-1}`.
- **Tag chips are keyboard-accessible.** The `role="checkbox"` badges had only an `onClick` — Tab skipped from the payee select straight to the "add tag" button. Chips now take focus (`tabIndex={0}`) and toggle on Enter/Space (Space `preventDefault`ed so the page doesn't scroll, key-repeat guarded), keeping the existing `aria-checked` semantics and the Badge focus ring.

Resulting Tab order in the expense form: amount → category → recipient → tag chips → add tag → notes → Cancel → Add, with Shift+Tab mirroring it (and reaching the account select above the amount).

## Why

Tab from the autofocused amount field appeared to jump "past" the account/category selects, making the dialog effectively mouse-only.

## Notes for review

- Two new vitest cases in `TransactionDialog.test.tsx` (Tab from amount lands on category / chips toggle via keyboard); both fail without the fix. Full `pnpm test` (382) and `pnpm lint` are green.
- Verified end-to-end in a browser against the demo DB; other `Badge` usages (`TransactionRow`, `ViewTransactionDialog`) are display-only and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)