### PR TITLE
fix(web): set explicit Cache-Control headers on SPA responses

### DIFF
--- a/internal/web/spa/spa.go
+++ b/internal/web/spa/spa.go
@@ -43,6 +43,7 @@ func Handler(dir string) http.Handler {
 		fsPath := filepath.Join(dir, filepath.FromSlash(rel))
 
 		if fileExists(fsPath) {
+			setCacheControl(w, cleaned)
 			fs.ServeHTTP(w, r)
 			return
 		}
@@ -62,8 +63,25 @@ func Handler(dir string) http.Handler {
 		}
 
 		// SPA fallback: serve index.html for client-side routes.
+		setCacheControl(w, "/"+indexFile)
 		http.ServeFile(w, r, filepath.Join(dir, indexFile))
 	})
+}
+
+// setCacheControl picks the caching policy by path. Vite-fingerprinted files
+// under /assets/ are content-addressed, so they never change and cache forever.
+// Everything else (index.html, econumo-config.js, manifest, icons) keeps its
+// name across deploys and must revalidate on every load: without an explicit
+// Cache-Control, iOS home-screen web apps heuristically cache the shell across
+// launches and keep running the old bundle until the icon is re-added.
+// no-cache still allows storing — revalidation is a cheap 304 via
+// Last-Modified/If-Modified-Since.
+func setCacheControl(w http.ResponseWriter, cleaned string) {
+	if strings.HasPrefix(cleaned, "/assets/") {
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-cache")
 }
 
 // isReservedPath reports whether the path belongs to a server-side route group

--- a/internal/web/spa/spa_test.go
+++ b/internal/web/spa/spa_test.go
@@ -23,6 +23,9 @@ func newSPADir(t *testing.T) string {
 	if err := os.WriteFile(filepath.Join(dir, "assets", "econumo.abc123.svg"), []byte("<svg/>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	return dir
 }
 
@@ -63,6 +66,36 @@ func TestSPA_Serving(t *testing.T) {
 			}
 			if tc.wantBody != "" && !strings.Contains(body, tc.wantBody) {
 				t.Errorf("%s: body %q missing %q", tc.path, body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// Without an explicit Cache-Control, iOS home-screen web apps heuristically
+// cache index.html across launches and keep serving a stale shell (pointing at
+// old hashed bundles) long after a deploy. The shell and other non-fingerprinted
+// files must force revalidation; Vite-fingerprinted /assets/ files are immutable.
+func TestSPA_CacheHeaders(t *testing.T) {
+	h := Handler(newSPADir(t))
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"index at root revalidates", "/", "no-cache"},
+		{"index direct revalidates", "/index.html", "no-cache"},
+		{"client route fallback revalidates", "/accounts", "no-cache"},
+		{"runtime config revalidates", "/econumo-config.js", "no-cache"},
+		{"hashed asset immutable", "/assets/econumo.abc123.svg", "public, max-age=31536000, immutable"},
+		{"missing asset 404 not immutable", "/assets/missing.js", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if got := rec.Header().Get("Cache-Control"); got != tc.want {
+				t.Errorf("%s: Cache-Control = %q, want %q", tc.path, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

Every deploy required removing and re-adding the iPhone home-screen icon to see frontend changes, even after purging the Cloudflare cache.

Root cause: the Go SPA server (`internal/web/spa`) sent **no `Cache-Control` header at all** — responses carried only `Last-Modified`. With no explicit directive, Safari applies heuristic caching, and an iOS home-screen web app is the worst case: it reuses its cached copy of the start page across launches without revalidating. The phone kept loading the old `index.html`, which points at the old fingerprinted bundle (`/assets/index-<oldhash>.js`). Cloudflare purges couldn't help — the stale copy lives on the device (CF reports `cf-cache-status: DYNAMIC` for the HTML anyway).

Secondary: with no origin instructions, Cloudflare applied its default 4h TTL to `.js` files, so the non-fingerprinted runtime config `/econumo-config.js` was served stale from the edge (`max-age=14400`, HIT).

## Fix

The handler now sets an explicit policy per path class:

- **`/assets/*`** (Vite content-hashed, new name every build): `public, max-age=31536000, immutable` — cached forever in browsers and at the Cloudflare edge.
- **Everything else** (`index.html`, SPA-route fallback, `econumo-config.js`, `manifest.json`, icons): `no-cache` — stored but revalidated on every load; revalidation is a cheap `304` via the existing `Last-Modified`/`If-Modified-Since` handling.

## Testing

- New `TestSPA_CacheHeaders` (written first, watched fail with empty headers) covering root, direct `index.html`, client-route fallback, runtime config, hashed assets, and 404s.
- `make go-test` passes (coverage 79.7%, gate 78%).

## Post-deploy note

The stale `index.html` cached on the phone predates this fix and won't revalidate on its own — remove/re-add the icon **one final time** after deploying (and purge Cloudflare once for the edge-cached `econumo-config.js`). Subsequent deploys show up on next launch automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPGq4esPC4YWYPevxnSkwS