### PR TITLE
fix(web): restore scroll position in account list and budget table

### DIFF
--- a/web/src/app/layouts/ApplicationLayout.tsx
+++ b/web/src/app/layouts/ApplicationLayout.tsx
@@ -13,6 +13,7 @@ import { UserAvatar } from '@/components/UserAvatar'
 import { econumoPackage } from '@/lib/package'
 import { formatDateTime } from '@/lib/datetime'
 import { useIsCompact } from '@/hooks/useIsCompact'
+import { useScrollMemory } from '@/hooks/useScrollMemory'
 import { useSidebarStore } from '@/app/uiStore'
 import { RouterPage } from '@/app/router-pages'
 import { SidebarAccountTree } from '@/features/accounts/SidebarAccountTree'
@@ -79,6 +80,9 @@ export function ApplicationLayout() {
   const isFetching = useIsFetching() > 0
   const lastSyncAt = useLastSyncAt()
   const { collapsed, toggleCollapsed } = useSidebarStore()
+  // compact unmounts the whole sidebar on navigation — going back must land
+  // on the same spot in the account list
+  const sidebarScrollRef = useScrollMemory('sidebar-accounts')
   // Icon-rail mode is desktop-only; compact keeps the full-width home sidebar.
   const rail = collapsed && !isCompact
 
@@ -108,7 +112,7 @@ export function ApplicationLayout() {
           {user && !isCompact ? userBlock : null}
 
           {isFullyLoaded || hasLoadedOnce.current ? (
-            <div className="flex-1 overflow-y-auto scrollbar-none">
+            <div ref={sidebarScrollRef} className="flex-1 overflow-y-auto scrollbar-none">
               {user && isCompact ? userBlock : null}
               {rail ? (
                 <div className="flex flex-col items-center gap-1 py-1">

--- a/web/src/features/budgets/BudgetPage.tsx
+++ b/web/src/features/budgets/BudgetPage.tsx
@@ -17,6 +17,7 @@ import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { PromptDialog } from '@/components/PromptDialog'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useLongPress } from '@/hooks/useLongPress'
+import { useScrollMemory } from '@/hooks/useScrollMemory'
 import { isNotEmpty, isValidBudgetFolderName } from '@/lib/validation'
 import type { BudgetElementDto } from '@/api/dto/budget'
 import { BudgetElementType } from '@/api/dto/budget'
@@ -206,6 +207,12 @@ export function BudgetPage() {
   const [transactionsTarget, setTransactionsTarget] = useState<BudgetTransactionsTarget | null>(null)
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }))
+
+  // Per budget AND period: the table remounts on route changes and month
+  // switches; only the same month of the same budget gets its spot back.
+  // Also shields against modal-induced resets (full-screen envelope form /
+  // set-limit drawer on phones).
+  const tableScrollRef = useScrollMemory(`budget:${budget?.meta.id ?? ''}:${selectedDate}`)
 
   // Every month switch surfaces the loader for a beat: cache hits (persisted
   // months, local fetches) resolve in a frame or two, which reads as "nothing
@@ -560,7 +567,7 @@ export function BudgetPage() {
         <>
           {selectedCurrencyId ? <ExpenseWidget budget={budget} currencyId={selectedCurrencyId} /> : null}
 
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div ref={tableScrollRef} className="min-h-0 flex-1 overflow-y-auto">
             <DndContext
               sensors={sensors}
               collisionDetection={preferRowCollisions}

--- a/web/src/hooks/useScrollMemory.test.tsx
+++ b/web/src/hooks/useScrollMemory.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { useScrollMemory } from './useScrollMemory'
+
+function Scroller({ memoryKey }: { memoryKey: string }) {
+  const ref = useScrollMemory(memoryKey)
+  return (
+    <div data-testid={`scroller-${memoryKey}`} ref={ref}>
+      <div style={{ height: 1000 }} />
+    </div>
+  )
+}
+
+const scrollTo = (el: HTMLElement, top: number) => {
+  el.scrollTop = top
+  el.dispatchEvent(new Event('scroll'))
+}
+
+const flushMutations = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('useScrollMemory', () => {
+  afterEach(() => {
+    cleanup()
+    document.body.removeAttribute('data-scroll-locked')
+  })
+
+  it('starts at the top when nothing was saved for the key', () => {
+    const { getByTestId } = render(<Scroller memoryKey="fresh" />)
+    expect(getByTestId('scroller-fresh').scrollTop).toBe(0)
+  })
+
+  it('restores the saved position when a container with the same key remounts', () => {
+    const first = render(<Scroller memoryKey="remount" />)
+    scrollTo(first.getByTestId('scroller-remount'), 400)
+    first.unmount()
+
+    const second = render(<Scroller memoryKey="remount" />)
+    expect(second.getByTestId('scroller-remount').scrollTop).toBe(400)
+  })
+
+  it('keeps positions of different keys independent', () => {
+    const first = render(<Scroller memoryKey="a" />)
+    scrollTo(first.getByTestId('scroller-a'), 250)
+    first.unmount()
+
+    const second = render(<Scroller memoryKey="b" />)
+    expect(second.getByTestId('scroller-b').scrollTop).toBe(0)
+  })
+
+  it('ignores scrolls while the body is scroll-locked and restores on release', async () => {
+    const { getByTestId } = render(<Scroller memoryKey="locked" />)
+    const el = getByTestId('scroller-locked')
+    scrollTo(el, 300)
+
+    // a modal opens (react-remove-scroll marks the body) and the platform
+    // resets the background scroller — that reset must not become the saved spot
+    document.body.setAttribute('data-scroll-locked', '1')
+    scrollTo(el, 0)
+
+    document.body.removeAttribute('data-scroll-locked')
+    await flushMutations()
+    expect(el.scrollTop).toBe(300)
+  })
+})

--- a/web/src/hooks/useScrollMemory.ts
+++ b/web/src/hooks/useScrollMemory.ts
@@ -1,0 +1,58 @@
+import { useCallback, useRef } from 'react'
+
+// In-memory only: positions survive route remounts within a session, and a
+// full reload deliberately starts every list at the top again.
+const positions = new Map<string, number>()
+
+// react-remove-scroll (Radix dialogs AND vaul drawers) marks the body while a
+// modal is open. Background scrollers are inert then, so any scroll they
+// receive is platform-initiated (e.g. iOS scrolling under a full-screen
+// dialog when the keyboard opens) — never the user's position.
+const isScrollLocked = () => document.body.hasAttribute('data-scroll-locked')
+
+/**
+ * Keeps a scroll container's position across unmounts (compact-layout panes
+ * unmount whole sections on navigation) and across modal-induced resets.
+ * Attach the returned callback as the container's `ref`.
+ */
+export function useScrollMemory(key: string): (el: HTMLElement | null) => void {
+  const detach = useRef<(() => void) | null>(null)
+
+  return useCallback(
+    (el: HTMLElement | null) => {
+      detach.current?.()
+      detach.current = null
+      if (!el) {
+        return
+      }
+
+      const saved = positions.get(key)
+      if (saved !== undefined) {
+        el.scrollTop = saved
+      }
+
+      const onScroll = () => {
+        if (!isScrollLocked()) {
+          positions.set(key, el.scrollTop)
+        }
+      }
+      el.addEventListener('scroll', onScroll, { passive: true })
+
+      const observer = new MutationObserver(() => {
+        if (!isScrollLocked()) {
+          const want = positions.get(key)
+          if (want !== undefined && el.scrollTop !== want) {
+            el.scrollTop = want
+          }
+        }
+      })
+      observer.observe(document.body, { attributes: true, attributeFilter: ['data-scroll-locked'] })
+
+      detach.current = () => {
+        el.removeEventListener('scroll', onScroll)
+        observer.disconnect()
+      }
+    },
+    [key],
+  )
+}


### PR DESCRIPTION
## What

Scroll positions are now kept when returning to the account list (mobile/tablet) and to the budget table.

- New `useScrollMemory` hook (`web/src/hooks/useScrollMemory.ts`): remembers a scroll container's position in memory, restores it when the container remounts, and — while any modal is open (`data-scroll-locked` on `<body>`, set by both Radix dialogs and vaul drawers) — ignores background scrolls and re-applies the saved position when the lock is released.
- Wired into the sidebar account list (`ApplicationLayout`) and the budget table (`BudgetPage`). Budget positions are keyed per budget **and** period, so switching to a new month still opens at the top while returning to a visited month restores its spot.

## Why

The window never scrolls in the app shell — panes are independent overflow containers, so neither the browser nor the router restores anything:

- **Account list:** on compact layouts the whole `<aside>` unmounts when leaving `/` and remounts at `scrollTop 0` on the way back.
- **Budget:** the table scroller is remounted on route changes, and on real phones the platform itself resets the background scroll while the full-screen envelope form / set-limit drawer is open (iOS keyboard/focus behavior under fixed overlays). The hook covers both classes.

## Notes for review

- Positions are in-memory only: a full page reload deliberately starts lists at the top again.
- Saves are suppressed while `data-scroll-locked` is present because the background is inert then — any scroll it receives is platform-initiated, not the user's position.
- TDD: the hook's four unit tests were written first; full frontend suite passes (427/427). Verified live at phone/tablet/desktop viewports against the demo DB: back-navigation from an account restores the list position; budget keeps its spot across leave/return, envelope edit with a simulated platform reset, the limit drawer, and month switches.
- The platform-reset mechanism in the budget could not be reproduced in desktop emulation (no real keyboard); if a device still jumps after this fix, the reset happens *after* the scroll-lock release and the restore needs a short deferral — please test on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)