### PR TITLE
fix(transaction): make category/payee pickers keyboard-reachable in Safari

### DIFF
--- a/web/src/components/ResponsiveDialog.tsx
+++ b/web/src/components/ResponsiveDialog.tsx
@@ -44,6 +44,14 @@ export function ResponsiveDialog({ open, onOpenChange, title, description, child
   // the home indicator itself; a pinned footer carries its own inset instead
   const bodyClass = `flex-1 overflow-y-auto px-4 pt-1 ${footer ? 'pb-4' : 'pb-[max(env(safe-area-inset-bottom),1rem)]'}`
 
+  // An open combobox popup (Base UI, not a Radix layer, so Radix's document-
+  // capture Escape handler doesn't know about it) owns Escape: it closes the
+  // picker, and the dialog must stay put
+  const onEscapeKeyDown = (e: KeyboardEvent) => {
+    if (document.querySelector('[data-slot="combobox-content"]')) {
+      e.preventDefault()
+    }
+  }
   // An interaction that BEGAN inside a dialog stacked on top of this one must
   // never dismiss this one. Radix defers its outside-check to the click phase,
   // by which time the upper dialog may have closed and unmounted — a detached
@@ -79,6 +87,7 @@ export function ResponsiveDialog({ open, onOpenChange, title, description, child
           ref={contentRef}
           className="top-0 left-0 flex h-dvh max-h-dvh w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none p-0 ring-0 data-open:zoom-in-100 data-closed:zoom-out-100 [&_[data-slot=dialog-close]]:top-[max(env(safe-area-inset-top),0.5rem)]"
           onInteractOutside={onInteractOutside}
+          onEscapeKeyDown={onEscapeKeyDown}
           showCloseButton={showCloseButton}
         >
           {/* the full-viewport page sits under the status bar — keep the header (and the corner X above) clear of it */}
@@ -98,7 +107,7 @@ export function ResponsiveDialog({ open, onOpenChange, title, description, child
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={onOpenChange} dismissible={dismissible}>
-        <DrawerContent ref={contentRef} onInteractOutside={onInteractOutside}>
+        <DrawerContent ref={contentRef} onInteractOutside={onInteractOutside} onEscapeKeyDown={onEscapeKeyDown}>
           {/* the drawer has no corner X, so it never needs the pr-8 clearance */}
           <DrawerHeader className={hideHeader ? 'sr-only' : undefined}>
             <DrawerTitle className={titleClass}>{title}</DrawerTitle>
@@ -118,6 +127,7 @@ export function ResponsiveDialog({ open, onOpenChange, title, description, child
       <DialogContent
         ref={contentRef}
         onInteractOutside={onInteractOutside}
+        onEscapeKeyDown={onEscapeKeyDown}
         // a floating X with no header row to anchor it looks stray — unless asked for
         showCloseButton={showCloseButton}
       >

--- a/web/src/components/ui/combobox.tsx
+++ b/web/src/components/ui/combobox.tsx
@@ -91,14 +91,16 @@ function ComboboxContent({
   align = "start",
   alignOffset = 0,
   anchor,
+  container,
   ...props
 }: ComboboxPrimitive.Popup.Props &
   Pick<
     ComboboxPrimitive.Positioner.Props,
     "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
-  >) {
+  > &
+  Pick<ComboboxPrimitive.Portal.Props, "container">) {
   return (
-    <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Portal container={container}>
       <ComboboxPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/web/src/features/transactions/EntitySelect.test.tsx
+++ b/web/src/features/transactions/EntitySelect.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EntitySelect } from './EntitySelect'
+
+const OPTIONS = [
+  { value: 'c1', label: 'Food', icon: 'restaurant' },
+  { value: 'c2', label: 'Fuel' },
+  { value: 'c3', label: 'Rent' },
+]
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  }))
+})
+
+const combobox = () => screen.getByRole('combobox', { name: 'Category' })
+
+// macOS Safari's plain Tab only reaches text fields — a <button> picker is
+// unreachable there, so the trigger must be a real <input>.
+it('renders the picker as a text input so Tab reaches it in every browser', () => {
+  render(<EntitySelect aria-label="Category" value={null} onChange={() => {}} options={OPTIONS} />)
+  expect(combobox().tagName).toBe('INPUT')
+})
+
+it('shows the selected option label in the field', () => {
+  render(<EntitySelect aria-label="Category" value="c1" onChange={() => {}} options={OPTIONS} />)
+  expect(combobox()).toHaveValue('Food')
+})
+
+it('typing filters the options and Enter picks the highlighted one', async () => {
+  const user = userEvent.setup()
+  const onChange = vi.fn()
+  render(<EntitySelect aria-label="Category" value={null} onChange={onChange} options={OPTIONS} />)
+
+  await user.click(combobox())
+  await user.keyboard('fue')
+  expect(await screen.findByRole('option', { name: 'Fuel' })).toBeInTheDocument()
+  expect(screen.queryByRole('option', { name: 'Food' })).not.toBeInTheDocument()
+
+  await user.keyboard('{Enter}')
+  expect(onChange).toHaveBeenCalledWith('c2')
+})
+
+it('clicking an option selects it', async () => {
+  const user = userEvent.setup()
+  const onChange = vi.fn()
+  render(<EntitySelect aria-label="Category" value={null} onChange={onChange} options={OPTIONS} />)
+
+  await user.click(combobox())
+  await user.click(await screen.findByRole('option', { name: 'Rent' }))
+  expect(onChange).toHaveBeenCalledWith('c3')
+})
+
+it('Escape abandons the search and restores the selected label', async () => {
+  const user = userEvent.setup()
+  const onChange = vi.fn()
+  render(<EntitySelect aria-label="Category" value="c1" onChange={onChange} options={OPTIONS} />)
+
+  await user.click(combobox())
+  await user.keyboard('xyz')
+  await user.keyboard('{Escape}')
+  expect(combobox()).toHaveValue('Food')
+  expect(onChange).not.toHaveBeenCalled()
+})
+
+it('offers create-on-the-fly when the text matches nothing and passes validation', async () => {
+  const user = userEvent.setup()
+  const onCreate = vi.fn()
+  render(
+    <EntitySelect
+      aria-label="Category"
+      value={null}
+      onChange={() => {}}
+      options={OPTIONS}
+      onCreate={onCreate}
+      createValidator={(name) => name.length >= 3}
+    />,
+  )
+
+  await user.click(combobox())
+  await user.keyboard('Te')
+  expect(screen.queryByRole('option', { name: /Add/ })).not.toBeInTheDocument()
+
+  await user.keyboard('a')
+  expect(await screen.findByRole('option', { name: /Add.*Tea/ })).toBeInTheDocument()
+
+  await user.keyboard('{Enter}')
+  expect(onCreate).toHaveBeenCalledWith('Tea')
+})
+
+it('clearable shows a — row that clears the selection', async () => {
+  const user = userEvent.setup()
+  const onChange = vi.fn()
+  render(<EntitySelect aria-label="Category" value="c1" onChange={onChange} options={OPTIONS} clearable />)
+
+  await user.click(combobox())
+  await user.click(await screen.findByRole('option', { name: '—' }))
+  expect(onChange).toHaveBeenCalledWith(null)
+})

--- a/web/src/features/transactions/EntitySelect.tsx
+++ b/web/src/features/transactions/EntitySelect.tsx
@@ -1,16 +1,19 @@
 import { useRef, useState } from 'react'
 import { ChevronsUpDown, Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Button } from '@/components/ui/button'
-import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Combobox as ComboboxPrimitive } from '@base-ui/react'
+import { Combobox, ComboboxContent, ComboboxItem, ComboboxList } from '@/components/ui/combobox'
 import { EntityIcon } from '@/components/EntityIcon'
-import { useIsMobile } from '@/hooks/useIsMobile'
 
 export interface EntityOption {
   value: string
   label: string
   icon?: string
+}
+
+interface Row extends EntityOption {
+  create?: boolean
+  clear?: boolean
 }
 
 interface EntitySelectProps {
@@ -28,7 +31,9 @@ interface EntitySelectProps {
 }
 
 // Filter-as-you-type entity picker (category/payee) with optional create-on-the-fly,
-// mirroring the Vue q-select use-input + @new-value behavior.
+// mirroring the Vue q-select use-input + @new-value behavior. The field is a real
+// <input> (not a button-triggered popover): macOS Safari's plain Tab only reaches
+// text fields, so a button trigger would be unreachable by keyboard there.
 export function EntitySelect({
   value,
   onChange,
@@ -42,109 +47,122 @@ export function EntitySelect({
   createValidator,
 }: EntitySelectProps) {
   const { t } = useTranslation()
-  const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
-  const triggerRef = useRef<HTMLButtonElement | null>(null)
-  // inside the vaul drawer the popover must portal INTO the sheet: vaul's touch
-  // lock swallows touchmove on anything portaled to body, so the list would not
-  // scroll on mobile otherwise
-  const portalContainer = isMobile
-    ? (triggerRef.current?.closest('[data-slot="drawer-content"], [data-slot="dialog-content"]') as HTMLElement | null) ?? undefined
-    : undefined
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  // portal the popup INTO the containing dialog/drawer: the dialog's scroll lock
+  // swallows wheel events on anything portaled to body (and vaul's touch lock
+  // does the same to touchmove), so the list would not scroll otherwise
+  const portalContainer =
+    (rootRef.current?.closest('[data-slot="drawer-content"], [data-slot="dialog-content"]') as HTMLElement | null) ?? undefined
 
-  const selected = options.find((o) => o.value === value)
+  const selected = options.find((o) => o.value === value) ?? null
   const filtered = options.filter((o) => !search || o.label.toLowerCase().includes(search.toLowerCase()))
   const exactMatch = options.some((o) => o.label.toLowerCase() === search.toLowerCase())
   const canCreate = !!onCreate && search !== '' && !exactMatch && (createValidator ? createValidator(search) : true)
 
+  const rows: Row[] = [
+    // hidden while filtering so autoHighlight lands on a real match, not the clear row
+    ...(clearable && value && !search ? [{ value: '__clear__', label: '—', clear: true }] : []),
+    ...filtered,
+    ...(canCreate ? [{ value: '__create__', label: search, create: true }] : []),
+  ]
+
   return (
-    // modal on desktop only: the dialog's scroll lock otherwise swallows wheel
-    // events over the portaled popover, making the list unscrollable; inside
-    // the vaul drawer a modal popover dismisses itself immediately
-    <Popover modal={!isMobile} open={open} onOpenChange={(next) => { setOpen(next); setSearch('') }}>
-      <PopoverTrigger asChild>
-        <Button
-          ref={triggerRef}
-          id={id}
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          aria-label={ariaLabel}
-          disabled={disabled}
-          className="w-full justify-between font-normal"
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            {selected?.icon ? <EntityIcon name={selected.icon} className="text-base text-muted-foreground" /> : null}
-            <span className="truncate">{selected?.label ?? placeholder ?? ''}</span>
-          </span>
-          <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        // default open-autofocus lands on the search input everywhere — on
-        // mobile that pops the keyboard immediately, which is the point:
-        // pick-by-typing without a second tap
-        className="flex max-h-[min(20rem,var(--radix-popover-content-available-height))] w-[max(var(--radix-popover-trigger-width),14rem)] flex-col p-0 max-md:max-h-[min(26rem,var(--radix-popover-content-available-height))]"
-        align="start"
-        container={portalContainer}
+    <Combobox
+      items={rows}
+      filter={null}
+      value={selected}
+      onValueChange={(row: Row | null) => {
+        if (!row) {
+          return
+        }
+        if (row.create) {
+          onCreate?.(row.label)
+          return
+        }
+        onChange(row.clear ? null : row.value)
+      }}
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        // closing without a pick abandons the search; the field falls back to
+        // displaying the selected label
+        if (!next) {
+          setSearch('')
+        }
+      }}
+      inputValue={open ? search : (selected?.label ?? '')}
+      onInputValueChange={setSearch}
+      itemToStringLabel={(row: Row | null) => row?.label ?? ''}
+      isItemEqualToValue={(a: Row | null, b: Row | null) => a?.value === b?.value}
+      autoHighlight
+      openOnInputClick
+      disabled={disabled}
+    >
+      <div
+        ref={rootRef}
+        data-slot="entity-select"
+        className="flex h-8 w-full items-center gap-2 rounded-lg border border-input bg-transparent px-2.5 text-sm transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-disabled:opacity-50 dark:bg-input/30"
+        onClick={(e) => {
+          // clicks on the icon/chevron/padding (and clicks forwarded by
+          // SelectCard) open the picker, not just clicks on the input itself
+          if (!disabled && !open) {
+            e.currentTarget.querySelector('input')?.focus()
+            setOpen(true)
+          }
+        }}
       >
-        <Command shouldFilter={false} className="min-h-0">
-          <CommandInput
-            value={search}
-            onValueChange={setSearch}
-            placeholder={onCreate ? t('elements.select.create_placeholder') : t('elements.select.search_placeholder')}
-          />
-          <CommandList className="mt-1 max-h-none min-h-0 flex-1 overflow-y-auto">
-            <CommandEmpty />
-            {clearable && value ? (
-              <CommandItem
-                value="__clear__"
-                onSelect={() => {
-                  onChange(null)
-                  setOpen(false)
-                }}
-              >
-                —
-              </CommandItem>
-            ) : null}
-            {filtered.map((option) => (
-              <CommandItem
-                key={option.value}
-                value={option.value}
-                onSelect={() => {
-                  onChange(option.value)
-                  setOpen(false)
-                }}
-              >
-                {option.icon ? <EntityIcon name={option.icon} className="text-base text-muted-foreground" /> : null}
-                {option.label}
-              </CommandItem>
-            ))}
-            {canCreate ? (
-              <CommandItem
-                value={`__create__${search}`}
-                className="text-econumo-magenta data-[selected=true]:text-econumo-magenta"
-                onSelect={() => {
-                  onCreate?.(search)
-                  setOpen(false)
-                }}
-              >
+        {selected?.icon && !open ? <EntityIcon name={selected.icon} className="shrink-0 text-base text-muted-foreground" /> : null}
+        <ComboboxPrimitive.Input
+          id={id}
+          aria-label={ariaLabel}
+          placeholder={
+            open ? (onCreate ? t('elements.select.create_placeholder') : t('elements.select.search_placeholder')) : (placeholder ?? '')
+          }
+          className="h-full w-full min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !open) {
+              // the picker owns Enter: open the list instead of submitting the form
+              e.preventDefault()
+              setOpen(true)
+            }
+            // the hosting dialog leaves Escape to the picker while it is open
+            // (ResponsiveDialog's onEscapeKeyDown); close it here since the
+            // open state is controlled
+            if (e.key === 'Escape' && open) {
+              setOpen(false)
+              setSearch('')
+            }
+          }}
+        />
+        <ChevronsUpDown className="pointer-events-none size-4 shrink-0 opacity-50" />
+      </div>
+      <ComboboxContent container={portalContainer}>
+        <ComboboxList>
+          {(row: Row) => (
+            <ComboboxItem
+              key={row.create ? '__create__' : row.value}
+              value={row}
+              className={row.create ? 'text-econumo-magenta' : undefined}
+            >
+              {row.create ? (
                 <Plus className="size-4 text-econumo-magenta" />
-                {t('elements.button.add.label')} «{search}»
-              </CommandItem>
-            ) : null}
-          </CommandList>
-          {/* creation happens by typing a new name — say so instead of hiding it */}
-          {onCreate && !canCreate ? (
-            <div className="mt-1 flex items-center gap-1.5 border-t px-3 py-2 text-xs text-muted-foreground">
-              <Plus className="size-3.5" />
-              {t('elements.select.create_hint')}
-            </div>
-          ) : null}
-        </Command>
-      </PopoverContent>
-    </Popover>
+              ) : row.icon ? (
+                <EntityIcon name={row.icon} className="text-base text-muted-foreground" />
+              ) : null}
+              {row.create ? `${t('elements.button.add.label')} «${row.label}»` : row.label}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+        {/* creation happens by typing a new name — say so instead of hiding it */}
+        {onCreate && !canCreate ? (
+          <div className="flex items-center gap-1.5 border-t px-3 py-2 text-xs text-muted-foreground">
+            <Plus className="size-3.5" />
+            {t('elements.select.create_hint')}
+          </div>
+        ) : null}
+      </ComboboxContent>
+    </Combobox>
   )
 }

--- a/web/src/features/transactions/TransactionDialog.test.tsx
+++ b/web/src/features/transactions/TransactionDialog.test.tsx
@@ -52,6 +52,23 @@ it('Escape closes the dialog (outside clicks stay blocked via onInteractOutside)
   await waitFor(() => expect(useUiStore.getState().transactionModal).toBeNull())
 })
 
+it('Escape with a picker open closes the picker, not the dialog', async () => {
+  const user = userEvent.setup()
+  renderDialog()
+  useUiStore.getState().openTransactionModal({ type: 'expense' })
+  await screen.findByRole('heading', { name: 'Add transaction' })
+
+  await user.click(screen.getByRole('combobox', { name: 'Category' }))
+  expect(await screen.findByRole('option', { name: 'Food' })).toBeInTheDocument()
+
+  await user.keyboard('{Escape}')
+  await waitFor(() => expect(screen.queryByRole('option', { name: 'Food' })).not.toBeInTheDocument())
+  expect(useUiStore.getState().transactionModal).not.toBeNull()
+
+  await user.keyboard('{Escape}')
+  await waitFor(() => expect(useUiStore.getState().transactionModal).toBeNull())
+})
+
 it('clicking anywhere on a select card (label/padding) opens the picker', async () => {
   const user = userEvent.setup()
   renderDialog()
@@ -289,12 +306,11 @@ it('creates a category on the fly and selects it', async () => {
   useUiStore.getState().openTransactionModal({ type: 'expense' })
   await screen.findByRole('heading', { name: 'Add transaction' })
   await user.click(screen.getByRole('combobox', { name: 'Category' }))
-  // the modal popover hides the rest of the dialog from the a11y tree while
-  // open; the search input autofocuses, so type into the focused element
+  // the picker is the field itself: typing filters in place
   await user.keyboard('Books')
   await user.click(await screen.findByText(/Add «Books»/))
   await waitFor(() => expect(created).toBeDefined())
   expect(created!.name).toBe('Books')
   expect(created!.type).toBe('expense')
-  await waitFor(() => expect(screen.getByRole('combobox', { name: 'Category' })).toHaveTextContent('Books'))
+  await waitFor(() => expect(screen.getByRole('combobox', { name: 'Category' })).toHaveValue('Books'))
 })

--- a/web/src/features/transactions/TransactionDialog.tsx
+++ b/web/src/features/transactions/TransactionDialog.tsx
@@ -30,17 +30,17 @@ import type { TransactionType } from '@/api/dto/transaction'
 
 const TYPE_ORDER: TransactionType[] = ['income', 'transfer', 'expense']
 
-// strips the EntitySelect trigger button down so the CardField carries the chrome
+// strips the EntitySelect field down so the CardField carries the chrome
 const cardSelectClass =
-  '[&_button]:h-auto [&_button]:w-full [&_button]:border-0 [&_button]:bg-transparent [&_button]:p-0 [&_button]:font-normal [&_button]:shadow-none'
+  '[&_[data-slot=entity-select]]:h-auto [&_[data-slot=entity-select]]:border-0 [&_[data-slot=entity-select]]:px-0 [&_[data-slot=entity-select]]:ring-0 [&_[data-slot=entity-select]]:bg-transparent dark:[&_[data-slot=entity-select]]:bg-transparent'
 
 // CardField around an EntitySelect where the WHOLE card is the tap target —
-// clicks on the label/padding forward to the trigger inside
+// clicks on the label/padding forward to the field inside
 function SelectCard({ label, error, children }: { label: string; error?: string | null; children: ReactNode }) {
-  // if the popover was open at pointerdown, that press already dismissed it —
+  // if the picker was open at pointerdown, that press already dismissed it —
   // forwarding the click would immediately reopen
   const wasOpen = useRef(false)
-  const trigger = (root: HTMLElement) => root.querySelector<HTMLButtonElement>('button[role="combobox"]')
+  const trigger = (root: HTMLElement) => root.querySelector<HTMLInputElement>('[data-slot=entity-select] input')
   return (
     <div
       className="cursor-pointer"
@@ -48,7 +48,7 @@ function SelectCard({ label, error, children }: { label: string; error?: string 
         wasOpen.current = trigger(e.currentTarget)?.getAttribute('aria-expanded') === 'true'
       }}
       onClick={(e) => {
-        if (wasOpen.current || (e.target as HTMLElement).closest('button')) {
+        if (wasOpen.current || (e.target as HTMLElement).closest('input, button')) {
           return
         }
         trigger(e.currentTarget)?.click()
@@ -285,7 +285,7 @@ function TransactionForm({ params, onDone }: { params: OpenTransactionParams; on
       {/* Vue fuses the account and the oversized amount into one gray card */}
       <div className="flex flex-col rounded-lg bg-econumo-card px-3 py-2">
         {!isTransfer ? (
-          <div className="[&_button]:h-auto [&_button]:border-0 [&_button]:bg-transparent [&_button]:px-0 [&_button]:py-1 [&_button]:shadow-none">
+          <div className="[&_[data-slot=entity-select]]:h-auto [&_[data-slot=entity-select]]:border-0 [&_[data-slot=entity-select]]:px-0 [&_[data-slot=entity-select]]:py-1 [&_[data-slot=entity-select]]:ring-0 [&_[data-slot=entity-select]]:bg-transparent dark:[&_[data-slot=entity-select]]:bg-transparent">
             <EntitySelect
               aria-label="account"
               value={form.accountId}


### PR DESCRIPTION
## Problem

macOS Safari's plain Tab (default settings) only reaches text fields and listboxes — `<button>` elements are skipped entirely, and `tabindex` does not opt them back in. The transaction dialog's category/payee pickers were button-triggered popovers, the only non-text-field controls among the form fields, so Tab jumped straight from Amount to Notes for Safari users. The old Vue app's q-selects were input-based, making this a regression from the React port.

## Fix

Rewrite `EntitySelect` on the Base UI Combobox (the `ui/combobox.tsx` wrapper already in the repo): the field is now a real `<input>` — Tab lands in it in every browser, and typing filters the list in place (q-select `use-input` parity). Selection, create-on-the-fly, clearable "—" row, icons, and card styling are unchanged in behavior and looks.

Fallout handled along the way:

- **Escape scoping** — the Base UI popup is not a Radix layer, so the Radix Dialog's document-capture Escape handler used to close the dialog together with the picker. `ResponsiveDialog` now yields Escape while a combobox popup is open (first Escape closes the picker, second closes the dialog). Covered by a regression test.
- **Popup scrolling** — the popup portals INTO the containing dialog/drawer on all viewports (`ComboboxContent` grew a `container` prop): the dialog's scroll lock swallows wheel/touch events over body-portaled popups otherwise.
- **Enter semantics** — Enter in the closed picker opens the list instead of submitting the form, matching the old button-trigger behavior.

## Testing

- 7 new `EntitySelect` unit tests (input-based contract: Tab-reachable `<input>`, type-to-filter + Enter, click-select, Escape revert, create validation gating, clearable) + an Escape-scoping regression test in `TransactionDialog.test.tsx` — all written first and watched fail (TDD).
- Full web suite: 444 passed; the only failure is the pre-existing `ImportCsvDialog.test.tsx` one on `main`. tsc and oxlint clean.
- Verified end-to-end in real Chromium (desktop + phone viewport): Tab order Amount → Category → Recipient → tags → Notes, type-filter-Enter selection, payee create flow, Escape scoping, and wheel-scrolling the popup inside the open dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSqWiy7gqg9QB7LccSo97y