### PR TITLE
fix(budget): set-limit fails with "BudgetElement not found" for tags/categories created after the budget

### DIFF
--- a/internal/budget/accounts.go
+++ b/internal/budget/accounts.go
@@ -86,7 +86,7 @@ func (s *Service) ChangeElementCurrency(ctx context.Context, userID vo.Id, req m
 	now := s.clock.Now()
 	err = s.tx.WithTx(ctx, func(txCtx context.Context) error {
 		// elementId on the wire is the element's EXTERNAL id (category/tag/envelope).
-		el, gerr := s.elements.GetElementByExternal(txCtx, budgetID, elementID)
+		el, gerr := s.getElementSelfHeal(txCtx, budgetID, elementID, now)
 		if gerr != nil {
 			return gerr
 		}
@@ -127,15 +127,15 @@ func (s *Service) SetLimit(ctx context.Context, userID vo.Id, req model.SetLimit
 		return nil, model.ValidateBlank(map[string]string{"period": ""}) // invalid-date guard
 	}
 
-	// elementId on the wire is the EXTERNAL id; resolve to the budget element.
-	element, err := s.elements.GetElementByExternal(ctx, budgetID, externalID)
-	if err != nil {
-		return nil, err
-	}
-	elementID := element.ID
-
 	now := s.clock.Now()
 	err = s.tx.WithTx(ctx, func(txCtx context.Context) error {
+		// elementId on the wire is the EXTERNAL id; resolve to the budget element.
+		element, gerr := s.getElementSelfHeal(txCtx, budgetID, externalID, now)
+		if gerr != nil {
+			return gerr
+		}
+		elementID := element.ID
+
 		existing, gerr := s.limits.GetLimit(txCtx, elementID, period)
 		hasExisting := gerr == nil
 		if gerr != nil {
@@ -162,4 +162,24 @@ func (s *Service) SetLimit(ctx context.Context, userID vo.Id, req model.SetLimit
 		return nil, err
 	}
 	return &model.SetLimitResult{}, nil
+}
+
+// getElementSelfHeal resolves a wire (external) element id to its budget
+// element, backfilling a missing budget_elements row. Rows are seeded at
+// create-budget and maintained by restoreElementsOrder, which runs only on
+// structure mutations — so a tag/category created after the budget has no row
+// yet, even though get-budget already shows it (visibility is computed from
+// spending/limits, not element rows). On a miss, restore the element order
+// (which creates rows for every participant entity) and retry once; an id that
+// is no participant entity at all still resolves to "BudgetElement not found".
+func (s *Service) getElementSelfHeal(ctx context.Context, budgetID, externalID vo.Id, now time.Time) (*model.BudgetElement, error) {
+	el, err := s.elements.GetElementByExternal(ctx, budgetID, externalID)
+	var nf *errs.NotFoundError
+	if err == nil || !errors.As(err, &nf) {
+		return el, err
+	}
+	if rerr := s.restoreElementsOrder(ctx, budgetID, now); rerr != nil {
+		return nil, rerr
+	}
+	return s.elements.GetElementByExternal(ctx, budgetID, externalID)
 }

--- a/internal/budget/api/element_selfheal_test.go
+++ b/internal/budget/api/element_selfheal_test.go
@@ -1,0 +1,104 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/econumo/econumo/internal/test/dbtest"
+	"github.com/econumo/econumo/internal/test/fixture"
+)
+
+// TestSetLimit_TagCreatedAfterBudget is the regression for a reported production
+// bug: budget_elements rows are seeded at create-budget and backfilled by
+// restoreElementsOrder (move / envelope mutations) only, so a tag created AFTER
+// the budget had no element row and set-limit failed with "BudgetElement not
+// found" — even though get-budget happily shows such a tag (its visibility is
+// computed from spending/limits, not from the element row). set-limit must
+// self-heal the missing row instead.
+func TestSetLimit_TagCreatedAfterBudget(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok, createBudgetReq(budgetID1, "Later Tag Budget"))
+
+	// A tag created after the budget: no budget_elements row exists for it.
+	const laterTagID = "dddd2222-0000-7000-8000-000000000002"
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	f.Tag(fixture.Tag{ID: laterTagID, UserID: seedUserID, Name: "Later Tag"})
+
+	st, env := h.do(t, http.MethodPost, "/api/v1/budget/set-limit", tok, map[string]any{
+		"budgetId": budgetID1, "elementId": laterTagID, "period": "2099-01-01", "amount": "184.18",
+	})
+	if st != http.StatusOK {
+		t.Fatalf("set-limit on a tag created after the budget = %d, want 200; body=%s", st, env.raw)
+	}
+
+	// The limit must round-trip into get-budget.
+	status, b := h.do(t, http.MethodGet, "/api/v1/budget/get-budget?id="+budgetID1+"&date=2099-01-15", tok, nil)
+	if status != http.StatusOK {
+		t.Fatalf("get-budget=%d body=%s", status, b.raw)
+	}
+	budgeted, _, ok := mustUnmarshal[tagBudgetView](t, b.Data).findElement(laterTagID)
+	if !ok {
+		t.Fatalf("tag with a fresh limit must be visible in get-budget; body: %s", b.Data)
+	}
+	if budgeted != "184.18" {
+		t.Errorf("tag budgeted=%q want 184.18", budgeted)
+	}
+}
+
+// TestSetLimit_CategoryCreatedAfterBudget: same self-heal for a category created
+// after the budget.
+func TestSetLimit_CategoryCreatedAfterBudget(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok, createBudgetReq(budgetID1, "Later Cat Budget"))
+
+	const laterCatID = "cccc2222-0000-7000-8000-000000000002"
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	f.Category(fixture.Category{ID: laterCatID, UserID: seedUserID, Name: "Later Cat", Type: 0, Icon: "local_offer"})
+
+	st, env := h.do(t, http.MethodPost, "/api/v1/budget/set-limit", tok, map[string]any{
+		"budgetId": budgetID1, "elementId": laterCatID, "period": "2099-01-01", "amount": "50",
+	})
+	if st != http.StatusOK {
+		t.Fatalf("set-limit on a category created after the budget = %d, want 200; body=%s", st, env.raw)
+	}
+}
+
+// TestChangeElementCurrency_TagCreatedAfterBudget: change-element-currency
+// resolves elements the same way and must self-heal too.
+func TestChangeElementCurrency_TagCreatedAfterBudget(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok, createBudgetReq(budgetID1, "Later Tag Currency Budget"))
+
+	const laterTagID = "dddd2222-0000-7000-8000-000000000003"
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	f.Tag(fixture.Tag{ID: laterTagID, UserID: seedUserID, Name: "Later Tag"})
+
+	st, env := h.do(t, http.MethodPost, "/api/v1/budget/change-element-currency", tok, map[string]any{
+		"budgetId": budgetID1, "elementId": laterTagID, "currencyId": usdID,
+	})
+	if st != http.StatusOK {
+		t.Fatalf("change-element-currency on a tag created after the budget = %d, want 200; body=%s", st, env.raw)
+	}
+}
+
+// TestSetLimit_UnknownElement_StillNotFound guards the frozen error contract:
+// the self-heal must not turn a genuinely unknown element id into anything other
+// than the "BudgetElement not found" 400.
+func TestSetLimit_UnknownElement_StillNotFound(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok, createBudgetReq(budgetID1, "Unknown Element Budget"))
+
+	st, env := h.do(t, http.MethodPost, "/api/v1/budget/set-limit", tok, map[string]any{
+		"budgetId": budgetID1, "elementId": "9999aaaa-0000-7000-8000-00000000dead", "period": "2099-01-01", "amount": "10",
+	})
+	if st != http.StatusBadRequest {
+		t.Fatalf("set-limit on an unknown element = %d, want 400; body=%s", st, env.raw)
+	}
+	if env.Message != "BudgetElement not found" {
+		t.Errorf("message=%q want %q", env.Message, "BudgetElement not found")
+	}
+}


