### PR TITLE
feat(web): add version and API link footer to settings page

### DIFF
--- a/web/src/features/settings/SettingsPage.test.tsx
+++ b/web/src/features/settings/SettingsPage.test.tsx
@@ -64,6 +64,27 @@ it('renders the menu rows with exact labels and navigates', async () => {
 })
 
 
+it('shows a plain version label for non-release builds', async () => {
+  window.econumoConfig = { VERSION: 'dev' }
+  renderPage()
+  const label = await screen.findByText('Econumo dev')
+  expect(label.tagName).toBe('SPAN')
+})
+
+it('links a semver version to its release notes page', async () => {
+  window.econumoConfig = { VERSION: 'v1.2.3' }
+  renderPage()
+  const label = await screen.findByText('Econumo v1.2.3')
+  expect(label).toHaveAttribute('href', 'https://econumo.com/releases/v1.2.3/')
+})
+
+it('links to the API docs', async () => {
+  window.econumoConfig = { API_URL: 'https://api.example.test' }
+  renderPage()
+  const link = await screen.findByRole('link', { name: 'API' })
+  expect(link).toHaveAttribute('href', 'https://api.example.test/api/doc')
+})
+
 it('Import CSV and Export CSV rows open their dialogs', async () => {
   server.use(...coreHandlers())
   const user = userEvent.setup()

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router'
 import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { UserAvatar } from '@/components/UserAvatar'
-import { getLocaleOptions } from '@/lib/config'
+import { getLocaleOptions, getVersion, backendHost } from '@/lib/config'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useNavigate } from 'react-router'
 import { RouterPage } from '@/app/router-pages'
@@ -103,6 +103,19 @@ export function SettingsPage() {
           ) : null}
         </div>
       </div>
+
+      <footer className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground/60">
+        <span>Econumo {getVersion()}</span>
+        <span aria-hidden="true">·</span>
+        <a
+          href={`${backendHost()}/api/doc`}
+          target="_blank"
+          rel="noreferrer"
+          className="transition-colors hover:text-muted-foreground"
+        >
+          {t('pages.settings.settings.footer.api')}
+        </a>
+      </footer>
 
       <ExportCsvDialog open={exportOpen} onClose={() => setExportOpen(false)} />
       <ImportCsvDialog open={importOpen} onClose={() => setImportOpen(false)} onComplete={setImportResult} />

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router'
 import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { UserAvatar } from '@/components/UserAvatar'
-import { getLocaleOptions, getVersion, backendHost } from '@/lib/config'
+import { getLocaleOptions, getVersion, backendHost, getWebsiteUrl } from '@/lib/config'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useNavigate } from 'react-router'
 import { RouterPage } from '@/app/router-pages'
@@ -14,6 +14,10 @@ import { ExportCsvDialog } from '@/features/transactions/ExportCsvDialog'
 import { ImportCsvDialog } from '@/features/transactions/ImportCsvDialog'
 import { ImportResultDialog } from '@/features/transactions/ImportResultDialog'
 import type { AggregatedImportResult } from '@/features/transactions/importCsv'
+
+// A tagged release (e.g. "v1.2.3") links to its notes; anything else ("dev",
+// a commit sha) has no release page, so it stays plain text.
+const SEMVER = /^v\d+\.\d+\.\d+$/
 
 function MenuGroup({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -50,6 +54,7 @@ export function SettingsPage() {
   const [exportOpen, setExportOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [importResult, setImportResult] = useState<AggregatedImportResult | null>(null)
+  const version = getVersion()
 
   return (
     <div className="flex h-full flex-col gap-3 p-4">
@@ -105,7 +110,18 @@ export function SettingsPage() {
       </div>
 
       <footer className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground/60">
-        <span>Econumo {getVersion()}</span>
+        {SEMVER.test(version) ? (
+          <a
+            href={`${getWebsiteUrl()}/releases/${version}/`}
+            target="_blank"
+            rel="noreferrer"
+            className="transition-colors hover:text-muted-foreground"
+          >
+            Econumo {version}
+          </a>
+        ) : (
+          <span>Econumo {version}</span>
+        )}
         <span aria-hidden="true">·</span>
         <a
           href={`${backendHost()}/api/doc`}
@@ -116,6 +132,7 @@ export function SettingsPage() {
           {t('pages.settings.settings.footer.api')}
         </a>
       </footer>
+
 
       <ExportCsvDialog open={exportOpen} onClose={() => setExportOpen(false)} />
       <ImportCsvDialog open={importOpen} onClose={() => setImportOpen(false)} onComplete={setImportResult} />

--- a/web/src/locales/en-US.ts
+++ b/web/src/locales/en-US.ts
@@ -151,7 +151,8 @@ export default {
           'classification': 'Classification',
           'data': 'Data',
           'preferences': 'Preferences'
-        }
+        },
+        'footer': { 'api': 'API' }
       },
       'sync': { 'menu_item': 'Full sync', 'failing': 'Can\'t reach the server — retrying' },
       'accounts': {


### PR DESCRIPTION
Show the Econumo version and a subtle link to the API docs, centered
at the bottom of the settings hub.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wzzw8JPfjyht1a2hYMKAiF