### PR TITLE
fix(web): unbreak ImportCsvDialog happy-path test (msw XHR + FormData hang)

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,4 +1,11 @@
 import '@testing-library/jest-dom/vitest'
+import axios from 'axios'
+
+// Under jsdom axios picks its XHR adapter, and msw's XHR interceptor never
+// delivers the response when the request body is FormData (the promise hangs
+// forever). Route axios through the fetch adapter, which msw handles fine.
+// Must run before api/client.ts calls axios.create(), which snapshots defaults.
+axios.defaults.adapter = 'fetch'
 
 // Node >= 25 defines an experimental global `localStorage` (unusable without
 // --localstorage-file), so vitest's jsdom environment skips copying jsdom's


### PR DESCRIPTION
## Summary
- Fixes the long-standing deterministic failure of `web/src/features/transactions/ImportCsvDialog.test.tsx` ("happy path: import posts once, invalidates queries, and reports the result"), which kept `make test`'s frontend tier red on main.
- Root cause: under jsdom axios defaults to its XHR adapter, and msw's XHR interceptor never delivers the response when the request body is `FormData` — the msw handler runs and responds, but the axios promise hangs forever, so `onComplete` is never called. Verified with a minimal repro: axios+JSON resolves, native `fetch`+FormData resolves, axios fetch-adapter+FormData resolves; only axios XHR+FormData hangs (axios 1.18.1 / msw 2.14.6 / jsdom 29 / Node 24).
- Fix is test-environment-only: set `axios.defaults.adapter = 'fetch'` in `web/src/test/setup.ts`, before `api/client.ts` calls `axios.create()` (which snapshots defaults). No production code changed; real browsers were never affected.

## Test plan
- [x] `pnpm vitest run src/features/transactions/ImportCsvDialog.test.tsx` — 5/5 pass (previously 4/5)
- [x] full `pnpm test` — 89 files / 459 tests pass
- [x] `pnpm exec tsc -b` clean; `pnpm lint` — only pre-existing fast-refresh warnings
- [x] `make test` Go tiers (smoke + enginecompare) passed on the same tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsNzv7KjUeWgS4exzC1Ke9