### PR TITLE
feat(web): survive an unreachable backend — endless retry, logout escape, sync warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ coverage.out
 # shared config like .claude/settings.json would still be committed.
 .claude/settings.local.json
 .claude/worktrees/
+.claude/launch.json
 
 # design-sync machine state (staged scripts, build output, caches)
 .ds-sync/

--- a/web/src/app/layouts/ApplicationLayout.test.tsx
+++ b/web/src/app/layouts/ApplicationLayout.test.tsx
@@ -112,6 +112,60 @@ it('a reload with a persisted cache skips the boot loader and refreshes in the b
   await waitFor(() => expect(accountFetches).toBeGreaterThan(coldBootFetches))
 })
 
+it('the boot loader grows a logout escape after three seconds when the backend is unreachable', async () => {
+  mockViewport(false)
+  server.use(http.get('*/api/*', () => HttpResponse.error()))
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  try {
+    renderShell('/')
+    expect(screen.getByText('Loading your data')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Log out' })).not.toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(3000)
+    const link = await screen.findByRole('link', { name: 'Log out' })
+    expect(link).toHaveAttribute('href', '/logout')
+    // the escape floats at the bottom of the screen so its appearance never
+    // shifts the loader
+    expect(screen.getByText(/Having trouble\?/)).toBeInTheDocument()
+    expect(link.closest('div')?.className).toContain('fixed')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('no logout escape appears once the app has loaded', async () => {
+  mockViewport(false)
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  try {
+    renderShell('/')
+    expect(await screen.findByText('Cash')).toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(screen.queryByRole('link', { name: 'Log out' })).not.toBeInTheDocument()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('the sync icon turns into an amber warning while background refreshes fail, and recovers on success', async () => {
+  mockViewport(false)
+  const user = userEvent.setup()
+  renderShell('/')
+  expect(await screen.findByText('Cash')).toBeInTheDocument()
+  const syncButton = screen.getByRole('button', { name: 'sync' })
+  expect(syncButton.title).toContain('Full sync')
+  expect(syncButton.className).not.toContain('amber')
+
+  server.use(http.get('*/api/*', () => HttpResponse.error()))
+  await user.click(syncButton)
+  await waitFor(() => expect(syncButton.title).toContain("Can't reach the server"))
+  expect(syncButton.className).toContain('amber')
+
+  server.resetHandlers()
+  server.use(...coreHandlers())
+  await user.click(syncButton)
+  await waitFor(() => expect(syncButton.title).toContain('Full sync'))
+  expect(syncButton.className).not.toContain('amber')
+})
+
 it('desktop shows sidebar and workspace together', async () => {
   mockViewport(false)
   renderShell('/account/a1')

--- a/web/src/app/layouts/ApplicationLayout.tsx
+++ b/web/src/app/layouts/ApplicationLayout.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useCallback, useRef, useSyncExternalStore } from 'react'
 import { Link, Outlet, useLocation } from 'react-router'
 import { useIsFetching, useIsRestoring, useQueryClient } from '@tanstack/react-query'
 import { RefreshCw, Rocket, Settings, Wallet } from 'lucide-react'
@@ -13,9 +13,11 @@ import { UserAvatar } from '@/components/UserAvatar'
 import { econumoPackage } from '@/lib/package'
 import { formatDateTime } from '@/lib/datetime'
 import { useIsCompact } from '@/hooks/useIsCompact'
+import { useLogoutEscape } from '@/hooks/useLogoutEscape'
 import { useScrollMemory } from '@/hooks/useScrollMemory'
 import { useSidebarStore } from '@/app/uiStore'
 import { RouterPage } from '@/app/router-pages'
+import { LogoutEscapeButton } from '@/features/auth/LogoutEscapeButton'
 import { SidebarAccountTree } from '@/features/accounts/SidebarAccountTree'
 import { AccountDialog } from '@/features/accounts/AccountDialog'
 import { SwitchAccountPrompt } from '@/features/accounts/SwitchAccountPrompt'
@@ -42,6 +44,17 @@ function useIsFullyLoaded() {
     useBudgets(),
   ]
   return queries.every((q) => q.data !== undefined)
+}
+
+// A background refresh that isn't succeeding — mid-retry after failures, or
+// settled in error with stale data on screen — must be visible: the sync icon
+// becomes an amber warning until the next successful fetch clears it.
+function useSyncFailing(): boolean {
+  const cache = useQueryClient().getQueryCache()
+  return useSyncExternalStore(
+    useCallback((onChange: () => void) => cache.subscribe(onChange), [cache]),
+    () => cache.getAll().some((q) => q.state.status === 'error' || q.state.fetchFailureCount > 0),
+  )
 }
 
 // lastSyncAt = the oldest fetch among the core lists (Vue takes the min of the
@@ -75,10 +88,19 @@ export function ApplicationLayout() {
   }
   const showBootLoader = !isFullyLoaded && !hasLoadedOnce.current && !isRestoring
 
+  const showLogoutEscape = useLogoutEscape(showBootLoader)
+
   const showSidebar = !isCompact || location.pathname === '/'
   const showWorkspace = !isCompact || location.pathname !== '/'
   const isFetching = useIsFetching() > 0
   const lastSyncAt = useLastSyncAt()
+  const syncFailing = useSyncFailing()
+  const syncTitle = `${t(syncFailing ? 'pages.settings.sync.failing' : 'pages.settings.sync.menu_item')} — ${lastSyncAt}`
+  // constant geometry (-m/p cancel out) so the amber circle appears without
+  // nudging the icon
+  const syncClass = `-m-1.5 rounded-full p-1.5 ${
+    syncFailing ? 'bg-amber-500/15 text-amber-600 hover:text-amber-700' : 'text-muted-foreground hover:text-foreground'
+  }`
   const { collapsed, toggleCollapsed } = useSidebarStore()
   // compact unmounts the whole sidebar on navigation — going back must land
   // on the same spot in the account list
@@ -164,8 +186,8 @@ export function ApplicationLayout() {
               <button
                 type="button"
                 aria-label="sync"
-                title={`${t('pages.settings.sync.menu_item')} — ${lastSyncAt}`}
-                className="text-muted-foreground hover:text-foreground"
+                title={syncTitle}
+                className={syncClass}
                 onClick={() => void queryClient.invalidateQueries()}
               >
                 <RefreshCw className={`size-5 ${isFetching ? 'animate-spin' : ''}`} />
@@ -185,8 +207,8 @@ export function ApplicationLayout() {
               <button
                 type="button"
                 aria-label="sync"
-                title={`${t('pages.settings.sync.menu_item')} — ${lastSyncAt}`}
-                className="text-muted-foreground hover:text-foreground"
+                title={syncTitle}
+                className={syncClass}
                 onClick={() => void queryClient.invalidateQueries()}
               >
                 <RefreshCw className={`size-6 ${isFetching ? 'animate-spin' : ''}`} />
@@ -217,6 +239,7 @@ export function ApplicationLayout() {
       <TransactionDialog />
       <SwitchAccountPrompt />
       <LoadingDialog open={showBootLoader} label={t('modules.app.modal.loading.data_loading')} />
+      {showLogoutEscape ? <LogoutEscapeButton /> : null}
     </div>
   )
 }

--- a/web/src/features/auth/LogoutEscapeButton.tsx
+++ b/web/src/features/auth/LogoutEscapeButton.tsx
@@ -1,0 +1,42 @@
+import { createPortal } from 'react-dom'
+import { Link } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { RouterPage } from '@/app/router-pages'
+
+// Floats over the loader it escapes from so its appearance never shifts
+// layout.
+//
+// placement="screen" (default) portals to <body>, pinned to the viewport
+// bottom — for modal loaders. It must stay OUTSIDE dialog content (the
+// centered card is CSS-transformed, which would re-anchor position:fixed to
+// the card) and outside the layout tree (an open modal aria-hides layout
+// siblings and swallows their clicks via body pointer-events:none); mounting
+// after the dialog's hide pass with own pointer-events keeps it usable.
+//
+// placement="container" anchors to the nearest positioned ancestor — for
+// in-page loaders that are centered in a sub-area (e.g. the workspace next
+// to the sidebar), so the caption stays on the spinner's own axis.
+export function LogoutEscapeButton({ placement = 'screen' }: { placement?: 'screen' | 'container' }) {
+  const { t } = useTranslation()
+  const caption = (
+    <span className="text-xs text-muted-foreground">
+      {t('elements.loader.having_trouble')}{' '}
+      <Link to={RouterPage.LOGOUT} className="underline underline-offset-2 hover:text-foreground">
+        {t('pages.settings.settings.logout')}
+      </Link>
+    </span>
+  )
+  if (placement === 'container') {
+    return (
+      <div className="absolute inset-x-0 bottom-[max(env(safe-area-inset-bottom),1rem)] flex justify-center animate-in fade-in duration-500">
+        {caption}
+      </div>
+    )
+  }
+  return createPortal(
+    <div className="pointer-events-auto fixed inset-x-0 bottom-[max(env(safe-area-inset-bottom),1rem)] z-[60] flex justify-center animate-in fade-in duration-500">
+      {caption}
+    </div>,
+    document.body,
+  )
+}

--- a/web/src/features/budgets/BudgetPage.test.tsx
+++ b/web/src/features/budgets/BudgetPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createMemoryRouter, RouterProvider } from 'react-router'
-import { http, HttpResponse } from 'msw'
+import { delay, http, HttpResponse } from 'msw'
 import { server } from '@/test/msw'
 import { coreHandlers, fixtureUser, fixtureWireBudget } from '@/test/fixtures'
 import { BudgetPage } from './BudgetPage'
@@ -60,6 +60,32 @@ it('renders the full budget page: strip, chips, table, totals', async () => {
   expect(screen.getByRole('button', { name: 'currency EUR' })).toBeInTheDocument()
   // widget hidden until a chip is selected
   expect(screen.queryByTestId('expense-widget')).not.toBeInTheDocument()
+})
+
+it('the cold-load spinner grows a logout escape after three seconds when the backend never answers', async () => {
+  server.use(
+    ...coreHandlers({ user: userWithBudget }),
+    http.get('*/api/v1/budget/get-budget', async () => {
+      await delay('infinite')
+      return HttpResponse.error()
+    }),
+  )
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  try {
+    renderPage()
+    expect(await screen.findByTestId('budget-loading')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Log out' })).not.toBeInTheDocument()
+    await vi.advanceTimersByTimeAsync(3000)
+    const link = await screen.findByRole('link', { name: 'Log out' })
+    expect(link).toHaveAttribute('href', '/logout')
+    expect(screen.getByText(/Having trouble\?/)).toBeInTheDocument()
+    // anchored inside the loader area (not the viewport) so it centers under
+    // the spinner next to the sidebar, without shifting layout
+    expect(link.closest('div')?.className).toContain('absolute')
+    expect(screen.getByTestId('budget-loading').className).toContain('relative')
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 it('toggling a currency chip mounts the expense widget', async () => {

--- a/web/src/features/budgets/BudgetPage.tsx
+++ b/web/src/features/budgets/BudgetPage.tsx
@@ -14,8 +14,10 @@ import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
+import { LogoutEscapeButton } from '@/features/auth/LogoutEscapeButton'
 import { PromptDialog } from '@/components/PromptDialog'
 import { useIsCompact } from '@/hooks/useIsCompact'
+import { useLogoutEscape } from '@/hooks/useLogoutEscape'
 import { useLongPress } from '@/hooks/useLongPress'
 import { useScrollMemory } from '@/hooks/useScrollMemory'
 import { isNotEmpty, isValidBudgetFolderName } from '@/lib/validation'
@@ -175,6 +177,7 @@ export function BudgetPage() {
   // user record loads); month switches show the previous period as placeholder
   // data (isPlaceholderData) while the new one loads
   const { data: budget, isPending, isPlaceholderData, isFetching } = useBudget()
+  const showLogoutEscape = useLogoutEscape(isPending)
   const { data: currencies = [] } = useCurrencies()
   const { data: accounts = [] } = useAccounts()
   const { data: categories = [] } = useCategories()
@@ -319,8 +322,9 @@ export function BudgetPage() {
   if (!budget || !buckets) {
     // cold load only — month switches keep the previous period via keepPreviousData
     return isPending ? (
-      <div className="flex h-full items-center justify-center" data-testid="budget-loading">
+      <div className="relative flex h-full items-center justify-center" data-testid="budget-loading">
         <CoinLoader label={t('modules.app.modal.loading.data_loading')} />
+        {showLogoutEscape ? <LogoutEscapeButton placement="container" /> : null}
       </div>
     ) : null
   }

--- a/web/src/hooks/useLogoutEscape.ts
+++ b/web/src/hooks/useLogoutEscape.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+const LOGOUT_ESCAPE_DELAY_MS = 3000
+
+// An unreachable backend keeps blocking loaders up forever (queries retry
+// endlessly) — once a loader has been visible for a few seconds, surface a
+// logout escape hatch so the user isn't trapped behind it.
+export function useLogoutEscape(loading: boolean): boolean {
+  const [escape, setEscape] = useState(false)
+  useEffect(() => {
+    if (!loading) {
+      setEscape(false)
+      return
+    }
+    const id = setTimeout(() => setEscape(true), LOGOUT_ESCAPE_DELAY_MS)
+    return () => clearTimeout(id)
+  }, [loading])
+  return escape
+}

--- a/web/src/lib/queryPersist.test.ts
+++ b/web/src/lib/queryPersist.test.ts
@@ -1,0 +1,33 @@
+import { AxiosError, type AxiosResponse } from 'axios'
+import { createAppQueryClient } from './queryPersist'
+
+function defaultRetry(): (failureCount: number, error: unknown) => boolean {
+  const retry = createAppQueryClient().getDefaultOptions().queries?.retry
+  if (typeof retry !== 'function') {
+    throw new Error('expected the default query retry to be a function')
+  }
+  return retry as (failureCount: number, error: unknown) => boolean
+}
+
+it('retries without limit while the backend is unreachable (network error, no response)', () => {
+  const retry = defaultRetry()
+  const networkError = new AxiosError('Network Error', 'ERR_NETWORK')
+  expect(retry(1, networkError)).toBe(true)
+  expect(retry(50, networkError)).toBe(true)
+})
+
+it('keeps the three-attempt default for HTTP errors', () => {
+  const retry = defaultRetry()
+  const httpError = new AxiosError('Server Error', 'ERR_BAD_RESPONSE', undefined, undefined, {
+    status: 500,
+  } as AxiosResponse)
+  expect(retry(2, httpError)).toBe(true)
+  expect(retry(3, httpError)).toBe(false)
+})
+
+it('keeps the three-attempt default for non-axios errors', () => {
+  const retry = defaultRetry()
+  const plainError = new Error('boom')
+  expect(retry(2, plainError)).toBe(true)
+  expect(retry(3, plainError)).toBe(false)
+})

--- a/web/src/lib/queryPersist.ts
+++ b/web/src/lib/queryPersist.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { QueryClient } from '@tanstack/react-query'
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
 import { getVersion } from './config'
@@ -9,12 +10,22 @@ export const QUERY_CACHE_KEY = 'econumo.query-cache'
 
 const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
 
+// An unreachable backend (network error — no HTTP response) retries forever
+// with capped backoff, so the boot loader recovers by itself once the backend
+// is back. HTTP errors keep the default three attempts.
+function retryPolicy(failureCount: number, error: unknown): boolean {
+  if (axios.isAxiosError(error) && !error.response) {
+    return true
+  }
+  return failureCount < 3
+}
+
 export function createAppQueryClient() {
   return new QueryClient({
     defaultOptions: {
       // gcTime must outlive maxAge, or queries get garbage-collected out of
       // the persisted snapshot before it expires.
-      queries: { gcTime: CACHE_MAX_AGE_MS },
+      queries: { gcTime: CACHE_MAX_AGE_MS, retry: retryPolicy },
     },
   })
 }

--- a/web/src/locales/en-US.ts
+++ b/web/src/locales/en-US.ts
@@ -21,7 +21,7 @@ export default {
   // elements
   'elements': {
     'econumo': { 'label': 'Econumo' },
-    'loader': { 'label': 'loading' },
+    'loader': { 'label': 'loading', 'having_trouble': 'Having trouble?' },
     'select': {
       'search_placeholder': 'Search',
       'create_placeholder': 'Search or enter a new name',
@@ -153,7 +153,7 @@ export default {
           'preferences': 'Preferences'
         }
       },
-      'sync': { 'menu_item': 'Full sync' },
+      'sync': { 'menu_item': 'Full sync', 'failing': 'Can\'t reach the server — retrying' },
       'accounts': {
         'menu_item': 'Accounts',
         'header': 'Accounts',


### PR DESCRIPTION
## What

Three UX improvements for when the backend is unavailable:

1. **Endless retry on network errors** (`web/src/lib/queryPersist.ts`) — queries that fail without an HTTP response now retry forever with TanStack's capped exponential backoff, so blocking loaders recover by themselves the moment the backend returns. HTTP errors (4xx/5xx) keep the default three attempts.

2. **Logout escape on blocking loaders** — after ~3 seconds of the boot loader or the budget page's cold-load spinner, a subtle "Having trouble? Log out" caption fades in at the bottom of the screen (`useLogoutEscape` + `LogoutEscapeButton`). `/logout` clears the token and cache best-effort, so it works even fully offline.

3. **Sync-failure indicator** — while any background refresh is failing (mid-retry, or settled in error with stale data on screen), the sidebar sync icon turns amber on a soft amber circle with a "Can't reach the server — retrying" tooltip; the first successful fetch clears it. The icon geometry doesn't shift when the state flips.

## Why

With the backend down the SPA used to dead-end: boot queries gave up after three retries, leaving the non-dismissible boot loader up forever with no recovery and no way out (the budget page's own cold loader had the same trap), and failing background refreshes looked identical to healthy syncs.

## Reviewer notes

- The escape caption is **portaled to `<body>`**, not rendered in the dialog: the centered dialog card is CSS-transformed (re-anchors `position:fixed` to the card), and as a layout sibling an open modal aria-hides it and swallows its clicks via body `pointer-events:none`. The full test suite caught the latter.
- On the budget page the caption uses `placement="container"` so it centers on the workspace axis (next to the sidebar), not the viewport.
- Behind a reverse proxy a down backend usually surfaces as 502/504 HTTP responses, which keep the three-attempt limit — the loader still stays and the escape appears, but auto-recovery then relies on tab-refocus refetch. Extending forever-retry to gateway errors is a deliberate non-goal here; easy follow-up if wanted.
- All three features were TDD'd and verified live in a browser against a real backend that was killed and restarted mid-session (loader → escape → auto-recovery, amber icon → recovery, escape click through the open modal).
- Also gitignores `.claude/launch.json` alongside the other Claude local state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)