### PR TITLE
ci: cross-compile release image, upgrade to pnpm 11, add Publish Dev checkbox

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,12 +14,12 @@ on:
         description: "Version tag to publish (e.g., v1.2.3)"
         required: true
       push_latest:
-        description: "Publish Latest (move the 'latest' tag to this build; main only)"
+        description: "Publish Latest"
         required: false
         type: boolean
         default: false
       push_dev:
-        description: "Publish Dev (move the 'dev' tag to this build)"
+        description: "Publish Dev"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,8 @@ name: Publish Release
 # - Always pushes the version tag (e.g. v1.2.3).
 # - Also pushes/moves "latest" only when push_latest is checked AND the workflow
 #   is dispatched from the main branch.
-# The local "dev" tag is published separately via `make publish`.
+# - Also pushes/moves "dev" when push_dev is checked (any branch). Unlike
+#   `make publish-dev`, the UI version label is the release version, not "dev".
 
 on:
   workflow_dispatch:
@@ -13,7 +14,12 @@ on:
         description: "Version tag to publish (e.g., v1.2.3)"
         required: true
       push_latest:
-        description: "Also move the 'latest' tag to this build (main only)"
+        description: "Publish Latest (move the 'latest' tag to this build; main only)"
+        required: false
+        type: boolean
+        default: false
+      push_dev:
+        description: "Publish Dev (move the 'dev' tag to this build)"
         required: false
         type: boolean
         default: false
@@ -52,6 +58,9 @@ jobs:
           if [ "${{ github.event.inputs.push_latest }}" = "true" ]; then
             TAGS="${TAGS},${IMAGE}:latest"
           fi