### PR DESCRIPTION
## Problem

Setting a limit on a tag (or category) that was created *after* the budget fails with the 400 envelope `"BudgetElement not found"` — reproduced in production on a shared budget, but it fails for the budget owner too.

`budget_elements` rows are created in only two places in the Go backend:

1. `create-budget` seeds rows for the creator's categories/tags that exist at that moment, and
2. `restoreElementsOrder` backfills missing participant rows — but it only runs as the last step of `move-element-list` and envelope create/update/delete.

The old PHP backend created rows eagerly on tag/category creation (`BudgetElementService::createTagElements`) and on accepting budget access; the Go rewrite did not port those hooks. Meanwhile `get-budget` computes tag/category visibility from spending/limits alone (no element row needed), so the UI happily offers "set limit" on an element whose row doesn't exist, and the write then 400s. `change-element-currency` has the same failure mode.

## Fix

Resolve wire element ids in `SetLimit` / `ChangeElementCurrency` through a self-healing lookup (`getElementSelfHeal`): on a miss, run `restoreElementsOrder` — the same backfill the move/envelope paths already rely on — and retry the lookup once. This keeps `budget_elements` a self-healing cache instead of reintroducing cross-feature eager hooks (tag → budget) that the dependency rule forbids.

- `SetLimit`'s element resolution moves inside its existing transaction, so the backfill and the limit write commit atomically.
- A genuinely unknown element id rolls the backfill back and still returns the frozen `"BudgetElement not found"` envelope.

## Tests

New `internal/budget/api/element_selfheal_test.go` (written test-first; the primary test reproduced the exact production 400 before the fix):

- set-limit on a tag created after the budget succeeds and round-trips into `get-budget` `budgeted`
- same for a category created after the budget
- same for `change-element-currency`
- an unknown element id still returns the exact `"BudgetElement not found"` message (frozen contract guard)

`make go-test` passes clean: all apiparity goldens byte-identical, coverage 79.6% (gate 78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbtqrcdNnDw3xXiNeq5QAA