+          if [ "${{ github.event.inputs.push_dev }}" = "true" ]; then
+            TAGS="${TAGS},${IMAGE}:dev"
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "Publishing ${VERSION} -> [${TAGS}]"
@@ -84,9 +93,8 @@ jobs:
         with:
           ref: ${{ needs.create-tag.outputs.version }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
+      # No QEMU: both build stages run on $BUILDPLATFORM (Go cross-compiles,
+      # the SPA is platform-independent) and the distroless stage only COPYs.
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ make publish-dev   # build + push the multi-arch `dev` image to ghcr.io/econumo/
 ```
 
 Releases (`latest` + `vX.Y.Z`) are cut by the GitHub release workflow
-(`.github/workflows/publish-release.yml`), not locally. Everything publishes to
+(`.github/workflows/publish-release.yml`), not locally; its "Publish Dev"
+checkbox can also move the `dev` tag. Everything publishes to
 `ghcr.io/econumo/econumo` only.
 
 ## Architecture
@@ -418,7 +419,7 @@ data unreadable. Most are also asserted by the test suite.
 ## Deployment
 
 - Image: `ghcr.io/econumo/econumo` (GitHub Container Registry only).
-  - `:dev` — published locally via `make publish-dev`.
+  - `:dev` — published locally via `make publish-dev`, or by the release workflow's "Publish Dev" checkbox.
   - `:latest` + `:vX.Y.Z` — published by the GitHub release workflow (latest only from `main`).
 - Self-hosting: see the root `docker-compose.yml` (+ `.env.example`, copied to `.env`)
   and the README quick-start. The Dockerfile is `deployment/docker/Dockerfile`.

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -4,11 +4,17 @@
 # DATABASE_URL comes from the environment (.env), not baked in. Mount a volume
 # under /app/var to persist the sqlite db. Migrations run inside the binary on boot.
 
+# Both build stages run natively on the build host ($BUILDPLATFORM) — the SPA
+# output is platform-independent and Go cross-compiles — so a multi-arch build
+# never runs the heavy toolchains under QEMU emulation.
+
 # --- 1. Frontend build ---
-FROM node:26-alpine AS frontend
+FROM --platform=$BUILDPLATFORM node:26-alpine AS frontend
 WORKDIR /build/web
-RUN npm install -g pnpm@10
-COPY web/package.json web/pnpm-lock.yaml ./
+RUN npm install -g pnpm@11
+# pnpm-workspace.yaml carries allowBuilds; without it pnpm 11 fails the
+# install on unapproved build scripts.
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY web/ ./
 # Vite inlines ECONUMO_VERSION (envPrefix in vite.config.ts) as the UI version label.
@@ -17,14 +23,15 @@ ARG ECONUMO_VERSION=""
 RUN ECONUMO_VERSION="${ECONUMO_VERSION:-dev}" pnpm run build
 
 # --- 2. Go build (CGO off -> fully static binary) ---
-FROM golang:1.26-alpine AS gobuild
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS gobuild
 WORKDIR /src
 # Module files first for layer-cached `go mod download`.
 COPY go.mod go.sum ./
 RUN go mod download
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /app/econumo ./cmd/econumo
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /app/econumo ./cmd/econumo
 # Pre-create runtime dirs owned by the non-root user (distroless can't mkdir on boot).
 RUN mkdir -p /out/var/db
 

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@11.13.1",
   "type": "module",
   "types": "dist/types/index.d.ts",
   "scripts": {
@@ -50,11 +51,6 @@
     "uuid": "^14.0.1",
     "vaul": "^1.1.2",
     "zustand": "^5.0.14"
-  },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher"
-    ]
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.3.2",


### PR DESCRIPTION
## Summary

Three improvements to the release build pipeline, prompted by the ~7.5-minute "Build and Publish Go Image" job.

### 1. Eliminate QEMU emulation from the multi-arch image build

The arm64 half of the image build ran the entire Node and Go toolchain under QEMU (`go build` 377s vs 73s native, Vite build 221s vs 23s). None of it was necessary: the SPA bundle is platform-independent and the CGO-free binary cross-compiles.

- `frontend` and `gobuild` stages now run on `$BUILDPLATFORM`; the Go build takes `TARGETOS`/`TARGETARCH` and cross-compiles per platform (declared after `go mod download`, keeping the module layer shared).
- The `docker/setup-qemu-action` step is removed — the final distroless stage only COPYs, so nothing needs emulation.
- Expected publish time: ~7.5 min → ~2 min. `make publish-dev` gets the same speedup (native arm64 + cross-compiled amd64 on Apple Silicon).

### 2. Upgrade pnpm 10 → 11

- Dockerfile installs `pnpm@11`; `web/package.json` pins `packageManager: pnpm@11.13.1` (existing pnpm ≥10 auto-switches via that field, so `make web-*` targets are unchanged).
- Removed the stale `pnpm.ignoredBuiltDependencies` block — the setting is gone in pnpm 11 and the committed `web/pnpm-workspace.yaml` already carries the `allowBuilds` equivalent.
- The Docker build now copies `pnpm-workspace.yaml` alongside the lockfile: pnpm 11 hard-fails (`ERR_PNPM_IGNORED_BUILDS`) on unapproved build scripts in non-interactive environments without it.
- The existing `pnpm-lock.yaml` (v9.0) installs frozen under pnpm 11 with no churn.

### 3. "Publish Dev" checkbox on the release workflow

The workflow now has two checkboxes: **Publish Latest** (unchanged input key, still main-only) and **Publish Dev** (new, any branch) — checking it appends `:dev` to the same multi-arch build, so all tags publish from one build. Note: a `dev` image published this way carries the release version as its UI label, unlike `make publish-dev`.

CLAUDE.md updated where it said `dev` is published only locally.

## Test plan

- [x] Full local `docker buildx build --platform linux/amd64,linux/arm64 --target prod` succeeds with zero emulated steps (cross-compile confirmed at 16s vs 377s under QEMU in CI)
- [x] `pnpm install --frozen-lockfile` under pnpm 11.13.1 passes locally and in the Docker frontend stage
- [x] Web test suite passes under pnpm 11: 437 tests / 86 files
- [x] Workflow YAML lints clean
- [ ] Next release run confirms the wall-clock improvement end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)