### PR TITLE
feat: new-release notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ ECONUMO_ALLOW_REGISTRATION=true
 # Optional: ECONUMO_DEBUG=true exposes stack traces in 500 responses (default: false).
 # ECONUMO_DEBUG=true
 
+# Optional: set ECONUMO_CHECK_UPDATES=false to disable the daily check for new
+# Econumo releases (a single request from the server to econumo.com).
+# ECONUMO_CHECK_UPDATES=false
+
 # Log level: debug | info | warn | error (default: info). Every request logs one
 # operation-result line (INFO/WARN/ERROR by outcome); debug also logs a per-request
 # transport line. Any command also accepts -v/-vv/-vvv (force debug) and -q (quiet),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,8 @@ checkbox can also move the `dev` tag. Everything publishes to
 ### Feature packages (vertical slices)
 
 The backend is organized as vertical feature packages rather than horizontal
-layers. Each of the nine features (`account`, `budget`, `category`, `connection`,
-`currency`, `payee`, `tag`, `transaction`, `user`) is a single `internal/<feature>`
+layers. Each of the ten features (`account`, `budget`, `category`, `connection`,
+`currency`, `payee`, `system`, `tag`, `transaction`, `user`) is a single `internal/<feature>`
 tree holding its own use cases, persistence, and HTTP edge; the entities and
 DTOs those use cases operate on live in the shared `internal/model` package
 (below), so a feature package is behavior-only:
@@ -87,7 +87,7 @@ DTOs those use cases operate on live in the shared `internal/model` package
 │   │                                one file per feature (account.go, account_dto.go, ...); imports only
 │   │                                the shared kernel; part of the archtest kernel alongside `shared`
 │   ├── <feature>/ ................. one package per feature (account, budget, category, connection,
-│   │   │                            currency, payee, tag, transaction, user); root package holds only
+│   │   │                            currency, payee, system, tag, transaction, user); root package holds only
 │   │   │                            behavior — the entities/DTOs it operates on live in `internal/model`:
 │   │   │   <verb>.go .............   one file per use case or a closely related group (create.go,
 │   │   │                             update.go, delete.go, read.go, ...), naming a package-level `Service`
@@ -118,7 +118,9 @@ DTOs those use cases operate on live in the shared `internal/model` package
 
 Not every feature has a `repository.go`/`ports.go` — e.g. `currency` has no
 per-user persistence shape (it's rates + conversion + admin lookups), so it
-keeps `read.go`/`admin.go`/`convertor.go` but no `repository.go`.
+keeps `read.go`/`admin.go`/`convertor.go` but no `repository.go`; `system` is
+similar — it's in-memory poller state only (no persistence at all), so it has
+no `repository.go` either.
 
 ### Dependency rule
 
@@ -280,6 +282,7 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   only (no `Access-Control-Allow-Origin` emitted; the bundled SPA and API share an origin so it
   just works). A configured origin is reflected back with `Vary: Origin`; `*` allows any origin.
 - `ECONUMO_CURRENCY_BASE` — base currency (default `USD`).
+- `ECONUMO_CHECK_UPDATES` — daily check for new releases against `econumo.com/releases/latest.json` (single server-side request; result served to the SPA via `get-update-info`). `false` disables it.
 - `ECONUMO_DEBUG` — `true` exposes 500 stack traces (default `false`). Replaces the former `APP_ENV`.
 - `MAILER_DSN` — mail transport for password-reset email; the scheme selects the provider, exactly
   as `DATABASE_URL`'s scheme selects the DB engine. Empty (default) = the **console** transport (renders

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ go-lint: swagger-check
 # runs; the build pipeline uses this pinned version). `go run <pkg>@<ver>` needs
 # the module cache (network on first use).
 SWAG_VERSION := $(shell go list -m -f '{{.Version}}' github.com/swaggo/swag 2>/dev/null || echo v1.16.6)
-SWAG_INIT     = go run github.com/swaggo/swag/cmd/swag@$(SWAG_VERSION) init -g doc.go -d .,../../user,../../currency,../../account,../../category,../../tag,../../payee,../../transaction,../../connection,../../budget,../../model --parseInternal --parseDependency
+SWAG_INIT     = go run github.com/swaggo/swag/cmd/swag@$(SWAG_VERSION) init -g doc.go -d .,../../user,../../currency,../../account,../../category,../../tag,../../payee,../../transaction,../../connection,../../budget,../../system,../../model --parseInternal --parseDependency
 
 # Regenerate the committed OpenAPI docs from the handler/DTO annotations. This is
 # a prerequisite of go-build / go-run / publish-dev / up so a built artifact never

--- a/cmd/econumo/main.go
+++ b/cmd/econumo/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/econumo/econumo/internal/infra/storage/migrate"
 	"github.com/econumo/econumo/internal/logging"
 	"github.com/econumo/econumo/internal/server"
+	"github.com/econumo/econumo/internal/system"
 
 	"github.com/joho/godotenv"
 
@@ -203,7 +204,9 @@ func run(serveArgs []string) error {
 	}
 	slog.Info("migrations applied", "backend", be.Name())
 
-	handler := server.BuildAPI(cfg, db, server.Seams{})
+	updates := system.NewService(cfg.CheckUpdates, system.DefaultFeedURL)
+	handler := server.BuildAPI(cfg, db, server.Seams{Updates: updates})
+	updates.StartPolling(ctx)
 
 	srv := &http.Server{
 		Addr:              addr(cfg.Port),

--- a/docs/superpowers/plans/2026-07-17-release-notifications.md
+++ b/docs/superpowers/plans/2026-07-17-release-notifications.md
@@ -1,0 +1,1069 @@
+# Release Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Notify users when a new Econumo release is available, linking to `https://econumo.com/releases/<version>/`.
+
+**Architecture:** The website publishes `releases/latest.json`; the Go backend polls it (daily, in-memory cache, env opt-out `ECONUMO_CHECK_UPDATES`) and exposes it via `GET /api/v1/system/get-update-info`; the SPA compares against its own build version and renders a settings-gear badge, a dismissible sidebar notice, and a Settings-page row.
+
+**Tech Stack:** Go stdlib (net/http, sync, regexp), new feature package `internal/system`; React 19 + TanStack Query + react-i18next; Astro (website repo).
+
+**Spec:** `docs/superpowers/specs/2026-07-17-release-notifications-design.md`
+
+## Global Constraints
+
+- API envelope, routes, and method rules are frozen contract (see CLAUDE.md): success envelope `{"success": true, "message": "", "data": ...}`; only GET (reads) and POST (writes); route shape `/api/v1/{module}/{action}-{subject}`.
+- Env naming: app-owned config is prefixed `ECONUMO_` → the opt-out is `ECONUMO_CHECK_UPDATES` (default `true`).
+- Feed validation (trust boundary): accept only `version` matching `^v\d+\.\d+\.\d+$` AND `url` starting with `https://econumo.com/`. Invalid payloads are dropped, previous value retained.
+- Failure is silence: no error states or retry UI anywhere; `dev`/non-semver builds never show anything.
+- i18n: every new key must exist in BOTH `locales/en.json` and `locales/ru.json` with identical `{var}` placeholder sets (enforced by `internal/test/i18ntest`, part of `make go-test`).
+- Golden files: regenerate with `UPDATE_GOLDEN=1 go test ./internal/test/apiparity/`, inspect the diff, never hand-edit.
+- Comments: sparse, only non-obvious rationale. Swagger `// @…` blocks are required on handlers.
+- Frontend done-gate: `pnpm exec tsc -b` must pass in `web/` (vitest+oxlint do not type-check).
+- Work in this worktree (`/home/dmitry/dev/econumo/econumo/.claude/worktrees/hashed-greeting-hanrahan`); never cd to the main checkout. `git stash` is forbidden (shared stack).
+- Known pre-existing failure on main: `web/src/features/settings/ImportCsvDialog.test.tsx` — not caused by this work; ignore it in verification.
+
+---
+
+### Task 1: Website release feed (`econumo/website` repo — separate clone + PR)
+
+The app feature is inert without this feed. Work in a scratchpad clone; this repo is untouched.
+
+**Files (in the website clone):**
+- Create: `src/pages/releases/latest.json.ts`
+
+**Interfaces:**
+- Produces: `https://econumo.com/releases/latest.json` → `{"version": "v1.0.2", "date": "2026-07-16", "url": "https://econumo.com/releases/v1.0.2/"}`. Task 3's poller consumes this exact shape (`date` is informational; the backend ignores it).
+
+- [ ] **Step 1: Clone and branch**
+
+```bash
+git clone git@github.com:econumo/website.git /tmp/claude-1000/-home-dmitry-dev-econumo-econumo/d70d203b-4c91-4deb-bb5f-7d8d8fcf8f70/scratchpad/website
+cd /tmp/claude-1000/-home-dmitry-dev-econumo-econumo/d70d203b-4c91-4deb-bb5f-7d8d8fcf8f70/scratchpad/website
+git checkout -b feat/latest-release-feed
+```
+
+- [ ] **Step 2: Create the endpoint**
+
+The repo already has `getReleases()` (newest-first, draft-filtered) and `releaseSlug()` in `src/lib/content.ts`, and `SITE.url` in `src/lib/site.ts` — reuse them (mirror `src/pages/releases/index.xml.ts`). Sort by semver, not date, so same-day releases can't misorder.
+
+Create `src/pages/releases/latest.json.ts`:
+
+```ts
+import type { APIRoute } from 'astro';
+import { getReleases, releaseSlug } from '@/lib/content';
+import { SITE } from '@/lib/site';
+
+const SEMVER = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+const parts = (slug: string): number[] => SEMVER.exec(slug)!.slice(1).map(Number);
+
+// The latest published release as machine-readable JSON, consumed by the
+// self-hosted app's update check. Shape is a contract: {version, date, url}.
+export const GET: APIRoute = async () => {
+  const releases = (await getReleases()).filter((r) => SEMVER.test(releaseSlug(r)));
+  releases.sort((a, b) => {
+    const [aMaj, aMin, aPat] = parts(releaseSlug(a));
+    const [bMaj, bMin, bPat] = parts(releaseSlug(b));
+    return bMaj - aMaj || bMin - aMin || bPat - aPat;
+  });
+  const latest = releases[0];
+  const body = latest
+    ? {
+        version: releaseSlug(latest),
+        date: latest.data.date.toISOString().slice(0, 10),
+        url: `${SITE.url}/releases/${releaseSlug(latest)}/`,
+      }
+    : {};
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+};
+```
+
+- [ ] **Step 3: Build and verify the output**
+
+```bash
+npm ci && npm run build
+cat dist/releases/latest.json
+```
+
+Expected: valid JSON naming the newest release (v1.0.2 or later), e.g. `{"version":"v1.0.2","date":"2026-07-16","url":"https://econumo.com/releases/v1.0.2/"}`. If `npm run build` is not the build script, check `package.json`/`Makefile` for the build target and use that.
+
+- [ ] **Step 4: Commit, push, PR**
+
+```bash
+git add src/pages/releases/latest.json.ts
+git commit -m "feat: latest-release JSON feed for the app update check"
+git push -u origin feat/latest-release-feed
+gh pr create --repo econumo/website --title "feat: latest-release JSON feed" --body "Adds /releases/latest.json ({version, date, url}, semver-newest) for the self-hosted app's update notifications. Consumed by econumo/econumo (release-notifications feature)."
+```
+
+---
+
+### Task 2: Backend config flag `ECONUMO_CHECK_UPDATES`
+
+**Files:**
+- Modify: `internal/config/config.go` (Config struct ~line 22-26, Load ~line 64-77)
+- Modify: `internal/config/config_test.go`
+- Modify: `.env.example`
+
+**Interfaces:**
+- Produces: `config.Config.CheckUpdates bool` (default `true`) — consumed by Task 4's `serve` wiring.
+
+- [ ] **Step 1: Write the failing test** (append to `internal/config/config_test.go`):
+
+```go
+func TestLoad_CheckUpdates(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+	c, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.CheckUpdates {
+		t.Fatal("CheckUpdates default = false, want true")
+	}
+	t.Setenv("ECONUMO_CHECK_UPDATES", "false")
+	c, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.CheckUpdates {
+		t.Fatal("CheckUpdates with ECONUMO_CHECK_UPDATES=false = true, want false")
+	}
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `go test ./internal/config/ -run TestLoad_CheckUpdates -v`
+Expected: compile error `c.CheckUpdates undefined`.
+
+- [ ] **Step 3: Implement**
+
+In the `Config` struct, after the `SQLiteBusyTimeout int` line:
+
+```go
+	CheckUpdates      bool   // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
+```
+
+In `Load()`, after the `SQLiteBusyTimeout:` line:
+
+```go
+		CheckUpdates:           getBool("ECONUMO_CHECK_UPDATES", true),
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+Run: `go test ./internal/config/ -run TestLoad_CheckUpdates -v`
+
+- [ ] **Step 5: Document in `.env.example`** — add near the `ECONUMO_DEBUG` block:
+
+```
+# Optional: set ECONUMO_CHECK_UPDATES=false to disable the daily check for new
+# Econumo releases (a single request from the server to econumo.com).
+# ECONUMO_CHECK_UPDATES=false
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go .env.example
+git commit -m "feat(config): ECONUMO_CHECK_UPDATES flag (default true)"
+```
+
+---
+
+### Task 3: `internal/system` service — feed poll, validation, cache
+
+**Files:**
+- Create: `internal/model/system_dto.go`
+- Create: `internal/system/updates.go`
+- Create: `internal/system/updates_test.go`
+
+**Interfaces:**
+- Consumes: `model.GetUpdateInfoResult` (defined here), `vo.Id` from `internal/shared/vo`.
+- Produces (Task 4 relies on these exact signatures):
+  - `system.DefaultFeedURL` (const string)
+  - `system.NewService(enabled bool, feedURL string) *system.Service`
+  - `(*Service).GetUpdateInfo(ctx context.Context, userID vo.Id) (model.GetUpdateInfoResult, error)` — matches `endpoint.HandleNoBody`'s `call` shape
+  - `(*Service).StartPolling(ctx context.Context)` — non-blocking; no-op when disabled
+
+- [ ] **Step 1: DTO** — create `internal/model/system_dto.go`:
+
+```go
+// Result DTO for the system read endpoint (get-update-info).
+package model
+
+// GetUpdateInfoResult is the get-update-info response: the latest release
+// published on econumo.com, or empty strings when unknown (check disabled,
+// not fetched yet, or the feed unreachable). The SPA compares version against
+// its own build version; the server never does.
+type GetUpdateInfoResult struct {
+	Version string `json:"version"`
+	Url     string `json:"url"`
+}
+```
+
+- [ ] **Step 2: Write the failing tests** — create `internal/system/updates_test.go`:
+
+```go
+package system
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/econumo/econumo/internal/shared/vo"
+)
+
+func feedServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func info(t *testing.T, s *Service) (string, string) {
+	t.Helper()
+	res, err := s.GetUpdateInfo(context.Background(), vo.Id(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.Version, res.Url
+}
+
+func TestFetchValidPayload(t *testing.T) {
+	srv := feedServer(t, 200, `{"version":"v9.9.9","date":"2026-07-16","url":"https://econumo.com/releases/v9.9.9/"}`)
+	s := NewService(true, srv.URL)
+	s.fetch(context.Background())
+	v, u := info(t, s)
+	if v != "v9.9.9" || u != "https://econumo.com/releases/v9.9.9/" {
+		t.Fatalf("info = %q %q, want v9.9.9 + release url", v, u)
+	}
+}
+
+func TestFetchRejectsInvalidPayloads(t *testing.T) {
+	cases := map[string]struct {
+		status int
+		body   string
+	}{
+		"malformed json":   {200, `{"version": `},
+		"bad version":      {200, `{"version":"latest","url":"https://econumo.com/releases/latest/"}`},
+		"wrong url origin": {200, `{"version":"v9.9.9","url":"https://evil.example/phish/"}`},
+		"non-2xx":          {500, `{"version":"v9.9.9","url":"https://econumo.com/releases/v9.9.9/"}`},
+		"empty payload":    {200, `{}`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := feedServer(t, tc.status, tc.body)
+			s := NewService(true, srv.URL)
+			s.fetch(context.Background())
+			if v, u := info(t, s); v != "" || u != "" {
+				t.Fatalf("info = %q %q, want empty (payload must be dropped)", v, u)
+			}
+		})
+	}
+}
+
+func TestFetchFailureKeepsPreviousValue(t *testing.T) {
+	good := feedServer(t, 200, `{"version":"v9.9.9","url":"https://econumo.com/releases/v9.9.9/"}`)
+	s := NewService(true, good.URL)
+	s.fetch(context.Background())
+
+	bad := feedServer(t, 500, ``)
+	s.feedURL = bad.URL
+	s.fetch(context.Background())
+	if v, _ := info(t, s); v != "v9.9.9" {
+		t.Fatalf("version after failed refetch = %q, want v9.9.9 retained", v)
+	}
+}
+
+func TestStartPollingDisabledIsNoop(t *testing.T) {
+	srv := feedServer(t, 200, `{"version":"v9.9.9","url":"https://econumo.com/releases/v9.9.9/"}`)
+	s := NewService(false, srv.URL)
+	s.StartPolling(context.Background())
+	if v, _ := info(t, s); v != "" {
+		t.Fatalf("disabled service has version %q, want empty", v)
+	}
+}
+```
+
+- [ ] **Step 3: Run — expect FAIL**
+
+Run: `go test ./internal/system/ -v`
+Expected: compile errors (package/`NewService` undefined).
+
+- [ ] **Step 4: Implement** — create `internal/system/updates.go`:
+
+```go
+// Package system reports instance-level information; currently the latest
+// published Econumo release, polled from the econumo.com feed.
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/shared/vo"
+)
+
+const DefaultFeedURL = "https://econumo.com/releases/latest.json"
+
+// The feed is remote input rendered as a trusted link in every instance's UI:
+// only well-formed versions and econumo.com URLs are ever accepted.
+const allowedURLPrefix = "https://econumo.com/"
+
+var versionPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+const pollInterval = 24 * time.Hour
+
+type Service struct {
+	enabled bool
+	feedURL string
+	client  *http.Client
+
+	mu   sync.RWMutex
+	info model.GetUpdateInfoResult
+}
+
+func NewService(enabled bool, feedURL string) *Service {
+	return &Service{
+		enabled: enabled,
+		feedURL: feedURL,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// GetUpdateInfo returns the cached latest-release info; empty strings when the
+// check is disabled, hasn't run yet, or nothing valid was ever received. The
+// SPA does the version comparison, so failure here is silence, never an error.
+func (s *Service) GetUpdateInfo(_ context.Context, _ vo.Id) (model.GetUpdateInfoResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.info, nil
+}
+
+// StartPolling launches the background feed poll (boot + every 24h). Only the
+// serve command calls this; CLI commands and tests never do, so their
+// responses stay deterministic and hermetic.
+func (s *Service) StartPolling(ctx context.Context) {
+	if !s.enabled {
+		return
+	}
+	go func() {
+		s.fetch(ctx)
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.fetch(ctx)
+			}
+		}
+	}()
+}
+
+func (s *Service) fetch(ctx context.Context) {
+	if err := s.fetchOnce(ctx); err != nil {
+		slog.Debug("release feed check failed", "err", err)
+	}
+}
+
+func (s *Service) fetchOnce(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.feedURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("feed returned status %d", resp.StatusCode)
+	}
+	var feed struct {
+		Version string `json:"version"`
+		Url     string `json:"url"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&feed); err != nil {
+		return err
+	}
+	if !versionPattern.MatchString(feed.Version) {
+		return fmt.Errorf("feed version %q is not vX.Y.Z", feed.Version)
+	}
+	if !strings.HasPrefix(feed.Url, allowedURLPrefix) {
+		return fmt.Errorf("feed url %q is outside %s", feed.Url, allowedURLPrefix)
+	}
+	s.mu.Lock()
+	s.info = model.GetUpdateInfoResult{Version: feed.Version, Url: feed.Url}
+	s.mu.Unlock()
+	return nil
+}
+```
+
+- [ ] **Step 5: Run — expect PASS (and race-clean)**
+
+Run: `go test ./internal/system/ -race -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/model/system_dto.go internal/system/
+git commit -m "feat(system): latest-release feed poller with validation and in-memory cache"
+```
+
+---
+
+### Task 4: API edge — handler, route, wiring, swagger, apiparity golden
+
+**Files:**
+- Create: `internal/system/api/handler.go`
+- Create: `internal/system/api/system.go`
+- Create: `internal/system/api/routes.go`
+- Modify: `internal/server/server.go` (Seams struct ~line 57, BuildAPI wiring ~line 190-203)
+- Modify: `cmd/econumo/main.go` (`run`, ~line 206)
+- Modify: `internal/test/apiparity/catalogue.go` (read-scenario section, after `budget_reads` ~line 75)
+- Modify: `CLAUDE.md` (config var list; the two "nine features" mentions in the feature-packages section)
+- Generated: OpenAPI docs via `make swagger`; golden via `UPDATE_GOLDEN=1`
+
+**Interfaces:**
+- Consumes: `system.NewService/StartPolling/GetUpdateInfo`, `system.DefaultFeedURL` (Task 3); `cfg.CheckUpdates` (Task 2); `endpoint.HandleNoBody`, `middleware.Auth`, `router.RegisterAPI` (existing).
+- Produces: `GET /api/v1/system/get-update-info` (auth) → `data: {"version": "", "url": ""}` until the poller has data. Frontend Task 5 consumes this route. `server.Seams.Updates *system.Service` — nil (all tests) means a never-started, disabled service.
+
+- [ ] **Step 1: Handler package** — create `internal/system/api/handler.go`:
+
+```go
+// Package api wires the system module's HTTP edge.
+package api
+
+import (
+	appsystem "github.com/econumo/econumo/internal/system"
+	"github.com/econumo/econumo/internal/web/apidoc"
+)
+
+// _ keeps the apidoc import alias visible to swag's annotation parser.
+var _ = apidoc.JsonResponseOk{}
+
+type Handlers struct {
+	svc *appsystem.Service
+	dev bool
+}
+
+func NewHandlers(svc *appsystem.Service, dev bool) *Handlers {
+	return &Handlers{svc: svc, dev: dev}
+}
+```
+
+- [ ] **Step 2: Endpoint** — create `internal/system/api/system.go`:
+
+```go
+package api
+
+import (
+	"net/http"
+
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/web/apidoc"
+	"github.com/econumo/econumo/internal/web/endpoint"
+)
+
+// _ keeps the apidoc and model import aliases visible to swag's annotation
+// parser (a type reference's leading identifier must resolve to an import alias).
+var (
+	_ = apidoc.JsonResponseError{}
+	_ = model.GetUpdateInfoResult{}
+)
+
+// GetUpdateInfo handles GET /api/v1/system/get-update-info (auth). No request
+// body; returns the latest release published on econumo.com, or empty strings
+// when unknown (update checks disabled or the feed not fetched yet).
+//
+// @Summary     Get the latest published release
+// @Description Returns the latest Econumo release published on econumo.com (version + release-page URL), or empty strings when unknown. The client compares against its own version.
+// @Tags        System
+// @Produce     json
+// @Success     200 {object} apidoc.JsonResponseOk{data=model.GetUpdateInfoResult}
+// @Failure     401 {object} apidoc.JsonResponseUnauthorized
+// @Failure     500 {object} apidoc.JsonResponseException
+// @Security    Bearer
+// @Router      /api/v1/system/get-update-info [get]
+func (h *Handlers) GetUpdateInfo(w http.ResponseWriter, r *http.Request) {
+	endpoint.HandleNoBody(w, r, h.dev, h.svc.GetUpdateInfo)
+}
+```
+
+- [ ] **Step 3: Routes** — create `internal/system/api/routes.go` (the apiparity guard's `internal/*/api/routes.go` glob picks this up automatically):
+
+```go
+package api
+
+import (
+	"net/http"
+
+	"github.com/econumo/econumo/internal/web/middleware"
+	"github.com/econumo/econumo/internal/web/router"
+)
+
+func RegisterAPI(h *Handlers, authn middleware.TokenAuthenticator, dev bool) router.RegisterAPI {
+	return func(mux *http.ServeMux) {
+		authMw := middleware.Auth(authn, dev)
+		auth := func(fn http.HandlerFunc) http.Handler { return authMw(fn) }
+
+		mux.Handle("GET /api/v1/system/get-update-info", auth(h.GetUpdateInfo))
+	}
+}
+```
+
+- [ ] **Step 4: Wire into BuildAPI** — in `internal/server/server.go`:
+
+Add imports (alphabetical among the app imports):
+
+```go
+	appsystem "github.com/econumo/econumo/internal/system"
+	handlersystem "github.com/econumo/econumo/internal/system/api"
+```
+
+Extend `Seams` (the comment explains why it lives here):
+
+```go
+type Seams struct {
+	Clock   port.Clock
+	Avatars appuser.AvatarPicker
+	// Updates is the release-check service. serve constructs an enabled one and
+	// starts its poller; nil (every test and CLI path) wires a disabled service
+	// that never polls, keeping responses deterministic and hermetic.
+	Updates *appsystem.Service
+}
+```
+
+In `BuildAPI`, next to the other handler constructions (after the `currencyHandlers` block, ~line 135):
+
+```go
+	updates := seams.Updates
+	if updates == nil {
+		updates = appsystem.NewService(false, appsystem.DefaultFeedURL)
+	}
+	systemHandlers := handlersystem.NewHandlers(updates, cfg.IsDev())
+```
+
+Register in `router.Compose(...)`, after `handlerbudget.RegisterAPI(...)`:
+
+```go
+		handlersystem.RegisterAPI(systemHandlers, userSvc, cfg.IsDev()),
+```
+
+- [ ] **Step 5: Start polling in serve** — in `cmd/econumo/main.go` `run()`, replace
+
+```go
+	handler := server.BuildAPI(cfg, db, server.Seams{})
+```
+
+with
+
+```go
+	updates := system.NewService(cfg.CheckUpdates, system.DefaultFeedURL)
+	handler := server.BuildAPI(cfg, db, server.Seams{Updates: updates})
+	updates.StartPolling(ctx)
+```
+
+and add the import `"github.com/econumo/econumo/internal/system"`.
+
+- [ ] **Step 6: apiparity scenario** — in `internal/test/apiparity/catalogue.go`, after the `budget_reads` registration:
+
+```go
+	register(Scenario{Name: "system_reads", Calls: func() []Call {
+		return []Call{
+			{Label: "get-update-info", Method: "GET", Path: "/api/v1/system/get-update-info", Auth: "owner", Body: map[string]any{}},
+		}
+	}})
+```
+
+- [ ] **Step 7: Regenerate swagger docs and the golden**
+
+```bash
+make swagger
+UPDATE_GOLDEN=1 go test ./internal/test/apiparity/
+git diff --stat internal/test/apiparity/testdata/
+```
+
+Expected: exactly ONE new golden file (`system_reads` scenario, body `{"success":true,"message":"","data":{"version":"","url":""}}`) and zero changes to existing goldens. Any changed existing golden means observable behavior changed — stop and investigate.
+
+- [ ] **Step 8: Full backend gate**
+
+Run: `make go-test`
+Expected: PASS (build, vet, gofmt, docs-fresh, tests, coverage gate, i18ntest, apiparity guards).
+
+- [ ] **Step 9: Update CLAUDE.md** — in the config section add one line:
+
+```
+- `ECONUMO_CHECK_UPDATES` — daily check for new releases against `econumo.com/releases/latest.json` (single server-side request; result served to the SPA via `get-update-info`). `false` disables it.
+```
+
+and update the feature-package enumeration: "nine features" → "ten features", adding `system` to the alphabetical list (`account`, `budget`, `category`, `connection`, `currency`, `payee`, `system`, `tag`, `transaction`, `user`); note `system` has no `repository.go` (in-memory state only, like `currency` has no per-user persistence).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/system/api/ internal/server/server.go cmd/econumo/main.go internal/test/apiparity/ internal/web/apidoc/ CLAUDE.md
+git commit -m "feat(system): get-update-info endpoint + serve-time release poller"
+```
+
+(If `make swagger` writes docs elsewhere — check `git status` — add those paths too.)
+
+---
+
+### Task 5: Frontend — version helper, API client, hook
+
+**Files:**
+- Create: `web/src/lib/version.ts`
+- Create: `web/src/lib/version.test.ts`
+- Create: `web/src/api/dto/system.ts`
+- Create: `web/src/api/system.ts`
+- Create: `web/src/hooks/useAvailableUpdate.ts`
+- Modify: `web/src/app/queryKeys.ts` (add key)
+- Modify: `web/src/features/settings/SettingsPage.tsx:20` (delete local `SEMVER`, import from lib)
+
+**Interfaces:**
+- Consumes: `GET /api/v1/system/get-update-info` (Task 4); `getVersion()` from `@/lib/config`; `api`, `apiUrl` from `@/api/client`.
+- Produces (Task 6 relies on these):
+  - `SEMVER: RegExp` and `isNewerVersion(latest: string, current: string): boolean` from `@/lib/version`
+  - `getDismissedUpdateVersion(): string | null` / `setDismissedUpdateVersion(version: string): void` from `@/lib/version`
+  - `useAvailableUpdate(): { version: string; url: string } | null` from `@/hooks/useAvailableUpdate`
+
+- [ ] **Step 1: Write the failing test** — create `web/src/lib/version.test.ts`:
+
+```ts
+import { isNewerVersion } from './version'
+
+it.each([
+  ['v1.0.2', 'v1.0.1', true],
+  ['v1.1.0', 'v1.0.9', true],
+  ['v2.0.0', 'v1.9.9', true],
+  ['v1.0.2', 'v1.0.2', false],
+  ['v1.0.1', 'v1.0.2', false],
+  ['v1.0.10', 'v1.0.9', true],
+  ['v1.0.2', 'dev', false],
+  ['dev', 'v1.0.2', false],
+  ['', 'v1.0.2', false],
+  ['v1.0.2', '', false],
+  ['1.0.3', 'v1.0.2', false],
+])('isNewerVersion(%s, %s) -> %s', (latest, current, expected) => {
+  expect(isNewerVersion(latest, current)).toBe(expected)
+})
+
+it('dismissed-update version round-trips through localStorage', async () => {
+  const { getDismissedUpdateVersion, setDismissedUpdateVersion } = await import('./version')
+  localStorage.removeItem('econumo.dismissed-update-version')
+  expect(getDismissedUpdateVersion()).toBeNull()
+  setDismissedUpdateVersion('v1.0.2')
+  expect(getDismissedUpdateVersion()).toBe('v1.0.2')
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cd web && pnpm vitest run src/lib/version.test.ts`
+Expected: module `./version` not found.
+
+- [ ] **Step 3: Implement** — create `web/src/lib/version.ts`:
+
+```ts
+export const SEMVER = /^v(\d+)\.(\d+)\.(\d+)$/
+
+// True only when BOTH strings are strict vX.Y.Z and latest > current — so a
+// `dev` image, an empty feed, or a custom build tag can never trigger the
+// update surfaces.
+export function isNewerVersion(latest: string, current: string): boolean {
+  const l = SEMVER.exec(latest)
+  const c = SEMVER.exec(current)
+  if (!l || !c) {
+    return false
+  }
+  for (let i = 1; i <= 3; i++) {
+    const d = Number(l[i]) - Number(c[i])
+    if (d !== 0) {
+      return d > 0
+    }
+  }
+  return false
+}
+
+const DISMISSED_KEY = 'econumo.dismissed-update-version'
+
+export function getDismissedUpdateVersion(): string | null {
+  return localStorage.getItem(DISMISSED_KEY)
+}
+
+export function setDismissedUpdateVersion(version: string): void {
+  localStorage.setItem(DISMISSED_KEY, version)
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `cd web && pnpm vitest run src/lib/version.test.ts`
+
+- [ ] **Step 5: Deduplicate SEMVER** — in `web/src/features/settings/SettingsPage.tsx` delete line 20 (`const SEMVER = /^v\d+\.\d+\.\d+$/`) and add to the imports:
+
+```ts
+import { SEMVER } from '@/lib/version'
+```
+
+- [ ] **Step 6: API client + hook**
+
+Create `web/src/api/dto/system.ts`:
+
+```ts
+export interface UpdateInfoDto {
+  version: string
+  url: string
+}
+```
+
+Create `web/src/api/system.ts` (same envelope pattern as `currency.ts`):
+
+```ts
+import { api, apiUrl } from './client'
+import type { UpdateInfoDto } from './dto/system'
+
+interface Envelope<T> {
+  data: T
+}
+
+export async function getUpdateInfo(): Promise<UpdateInfoDto> {
+  const response = await api.get<Envelope<UpdateInfoDto>>(apiUrl('/api/v1/system/get-update-info'))
+  return response.data.data
+}
+```
+
+In `web/src/app/queryKeys.ts` add to `queryKeys`:
+
+```ts
+  updateInfo: ['updateInfo'] as const,
+```
+
+Create `web/src/hooks/useAvailableUpdate.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query'
+import { getUpdateInfo } from '@/api/system'
+import { ONE_DAY, queryKeys } from '@/app/queryKeys'
+import { getVersion } from '@/lib/config'
+import { isNewerVersion } from '@/lib/version'
+
+export interface AvailableUpdate {
+  version: string
+  url: string
+}
+
+// The latest published release when it is strictly newer than this build;
+// null otherwise (current, dev build, check disabled, or feed unavailable).
+export function useAvailableUpdate(): AvailableUpdate | null {
+  const { data } = useQuery({
+    queryKey: queryKeys.updateInfo,
+    queryFn: getUpdateInfo,
+    staleTime: ONE_DAY,
+    refetchOnWindowFocus: false,
+  })
+  if (!data || !isNewerVersion(data.version, getVersion())) {
+    return null
+  }
+  return { version: data.version, url: data.url }
+}
+```
+
+- [ ] **Step 7: Type-check and full web tests**
+
+Run: `cd web && pnpm exec tsc -b && pnpm test`
+Expected: tsc clean; tests pass (ImportCsvDialog failure is pre-existing, ignore).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/lib/version.ts web/src/lib/version.test.ts web/src/api/dto/system.ts web/src/api/system.ts web/src/hooks/useAvailableUpdate.ts web/src/app/queryKeys.ts web/src/features/settings/SettingsPage.tsx
+git commit -m "feat(web): update-info client, semver compare, useAvailableUpdate hook"
+```
+
+---
+
+### Task 6: Frontend — the three surfaces + i18n
+
+**Files:**
+- Create: `web/src/components/UpdateNotice.tsx`
+- Create: `web/src/components/UpdateNotice.test.tsx`
+- Modify: `web/src/app/layouts/ApplicationLayout.tsx` (both footers, ~lines 177-217)
+- Modify: `web/src/features/settings/SettingsPage.tsx` (footer area, ~line 105)
+- Modify: `locales/en.json`, `locales/ru.json`
+
+**Interfaces:**
+- Consumes: `useAvailableUpdate`, `getDismissedUpdateVersion`/`setDismissedUpdateVersion` (Task 5).
+- Produces: i18n keys `common.update.notice` (`{version}`), `common.update.dismiss`, `settings.update.available` (`{version}`).
+
+- [ ] **Step 1: i18n keys**
+
+In `locales/en.json`, inside the `common` object add:
+
+```json
+"update": {
+  "notice": "Econumo {version} is out",
+  "dismiss": "Dismiss"
+}
+```
+
+Inside the `settings` object add:
+
+```json
+"update": {
+  "available": "New version {version} available"
+}
+```
+
+In `locales/ru.json`, same paths:
+
+```json
+"update": {
+  "notice": "Вышла Econumo {version}",
+  "dismiss": "Скрыть"
+}
+```
+
+```json
+"update": {
+  "available": "Доступна новая версия {version}"
+}
+```
+
+- [ ] **Step 2: Write the failing component test** — create `web/src/components/UpdateNotice.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { AvailableUpdate } from '@/hooks/useAvailableUpdate'
+import { UpdateNotice } from './UpdateNotice'
+
+const mockUpdate = vi.hoisted(() => ({ value: null as AvailableUpdate | null }))
+vi.mock('@/hooks/useAvailableUpdate', () => ({
+  useAvailableUpdate: () => mockUpdate.value,
+}))
+
+beforeEach(() => {
+  localStorage.removeItem('econumo.dismissed-update-version')
+  mockUpdate.value = { version: 'v9.9.9', url: 'https://econumo.com/releases/v9.9.9/' }
+})
+
+it('renders the release link when an update is available', () => {
+  render(<UpdateNotice />)
+  const link = screen.getByRole('link', { name: /v9\.9\.9/ })
+  expect(link).toHaveAttribute('href', 'https://econumo.com/releases/v9.9.9/')
+  expect(link).toHaveAttribute('target', '_blank')
+})
+
+it('renders nothing when no update is available', () => {
+  mockUpdate.value = null
+  const { container } = render(<UpdateNotice />)
+  expect(container).toBeEmptyDOMElement()
+})
+
+it('dismisses per version and stays hidden', async () => {
+  const user = userEvent.setup()
+  render(<UpdateNotice />)
+  await user.click(screen.getByRole('button', { name: /dismiss/i }))
+  expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  expect(localStorage.getItem('econumo.dismissed-update-version')).toBe('v9.9.9')
+})
+
+it('reappears for a newer version after a dismissal', () => {
+  localStorage.setItem('econumo.dismissed-update-version', 'v9.9.8')
+  render(<UpdateNotice />)
+  expect(screen.getByRole('link', { name: /v9\.9\.9/ })).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 3: Run — expect FAIL**
+
+Run: `cd web && pnpm vitest run src/components/UpdateNotice.test.tsx`
+Expected: `./UpdateNotice` not found.
+
+- [ ] **Step 4: Implement** — create `web/src/components/UpdateNotice.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'
+import { getDismissedUpdateVersion, setDismissedUpdateVersion } from '@/lib/version'
+
+export function UpdateNotice() {
+  const { t } = useTranslation()
+  const update = useAvailableUpdate()
+  const [dismissed, setDismissed] = useState<string | null>(getDismissedUpdateVersion)
+  if (!update || dismissed === update.version) {
+    return null
+  }
+  return (
+    <div className="mx-3 mb-2 flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-xs text-muted-foreground">
+      <a
+        href={update.url}
+        target="_blank"
+        rel="noreferrer"
+        className="min-w-0 flex-1 truncate font-medium hover:text-foreground"
+      >
+        {t('common.update.notice', { version: update.version })}
+      </a>
+      <button
+        type="button"
+        aria-label={t('common.update.dismiss')}
+        className="shrink-0 hover:text-foreground"
+        onClick={() => {
+          setDismissedUpdateVersion(update.version)
+          setDismissed(update.version)
+        }}
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+Run: `cd web && pnpm vitest run src/components/UpdateNotice.test.tsx`
+
+- [ ] **Step 6: Mount in `ApplicationLayout.tsx`**
+
+Add imports:
+
+```tsx
+import { UpdateNotice } from '@/components/UpdateNotice'
+import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'
+```
+
+In the component body (near the other hooks, ~line 104): `const update = useAvailableUpdate()`.
+
+**Rail footer** (~line 179): wrap the Settings link contents with a dot —
+
+```tsx
+              <Link
+                to={RouterPage.SETTINGS}
+                title={t('settings.page.menu_item')}
+                className="relative text-muted-foreground hover:text-foreground"
+              >
+                <Settings className="size-5" />
+                {update ? (
+                  <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary" data-testid="update-dot" />
+                ) : null}
+              </Link>
+```
+
+**Full footer** (~line 203): the Settings text link gets the dot —
+
+```tsx
+                <Link to={RouterPage.SETTINGS} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+                  {t('settings.page.menu_item')}
+                  {update ? <span className="size-1.5 rounded-full bg-primary" data-testid="update-dot" /> : null}
+                </Link>
+```
+
+**Notice placement**: immediately BEFORE the `{rail ? (` footer conditional (~line 177), so it sits above the footer in both compact and full desktop modes but not in the icon rail:
+
+```tsx
+          {!rail ? <UpdateNotice /> : null}
+```
+
+- [ ] **Step 7: Settings page row** — in `web/src/features/settings/SettingsPage.tsx`:
+
+Add imports: `import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'` and in the body `const update = useAvailableUpdate()`.
+
+Directly above the `<footer ...>` element add:
+
+```tsx
+      {update ? (
+        <a
+          href={update.url}
+          target="_blank"
+          rel="noreferrer"
+          className="mx-auto pb-1 text-xs font-medium text-primary hover:underline"
+        >
+          {t('settings.update.available', { version: update.version })} →
+        </a>
+      ) : null}
+```
+
+- [ ] **Step 8: Verify everything**
+
+```bash
+cd web && pnpm exec tsc -b && pnpm lint && pnpm test
+cd .. && make go-test
+```
+
+Expected: all green (`make go-test` includes the i18ntest guards that check the new keys' en/ru + placeholder parity and t()-coverage; ImportCsvDialog failure is pre-existing).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/components/UpdateNotice.tsx web/src/components/UpdateNotice.test.tsx web/src/app/layouts/ApplicationLayout.tsx web/src/features/settings/SettingsPage.tsx locales/en.json locales/ru.json
+git commit -m "feat(web): release-update surfaces — sidebar notice, settings badge and row"
+```
+
+---
+
+### Task 7: End-to-end verification and PR
+
+- [ ] **Step 1: Full suite**
+
+Run: `make test` (needs the compose PostgreSQL; if unavailable, `make go-test` + `make web-test` and say so in the PR).
+
+- [ ] **Step 2: Live check** — run the app and verify the flow end-to-end (use the `verify`/`run` skill flow): start the server with a stub feed to see the surfaces.
+
+```bash
+# Terminal A: a stub feed
+python3 -c "
+import http.server, json
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps({'version': 'v99.0.0', 'date': '2026-07-17', 'url': 'https://econumo.com/releases/v99.0.0/'}).encode()
+        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
+        self.wfile.write(body)
+http.server.HTTPServer(('127.0.0.1', 9999), H).serve_forever()
+"
+```
+
+Point the poller at it for the manual run ONLY by temporarily editing `DefaultFeedURL` (do not commit) — or verify against the real feed once the website PR from Task 1 is merged. Confirm: `GET /api/v1/system/get-update-info` returns the version; the SPA (`make web-run` against `make go-run`) shows the sidebar notice, the settings dot, and the Settings row; dismissing the notice hides it; the dot survives. Revert any temporary edit (`git diff` must be clean except committed work).
+
+- [ ] **Step 3: Branch + PR** (superpowers:finishing-a-development-branch)
+
+```bash
+git branch -m feat/release-notifications
+git push -u origin feat/release-notifications
+gh pr create --title "feat: new-release notifications" --body "..."
+```
+
+PR body: summary of the three surfaces, the endpoint, `ECONUMO_CHECK_UPDATES`, the feed contract, a link to the econumo/website PR from Task 1, and the spec path.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: feed (Task 1), opt-out config (2), poller+validation+cache (3), endpoint+wiring+goldens+docs (4), comparison+hook (5), three surfaces+i18n (6), rollout order (1 before 7). ✔
+- Golden expectation: exactly one new file, zero changed — matches the spec's "additive only". ✔
+- Type consistency: `GetUpdateInfoResult{Version,Url}` ↔ `{"version","url"}` ↔ `UpdateInfoDto` ↔ `AvailableUpdate` verified across Tasks 3-6. ✔

--- a/docs/superpowers/specs/2026-07-17-release-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-notifications-design.md
@@ -122,9 +122,10 @@ DTOs live in `internal/model/system_dto.go`; routes in
    with a close button. Dismissal stores the version in `localStorage`
    (`econumo.dismissed-update-version`); the notice stays hidden for that
    version and reappears for the next one.
-3. **Settings page row** — next to the existing version label in the
-   `SettingsPage` footer area: a highlighted "New version v1.0.2 available →"
-   link to the release URL. Persistent, not dismissible.
+3. **Settings page row** — a primary-tinted card row at the top of the
+   `SettingsPage` menu (between the user card and the "Finances" group):
+   "New version v1.0.2 available", linking to the release URL (new tab).
+   Persistent, not dismissible.
 
 ### i18n
 

--- a/docs/superpowers/specs/2026-07-17-release-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-notifications-design.md
@@ -1,0 +1,149 @@
+# Release Notifications — Design
+
+**Date:** 2026-07-17
+**Status:** Approved
+
+## Overview
+
+Notify users of a self-hosted Econumo instance when a new release is available,
+linking to the release page on the main website (`https://econumo.com/releases/<version>/`),
+not GitHub.
+
+Architecture (approved as "Approach A"): the website publishes a machine-readable
+"latest release" JSON feed; the Go backend polls it and caches the result in
+memory; the SPA reads the cached info through a small authenticated API endpoint,
+compares against its own build version, and renders the notification surfaces.
+
+Why backend-proxied rather than browser-direct: one phone-home per instance
+(server → econumo.com) instead of one per browser — no per-user IP leakage —
+and the env opt-out works naturally because the backend owns the check. The SPA
+does the version comparison, so the Go binary never needs to know its own
+version (today only the SPA has one, Vite-inlined at image build).
+
+## Decisions
+
+- **Audience:** all users of the instance see the notification.
+- **Opt-out:** `ECONUMO_CHECK_UPDATES` (default `true`); `false` disables
+  polling entirely — standard self-hosted etiquette.
+- **Data source:** a new JSON feed on the website (`econumo/website` repo,
+  Astro on GitHub Pages). GitHub Pages already serves everything with
+  `Access-Control-Allow-Origin: *` and CDN caching.
+- **`dev` / non-semver builds:** never show anything. A `dev` image is
+  typically ahead of the latest tagged release, and there is no meaningful
+  ordering between `dev` and a semver. The backend still polls; the SPA
+  simply ignores the data until it runs a tagged build.
+- **Failure is silence:** feed unreachable, invalid payload, check disabled,
+  dev build, SPA query error — all render exactly nothing. No error states,
+  no retry UI.
+
+## Part 1 — Website: the release feed (`econumo/website` repo)
+
+New Astro endpoint `src/pages/releases/latest.json.ts` (same pattern as the
+existing `search-data.json.ts`), served at
+`https://econumo.com/releases/latest.json`:
+
+```json
+{ "version": "v1.0.2", "date": "2026-07-16", "url": "https://econumo.com/releases/v1.0.2/" }
+```
+
+Generated at build time from the releases content collection — newest by
+semver. No other website changes. **Ships first**; the app feature is inert
+without it.
+
+## Part 2 — Backend: poller + API endpoint
+
+New feature package `internal/system` (auto-covered by archtest; imports only
+`model`/`shared`/`web` — no sibling features).
+
+### Service
+
+`system.Service` holds the latest-release info in memory (mutex-guarded):
+
+- **Poller** — `StartPolling(ctx)`, launched from the `serve` command only
+  (the first in-process background job; CLI commands and tests never start it,
+  so test responses stay deterministic). Fetches the feed on boot, then every
+  24 h, with a 10 s HTTP timeout. A failed or invalid fetch logs at DEBUG and
+  keeps the previous value.
+- **Read use case** — returns the cached info; empty when disabled, never
+  fetched, or nothing valid received yet.
+
+### Feed validation (trust boundary)
+
+The feed is remote input rendered as a trusted link in every instance's UI.
+A payload is accepted only if:
+
+- `version` matches `^v\d+\.\d+\.\d+$`, and
+- `url` starts with `https://econumo.com/`.
+
+Anything else is dropped (previous value retained). This prevents a
+compromised feed from injecting an arbitrary phishing URL as an "update" link.
+
+### Endpoint
+
+`GET /api/v1/system/get-update-info` — authenticated, standard success
+envelope:
+
+```json
+{ "success": true, "message": "", "data": { "version": "v1.0.2", "url": "https://econumo.com/releases/v1.0.2/" } }
+```
+
+`version` and `url` are empty strings when nothing is known. Request/result
+DTOs live in `internal/model/system_dto.go`; routes in
+`internal/system/api/routes.go` per the standard handler pattern.
+
+### Config
+
+- `ECONUMO_CHECK_UPDATES` — bool, default `true`; parsed in `config.Load`
+  (malformed value fails at boot, consistent with other config).
+- The feed URL is a constant; tests override it via the service constructor
+  (no env knob).
+
+## Part 3 — Frontend: query, comparison, surfaces
+
+### Data
+
+- `web/src/api/system.ts` — typed client for `get-update-info`.
+- `useUpdateInfo` TanStack Query hook — fetched once per session (long
+  `staleTime`, no window-focus refetch).
+- `isNewerVersion(latest, current)` — pure helper; returns `true` only when
+  **both** strings match the existing `SEMVER` pattern and `latest` is
+  semver-greater than `current`. `dev`, empty strings, and malformed input
+  all yield `false`.
+
+### Surfaces (all driven by the same hook)
+
+1. **Settings gear badge** — a small dot on the Settings gear in the sidebar
+   footer (`ApplicationLayout`), visible on desktop and on mobile home.
+   Persistent while an update is pending; not dismissible.
+2. **Sidebar notice (dismissible)** — a compact one-liner above the sidebar
+   footer: "Econumo v1.0.2 is out", linking to the release URL (new tab),
+   with a close button. Dismissal stores the version in `localStorage`
+   (`econumo.dismissed-update-version`); the notice stays hidden for that
+   version and reappears for the next one.
+3. **Settings page row** — next to the existing version label in the
+   `SettingsPage` footer area: a highlighted "New version v1.0.2 available →"
+   link to the release URL. Persistent, not dismissible.
+
+### i18n
+
+New keys in `locales/{en,ru}.json` (e.g. `settings.update.available` with a
+`{version}` placeholder). The i18ntest guards enforce en/ru key parity,
+placeholder parity, and `t()`-call coverage automatically.
+
+## Testing
+
+- **Go:** unit tests for the poller against an `httptest` feed (valid,
+  malformed JSON, bad version format, wrong-origin URL, non-2xx); handler
+  test; apiparity scenario + golden for the new route (deterministic empty
+  response, since tests never start the poller); `make go-test` green.
+- **Web:** vitest for `isNewerVersion` and the dismissal logic; component
+  tests for the three surfaces (shown when newer, hidden when current / dev /
+  dismissed); `pnpm exec tsc -b` must pass.
+- **Website:** build the site and verify the generated
+  `releases/latest.json` output.
+
+## Rollout order
+
+1. `econumo/website`: add and deploy the feed.
+2. This repo: backend package + endpoint, then frontend surfaces (one branch,
+   one PR).

--- a/docs/superpowers/specs/2026-07-17-release-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-notifications-design.md
@@ -93,8 +93,10 @@ DTOs live in `internal/model/system_dto.go`; routes in
 
 ### Config
 
-- `ECONUMO_CHECK_UPDATES` — bool, default `true`; parsed in `config.Load`
-  (malformed value fails at boot, consistent with other config).
+- `ECONUMO_CHECK_UPDATES` — bool, default `true`; parsed in `config.Load` via
+  the repo's lenient `getBool` (malformed values fall back to the default
+  `true`, consistent with `ECONUMO_DEBUG` / `ECONUMO_ALLOW_REGISTRATION` and
+  the repo's other boolean flags — it does not fail at boot).
 - The feed URL is a constant; tests override it via the service constructor
   (no env knob).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	AllowRegistration bool
 	DataSalt          string // ECONUMO_DATA_SALT. DEPRECATED and IGNORED by the API/repositories (they run salt-free); consumed only by the data:remove-salt migration to decrypt existing data. Unset it after migrating.
 	SQLiteBusyTimeout int
+	CheckUpdates      bool // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
 
 	// Auth brute-force protection (see the 2026-07-09 auth-rate-limiting spec).
 	// Counts are attempts per key per RateLimitWindow; 0 disables a check.
@@ -69,6 +70,7 @@ func Load() (Config, error) {
 		MailerDSN:              os.Getenv("MAILER_DSN"),
 		DataSalt:               os.Getenv("ECONUMO_DATA_SALT"),
 		SQLiteBusyTimeout:      getInt("SQLITE_BUSY_TIMEOUT", 0),
+		CheckUpdates:           getBool("ECONUMO_CHECK_UPDATES", true),
 		Port:                   os.Getenv("PORT"),
 		CORSAllowedOrigins:     getStringList("ECONUMO_CORS_ALLOW_ORIGIN", nil),
 		LogLevel:               getEnv("ECONUMO_LOG_LEVEL", "info"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -198,3 +198,22 @@ func TestLoadLogLevel(t *testing.T) {
 		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, "debug")
 	}
 }
+
+func TestLoad_CheckUpdates(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+	c, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.CheckUpdates {
+		t.Fatal("CheckUpdates default = false, want true")
+	}
+	t.Setenv("ECONUMO_CHECK_UPDATES", "false")
+	c, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.CheckUpdates {
+		t.Fatal("CheckUpdates with ECONUMO_CHECK_UPDATES=false = true, want false")
+	}
+}

--- a/internal/model/system_dto.go
+++ b/internal/model/system_dto.go
@@ -1,0 +1,11 @@
+// Result DTO for the system read endpoint (get-update-info).
+package model
+
+// GetUpdateInfoResult is the get-update-info response: the latest release
+// published on econumo.com, or empty strings when unknown (check disabled,
+// not fetched yet, or the feed unreachable). The SPA compares version against
+// its own build version; the server never does.
+type GetUpdateInfoResult struct {
+	Version string `json:"version"`
+	Url     string `json:"url"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,8 @@ import (
 	handlerpayee "github.com/econumo/econumo/internal/payee/api"
 	payeerepo "github.com/econumo/econumo/internal/payee/repo"
 	"github.com/econumo/econumo/internal/shared/port"
+	appsystem "github.com/econumo/econumo/internal/system"
+	handlersystem "github.com/econumo/econumo/internal/system/api"
 	apptag "github.com/econumo/econumo/internal/tag"
 	handlertag "github.com/econumo/econumo/internal/tag/api"
 	tagrepo "github.com/econumo/econumo/internal/tag/repo"
@@ -57,6 +59,10 @@ import (
 type Seams struct {
 	Clock   port.Clock
 	Avatars appuser.AvatarPicker
+	// Updates is the release-check service. serve constructs an enabled one and
+	// starts its poller; nil (every test and CLI path) wires a disabled service
+	// that never polls, keeping responses deterministic and hermetic.
+	Updates *appsystem.Service
 }
 
 // BuildAPI wires every resource module over the given (already opened+migrated)
@@ -134,6 +140,12 @@ func BuildAPI(cfg config.Config, db *sql.DB, seams Seams) http.Handler {
 	currencyReadSvc := appcurrency.NewReadService(currencyReadRepo)
 	currencyHandlers := handlercurrency.NewHandlers(currencyReadSvc, cfg.IsDev())
 
+	updates := seams.Updates
+	if updates == nil {
+		updates = appsystem.NewService(false, appsystem.DefaultFeedURL)
+	}
+	systemHandlers := handlersystem.NewHandlers(updates, cfg.IsDev())
+
 	// Connection service is built first: the account result embeds sharedAccess[]
 	// and delete-account revokes the caller's own access.
 	accountRepo := accountrepo.NewRepo(cfg.DatabaseDriver, txm)
@@ -199,6 +211,7 @@ func BuildAPI(cfg config.Config, db *sql.DB, seams Seams) http.Handler {
 		handlertransaction.RegisterAPI(transactionHandlers, userSvc, cfg.IsDev()),
 		handlerconnection.RegisterAPI(connectionHandlers, userSvc, cfg.IsDev()),
 		handlerbudget.RegisterAPI(budgetHandlers, userSvc, cfg.IsDev()),
+		handlersystem.RegisterAPI(systemHandlers, userSvc, cfg.IsDev()),
 		apidoc.RegisterAPI(),
 	)
 

--- a/internal/system/api/handler.go
+++ b/internal/system/api/handler.go
@@ -1,0 +1,19 @@
+// Package api wires the system module's HTTP edge.
+package api
+
+import (
+	appsystem "github.com/econumo/econumo/internal/system"
+	"github.com/econumo/econumo/internal/web/apidoc"
+)
+
+// _ keeps the apidoc import alias visible to swag's annotation parser.
+var _ = apidoc.JsonResponseOk{}
+
+type Handlers struct {
+	svc *appsystem.Service
+	dev bool
+}
+
+func NewHandlers(svc *appsystem.Service, dev bool) *Handlers {
+	return &Handlers{svc: svc, dev: dev}
+}

--- a/internal/system/api/routes.go
+++ b/internal/system/api/routes.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/econumo/econumo/internal/web/middleware"
+	"github.com/econumo/econumo/internal/web/router"
+)
+
+func RegisterAPI(h *Handlers, authn middleware.TokenAuthenticator, dev bool) router.RegisterAPI {
+	return func(mux *http.ServeMux) {
+		authMw := middleware.Auth(authn, dev)
+		auth := func(fn http.HandlerFunc) http.Handler { return authMw(fn) }
+
+		mux.Handle("GET /api/v1/system/get-update-info", auth(h.GetUpdateInfo))
+	}
+}

--- a/internal/system/api/system.go
+++ b/internal/system/api/system.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/web/apidoc"
+	"github.com/econumo/econumo/internal/web/endpoint"
+)
+
+// _ keeps the apidoc and model import aliases visible to swag's annotation
+// parser (a type reference's leading identifier must resolve to an import alias).
+var (
+	_ = apidoc.JsonResponseError{}
+	_ = model.GetUpdateInfoResult{}
+)
+
+// GetUpdateInfo handles GET /api/v1/system/get-update-info (auth). No request
+// body; returns the latest release published on econumo.com, or empty strings
+// when unknown (update checks disabled or the feed not fetched yet).
+//
+// @Summary     Get the latest published release
+// @Description Returns the latest Econumo release published on econumo.com (version + release-page URL), or empty strings when unknown. The client compares against its own version.
+// @Tags        System
+// @Produce     json
+// @Success     200 {object} apidoc.JsonResponseOk{data=model.GetUpdateInfoResult}
+// @Failure     401 {object} apidoc.JsonResponseUnauthorized
+// @Failure     500 {object} apidoc.JsonResponseException
+// @Security    Bearer
+// @Router      /api/v1/system/get-update-info [get]
+func (h *Handlers) GetUpdateInfo(w http.ResponseWriter, r *http.Request) {
+	endpoint.HandleNoBody(w, r, h.dev, h.svc.GetUpdateInfo)
+}

--- a/internal/system/updates.go
+++ b/internal/system/updates.go
@@ -1,0 +1,115 @@
+// Package system reports instance-level information; currently the latest
+// published Econumo release, polled from the econumo.com feed.
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/shared/vo"
+)
+
+const DefaultFeedURL = "https://econumo.com/releases/latest.json"
+
+// The feed is remote input rendered as a trusted link in every instance's UI:
+// only well-formed versions and econumo.com URLs are ever accepted.
+const allowedURLPrefix = "https://econumo.com/"
+
+var versionPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+const pollInterval = 24 * time.Hour
+
+type Service struct {
+	enabled bool
+	feedURL string
+	client  *http.Client
+
+	mu   sync.RWMutex
+	info model.GetUpdateInfoResult
+}
+
+func NewService(enabled bool, feedURL string) *Service {
+	return &Service{
+		enabled: enabled,
+		feedURL: feedURL,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// GetUpdateInfo returns the cached latest-release info; empty strings when the
+// check is disabled, hasn't run yet, or nothing valid was ever received. The
+// SPA does the version comparison, so failure here is silence, never an error.
+func (s *Service) GetUpdateInfo(_ context.Context, _ vo.Id) (model.GetUpdateInfoResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.info, nil
+}
+
+// StartPolling launches the background feed poll (boot + every 24h). Only the
+// serve command calls this; CLI commands and tests never do, so their
+// responses stay deterministic and hermetic.
+func (s *Service) StartPolling(ctx context.Context) {
+	if !s.enabled {
+		return
+	}
+	go func() {
+		s.fetch(ctx)
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.fetch(ctx)
+			}
+		}
+	}()
+}
+
+func (s *Service) fetch(ctx context.Context) {
+	if err := s.fetchOnce(ctx); err != nil {
+		slog.Debug("release feed check failed", "err", err)
+	}
+}
+
+func (s *Service) fetchOnce(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.feedURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("feed returned status %d", resp.StatusCode)
+	}
+	var feed struct {
+		Version string `json:"version"`
+		Url     string `json:"url"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&feed); err != nil {
+		return err
+	}
+	if !versionPattern.MatchString(feed.Version) {
+		return fmt.Errorf("feed version %q is not vX.Y.Z", feed.Version)
+	}
+	if !strings.HasPrefix(feed.Url, allowedURLPrefix) {
+		return fmt.Errorf("feed url %q is outside %s", feed.Url, allowedURLPrefix)
+	}
+	s.mu.Lock()
+	s.info = model.GetUpdateInfoResult{Version: feed.Version, Url: feed.Url}
+	s.mu.Unlock()
+	return nil
+}

--- a/internal/system/updates_test.go
+++ b/internal/system/updates_test.go
@@ -1,0 +1,84 @@
+package system
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/econumo/econumo/internal/shared/vo"
+)
+
+func feedServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func info(t *testing.T, s *Service) (string, string) {
+	t.Helper()
+	res, err := s.GetUpdateInfo(context.Background(), vo.NewId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.Version, res.Url
+}
+
+func TestFetchValidPayload(t *testing.T) {
+	srv := feedServer(t, 200, `{"version":"v9.9.9","date":"2026-07-16","url":"https://econumo.com/releases/v9.9.9/"}`)
+	s := NewService(true, srv.URL)
+	s.fetch(context.Background())
+	v, u := info(t, s)
+	if v != "v9.9.9" || u != "https://econumo.com/releases/v9.9.9/" {
+		t.Fatalf("info = %q %q, want v9.9.9 + release url", v, u)
+	}
+}
+
+func TestFetchRejectsInvalidPayloads(t *testing.T) {
+	cases := map[string]struct {
+		status int
+		body   string
+	}{
+		"malformed json":   {200, `{"version": `},
+		"bad version":      {200, `{"version":"latest","url":"https://econumo.com/releases/latest/"}`},
+		"wrong url origin": {200, `{"version":"v9.9.9","url":"https://evil.example/phish/"}`},
+		"non-2xx":          {500, `{"version":"v9.9.9","url":"https://econumo.com/releases/v9.9.9/"}`},
+		"empty payload":    {200, `{}`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := feedServer(t, tc.status, tc.body)
+			s := NewService(true, srv.URL)
+			s.fetch(context.Background())
+			if v, u := info(t, s); v != "" || u != "" {
+				t.Fatalf("info = %q %q, want empty (payload must be dropped)", v, u)
+			}
+		})
+	}
+}
+
+func TestFetchFailureKeepsPreviousValue(t *testing.T) {
+	good := feedServer(t, 200, `{"version":"v9.9.9","url":"https://econumo.com/releases/v9.9.9/"}`)
+	s := NewService(true, good.URL)
+	s.fetch(context.Background())
+
+	bad := feedServer(t, 500, ``)
+	s.feedURL = bad.URL
+	s.fetch(context.Background())
+	if v, _ := info(t, s); v != "v9.9.9" {
+		t.Fatalf("version after failed refetch = %q, want v9.9.9 retained", v)
+	}
+}
+
+func TestStartPollingDisabledIsNoop(t *testing.T) {
+	srv := feedServer(t, 200, `{"version":"v9.9.9","url":"https://econumo.com/releases/v9.9.9/"}`)
+	s := NewService(false, srv.URL)
+	s.StartPolling(context.Background())
+	if v, _ := info(t, s); v != "" {
+		t.Fatalf("disabled service has version %q, want empty", v)
+	}
+}

--- a/internal/test/apiparity/catalogue.go
+++ b/internal/test/apiparity/catalogue.go
@@ -74,6 +74,12 @@ func init() {
 		}
 	}})
 
+	register(Scenario{Name: "system_reads", Calls: func() []Call {
+		return []Call{
+			{Label: "get-update-info", Method: "GET", Path: "/api/v1/system/get-update-info", Auth: "owner", Body: map[string]any{}},
+		}
+	}})
+
 	// ---- write -> read sequences (per mutating module) ----
 
 	register(Scenario{Name: "category_write_read", Calls: func() []Call {

--- a/internal/test/apiparity/testdata/golden/system_reads.golden
+++ b/internal/test/apiparity/testdata/golden/system_reads.golden
@@ -1,0 +1,3 @@
+== get-update-info GET /api/v1/system/get-update-info [owner] -> 200
+{"success":true,"message":"","data":{"version":"","url":""}}
+

--- a/internal/web/apidoc/docs/docs.go
+++ b/internal/web/apidoc/docs/docs.go
@@ -3457,6 +3457,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/system/get-update-info": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns the latest Econumo release published on econumo.com (version + release-page URL), or empty strings when unknown. The client compares against its own version.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Get the latest published release",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/apidoc.JsonResponseOk"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.GetUpdateInfoResult"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/tag/archive-tag": {
             "post": {
                 "security": [
@@ -6886,6 +6935,17 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.TransactionResult"
                     }
+                }
+            }
+        },
+        "model.GetUpdateInfoResult": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/web/apidoc/docs/swagger.json
+++ b/internal/web/apidoc/docs/swagger.json
@@ -3450,6 +3450,55 @@
                 }
             }
         },
+        "/api/v1/system/get-update-info": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns the latest Econumo release published on econumo.com (version + release-page URL), or empty strings when unknown. The client compares against its own version.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Get the latest published release",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/apidoc.JsonResponseOk"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/model.GetUpdateInfoResult"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/tag/archive-tag": {
             "post": {
                 "security": [
@@ -6879,6 +6928,17 @@
                     "items": {
                         "$ref": "#/definitions/model.TransactionResult"
                     }
+                }
+            }
+        },
+        "model.GetUpdateInfoResult": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/web/apidoc/docs/swagger.yaml
+++ b/internal/web/apidoc/docs/swagger.yaml
@@ -793,6 +793,13 @@ definitions:
           $ref: '#/definitions/model.TransactionResult'
         type: array
     type: object
+  model.GetUpdateInfoResult:
+    properties:
+      url:
+        type: string
+      version:
+        type: string
+    type: object
   model.GetUserDataResult:
     properties:
       user:
@@ -3563,6 +3570,36 @@ paths:
       summary: Update a payee
       tags:
       - Payee
+  /api/v1/system/get-update-info:
+    get:
+      description: Returns the latest Econumo release published on econumo.com (version
+        + release-page URL), or empty strings when unknown. The client compares against
+        its own version.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/apidoc.JsonResponseOk'
+            - properties:
+                data:
+                  $ref: '#/definitions/model.GetUpdateInfoResult'
+              type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
+      security:
+      - Bearer: []
+      summary: Get the latest published release
+      tags:
+      - System
   /api/v1/tag/archive-tag:
     post:
       consumes:

--- a/locales/en.json
+++ b/locales/en.json
@@ -142,6 +142,10 @@
           "data_loading": "Loading your data"
         }
       }
+    },
+    "update": {
+      "notice": "Econumo {version} is out",
+      "dismiss": "Dismiss"
     }
   },
   "accounts": {
@@ -300,6 +304,9 @@
     "export_csv": {
       "menu_item": "Export CSV",
       "error": "Failed to export transactions"
+    },
+    "update": {
+      "available": "New version {version} available"
     }
   },
   "transactions": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -142,6 +142,10 @@
           "data_loading": "Идёт загрузка"
         }
       }
+    },
+    "update": {
+      "notice": "Вышла Econumo {version}",
+      "dismiss": "Скрыть"
     }
   },
   "accounts": {
@@ -300,6 +304,9 @@
     "export_csv": {
       "menu_item": "Экспорт CSV",
       "error": "Не удалось экспортировать транзакции"
+    },
+    "update": {
+      "available": "Доступна новая версия {version}"
     }
   },
   "transactions": {

--- a/web/src/api/dto/system.ts
+++ b/web/src/api/dto/system.ts
@@ -1,0 +1,4 @@
+export interface UpdateInfoDto {
+  version: string
+  url: string
+}

--- a/web/src/api/system.ts
+++ b/web/src/api/system.ts
@@ -1,0 +1,11 @@
+import { api, apiUrl } from './client'
+import type { UpdateInfoDto } from './dto/system'
+
+interface Envelope<T> {
+  data: T
+}
+
+export async function getUpdateInfo(): Promise<UpdateInfoDto> {
+  const response = await api.get<Envelope<UpdateInfoDto>>(apiUrl('/api/v1/system/get-update-info'))
+  return response.data.data
+}

--- a/web/src/app/layouts/ApplicationLayout.test.tsx
+++ b/web/src/app/layouts/ApplicationLayout.test.tsx
@@ -8,7 +8,14 @@ import { http, HttpResponse } from 'msw'
 import { server } from '@/test/msw'
 import { coreHandlers, fixtureAccounts, fixtureUser } from '@/test/fixtures'
 import { QUERY_CACHE_KEY, refreshRestoredQueries } from '@/lib/queryPersist'
+import type { AvailableUpdate } from '@/hooks/useAvailableUpdate'
+import { useSidebarStore } from '@/app/uiStore'
 import { ApplicationLayout } from './ApplicationLayout'
+
+const mockUpdate = vi.hoisted(() => ({ value: null as AvailableUpdate | null }))
+vi.mock('@/hooks/useAvailableUpdate', () => ({
+  useAvailableUpdate: () => mockUpdate.value,
+}))
 
 function mockViewport(compact: boolean) {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -63,6 +70,10 @@ beforeEach(() => {
   localStorage.clear()
   window.econumoConfig = {}
   server.use(...coreHandlers())
+  mockUpdate.value = null
+  // the sidebar-collapsed flag lives in a module-level zustand store, so it
+  // survives across tests in this file independent of localStorage.clear()
+  useSidebarStore.setState({ collapsed: false })
 })
 
 it('shows the loading gate, then the sidebar tree with folder totals', async () => {
@@ -206,4 +217,44 @@ it('compact viewport hides the sidebar on content routes', async () => {
   renderShell('/account/a1')
   await waitFor(() => expect(screen.getByTestId('workspace')).toBeInTheDocument())
   expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument()
+})
+
+it('shows an update dot on the full-footer Settings link when an update is available', async () => {
+  mockViewport(false)
+  mockUpdate.value = { version: 'v9.9.9', url: 'https://econumo.com/releases/v9.9.9/' }
+  renderShell('/')
+  expect(await screen.findByText('Cash')).toBeInTheDocument()
+  const settingsLink = screen.getByText('Settings').closest('a')
+  expect(settingsLink?.querySelector('[data-testid="update-dot"]')).toBeInTheDocument()
+})
+
+it('shows no update dot on the full-footer Settings link when no update is available', async () => {
+  mockViewport(false)
+  renderShell('/')
+  expect(await screen.findByText('Cash')).toBeInTheDocument()
+  const settingsLink = screen.getByText('Settings').closest('a')
+  expect(settingsLink?.querySelector('[data-testid="update-dot"]')).not.toBeInTheDocument()
+})
+
+it('shows an update dot on the icon-rail Settings gear when an update is available', async () => {
+  mockViewport(false)
+  mockUpdate.value = { version: 'v9.9.9', url: 'https://econumo.com/releases/v9.9.9/' }
+  const user = userEvent.setup()
+  renderShell('/account/a1')
+  expect(await screen.findByText('Cash')).toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'toggle sidebar' }))
+  expect(screen.queryByText('Cash')).not.toBeInTheDocument()
+  expect(screen.getByTestId('update-dot')).toBeInTheDocument()
+})
+
+it('shows no update dot on the icon-rail Settings gear when no update is available', async () => {
+  mockViewport(false)
+  const user = userEvent.setup()
+  renderShell('/account/a1')
+  expect(await screen.findByText('Cash')).toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: 'toggle sidebar' }))
+  expect(screen.queryByText('Cash')).not.toBeInTheDocument()
+  expect(screen.queryByTestId('update-dot')).not.toBeInTheDocument()
 })

--- a/web/src/app/layouts/ApplicationLayout.tsx
+++ b/web/src/app/layouts/ApplicationLayout.tsx
@@ -10,8 +10,10 @@ import grayLogo from '@/assets/econumo-gray.svg?inline'
 import { LoadingDialog } from '@/components/LoadingDialog'
 import { UserCard } from '@/components/UserCard'
 import { UserAvatar } from '@/components/UserAvatar'
+import { UpdateNotice } from '@/components/UpdateNotice'
 import { econumoPackage } from '@/lib/package'
 import { formatDateTime } from '@/lib/datetime'
+import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useLogoutEscape } from '@/hooks/useLogoutEscape'
 import { useScrollMemory } from '@/hooks/useScrollMemory'
@@ -76,6 +78,7 @@ export function ApplicationLayout() {
   const isCompact = useIsCompact()
   const isFullyLoaded = useIsFullyLoaded()
   const { data: user } = useUserData()
+  const update = useAvailableUpdate()
 
   // The blocking loader belongs to the FIRST boot only; once data has been on
   // screen, refetches and cache churn must never re-cover the app (Vue parity).
@@ -174,14 +177,19 @@ export function ApplicationLayout() {
             <div className="flex-1" />
           )}
 
+          {!rail ? <UpdateNotice /> : null}
+
           {rail ? (
             <footer className="flex flex-col items-center gap-4 border-t px-2 pt-3 pb-[max(env(safe-area-inset-bottom),0.75rem)]">
               <Link
                 to={RouterPage.SETTINGS}
                 title={t('settings.page.menu_item')}
-                className="text-muted-foreground hover:text-foreground"
+                className="relative text-muted-foreground hover:text-foreground"
               >
                 <Settings className="size-5" />
+                {update ? (
+                  <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary" data-testid="update-dot" />
+                ) : null}
               </Link>
               <button
                 type="button"
@@ -200,8 +208,9 @@ export function ApplicationLayout() {
                   <img src={grayLogo} width={125} height={20} alt="" />
                   <span className="self-start text-[10px] text-muted-foreground">{econumoPackage().label}</span>
                 </div>
-                <Link to={RouterPage.SETTINGS} className="text-xs text-muted-foreground hover:text-foreground">
+                <Link to={RouterPage.SETTINGS} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
                   {t('settings.page.menu_item')}
+                  {update ? <span className="size-1.5 rounded-full bg-primary" data-testid="update-dot" /> : null}
                 </Link>
               </div>
               <button

--- a/web/src/app/queryKeys.ts
+++ b/web/src/app/queryKeys.ts
@@ -14,6 +14,7 @@ export const queryKeys = {
   budgetTransactions: ['budgetTransactions'] as const,
   sessions: ['sessions'] as const,
   personalTokens: ['personalTokens'] as const,
+  updateInfo: ['updateInfo'] as const,
 }
 
 export const TEN_MINUTES = 10 * 60_000

--- a/web/src/components/UpdateNotice.test.tsx
+++ b/web/src/components/UpdateNotice.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { AvailableUpdate } from '@/hooks/useAvailableUpdate'
+import { UpdateNotice } from './UpdateNotice'
+
+const mockUpdate = vi.hoisted(() => ({ value: null as AvailableUpdate | null }))
+vi.mock('@/hooks/useAvailableUpdate', () => ({
+  useAvailableUpdate: () => mockUpdate.value,
+}))
+
+beforeEach(() => {
+  localStorage.removeItem('econumo.dismissed-update-version')
+  mockUpdate.value = { version: 'v9.9.9', url: 'https://econumo.com/releases/v9.9.9/' }
+})
+
+it('renders the release link when an update is available', () => {
+  render(<UpdateNotice />)
+  const link = screen.getByRole('link', { name: /v9\.9\.9/ })
+  expect(link).toHaveAttribute('href', 'https://econumo.com/releases/v9.9.9/')
+  expect(link).toHaveAttribute('target', '_blank')
+})
+
+it('renders nothing when no update is available', () => {
+  mockUpdate.value = null
+  const { container } = render(<UpdateNotice />)
+  expect(container).toBeEmptyDOMElement()
+})
+
+it('dismisses per version and stays hidden', async () => {
+  const user = userEvent.setup()
+  render(<UpdateNotice />)
+  await user.click(screen.getByRole('button', { name: /dismiss/i }))
+  expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  expect(localStorage.getItem('econumo.dismissed-update-version')).toBe('v9.9.9')
+})
+
+it('reappears for a newer version after a dismissal', () => {
+  localStorage.setItem('econumo.dismissed-update-version', 'v9.9.8')
+  render(<UpdateNotice />)
+  expect(screen.getByRole('link', { name: /v9\.9\.9/ })).toBeInTheDocument()
+})

--- a/web/src/components/UpdateNotice.tsx
+++ b/web/src/components/UpdateNotice.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'
+import { getDismissedUpdateVersion, setDismissedUpdateVersion } from '@/lib/version'
+
+export function UpdateNotice() {
+  const { t } = useTranslation()
+  const update = useAvailableUpdate()
+  const [dismissed, setDismissed] = useState<string | null>(getDismissedUpdateVersion)
+  if (!update || dismissed === update.version) {
+    return null
+  }
+  return (
+    <div className="mx-3 mb-2 flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-xs text-muted-foreground">
+      <a
+        href={update.url}
+        target="_blank"
+        rel="noreferrer"
+        className="min-w-0 flex-1 truncate font-medium hover:text-foreground"
+      >
+        {t('common.update.notice', { version: update.version })}
+      </a>
+      <button
+        type="button"
+        aria-label={t('common.update.dismiss')}
+        className="shrink-0 hover:text-foreground"
+        onClick={() => {
+          setDismissedUpdateVersion(update.version)
+          setDismissed(update.version)
+        }}
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/web/src/features/settings/SettingsPage.test.tsx
+++ b/web/src/features/settings/SettingsPage.test.tsx
@@ -93,12 +93,14 @@ it('Import CSV and Export CSV rows open their dialogs', async () => {
   expect(await screen.findByText('Maximum file size: 10 MB')).toBeInTheDocument()
 })
 
-it('shows the new-version link when an update is available', async () => {
+it('shows the new-version menu row above the Finances group when an update is available', async () => {
   mockUpdate.value = { version: 'v9.9.9', url: 'https://econumo.com/releases/v9.9.9/' }
   renderPage()
   const link = await screen.findByRole('link', { name: /v9\.9\.9/ })
   expect(link).toHaveAttribute('href', 'https://econumo.com/releases/v9.9.9/')
   expect(link).toHaveAttribute('target', '_blank')
+  const finances = screen.getByText('Finances')
+  expect(link.compareDocumentPosition(finances) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 })
 
 it('shows no new-version link when no update is available', async () => {

--- a/web/src/features/settings/SettingsPage.test.tsx
+++ b/web/src/features/settings/SettingsPage.test.tsx
@@ -4,7 +4,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { server } from '@/test/msw'
 import { coreHandlers } from '@/test/fixtures'
+import type { AvailableUpdate } from '@/hooks/useAvailableUpdate'
 import { SettingsPage } from './SettingsPage'
+
+const mockUpdate = vi.hoisted(() => ({ value: null as AvailableUpdate | null }))
+vi.mock('@/hooks/useAvailableUpdate', () => ({
+  useAvailableUpdate: () => mockUpdate.value,
+}))
 
 function mockViewport(compact: boolean) {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -36,6 +42,7 @@ beforeEach(() => {
   localStorage.clear()
   window.econumoConfig = {}
   server.use(...coreHandlers())
+  mockUpdate.value = null
 })
 
 it('renders the menu rows with exact labels and navigates', async () => {
@@ -84,4 +91,18 @@ it('Import CSV and Export CSV rows open their dialogs', async () => {
   renderPage()
   await user.click(await screen.findByText('Import CSV'))
   expect(await screen.findByText('Maximum file size: 10 MB')).toBeInTheDocument()
+})
+
+it('shows the new-version link when an update is available', async () => {
+  mockUpdate.value = { version: 'v9.9.9', url: 'https://econumo.com/releases/v9.9.9/' }
+  renderPage()
+  const link = await screen.findByRole('link', { name: /v9\.9\.9/ })
+  expect(link).toHaveAttribute('href', 'https://econumo.com/releases/v9.9.9/')
+  expect(link).toHaveAttribute('target', '_blank')
+})
+
+it('shows no new-version link when no update is available', async () => {
+  renderPage()
+  expect(await screen.findByText('Settings')).toBeInTheDocument()
+  expect(screen.queryByText(/New version/)).not.toBeInTheDocument()
 })

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -14,10 +14,7 @@ import { ExportCsvDialog } from '@/features/transactions/ExportCsvDialog'
 import { ImportCsvDialog } from '@/features/transactions/ImportCsvDialog'
 import { ImportResultDialog } from '@/features/transactions/ImportResultDialog'
 import type { AggregatedImportResult } from '@/features/transactions/importCsv'
-
-// A tagged release (e.g. "v1.2.3") links to its notes; anything else ("dev",
-// a commit sha) has no release page, so it stays plain text.
-const SEMVER = /^v\d+\.\d+\.\d+$/
+import { SEMVER } from '@/lib/version'
 
 function MenuGroup({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -83,6 +83,18 @@ export function SettingsPage() {
             </Link>
           ) : null}
 
+          {update ? (
+            <a
+              href={update.url}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center justify-between gap-2 rounded-lg bg-primary/10 px-4 py-3.5 text-sm font-medium text-primary hover:bg-primary/15"
+            >
+              <span>{t('settings.update.available', { version: update.version })}</span>
+              <ChevronRight className="size-4" />
+            </a>
+          ) : null}
+
           <MenuGroup label={t('settings.page.groups.service')}>
             <MenuRow label={t('settings.accounts.menu_item')} to={RouterPage.SETTINGS_ACCOUNTS} />
             <MenuRow label={t('connections.pages.settings.menu_item')} to={RouterPage.SETTINGS_CONNECTIONS} />
@@ -102,17 +114,6 @@ export function SettingsPage() {
 
         </div>
       </div>
-
-      {update ? (
-        <a
-          href={update.url}
-          target="_blank"
-          rel="noreferrer"
-          className="mx-auto pb-1 text-xs font-medium text-primary hover:underline"
-        >
-          {t('settings.update.available', { version: update.version })} →
-        </a>
-      ) : null}
 
       <footer className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground/60">
         {SEMVER.test(version) ? (

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { UserAvatar } from '@/components/UserAvatar'
 import { getVersion, backendHost, getWebsiteUrl } from '@/lib/config'
+import { useAvailableUpdate } from '@/hooks/useAvailableUpdate'
 import { useIsCompact } from '@/hooks/useIsCompact'
 import { useNavigate } from 'react-router'
 import { RouterPage } from '@/app/router-pages'
@@ -52,6 +53,7 @@ export function SettingsPage() {
   const [importOpen, setImportOpen] = useState(false)
   const [importResult, setImportResult] = useState<AggregatedImportResult | null>(null)
   const version = getVersion()
+  const update = useAvailableUpdate()
 
   return (
     <div className="flex h-full flex-col gap-3 p-4">
@@ -100,6 +102,17 @@ export function SettingsPage() {
 
         </div>
       </div>
+
+      {update ? (
+        <a
+          href={update.url}
+          target="_blank"
+          rel="noreferrer"
+          className="mx-auto pb-1 text-xs font-medium text-primary hover:underline"
+        >
+          {t('settings.update.available', { version: update.version })} →
+        </a>
+      ) : null}
 
       <footer className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground/60">
         {SEMVER.test(version) ? (

--- a/web/src/hooks/useAvailableUpdate.ts
+++ b/web/src/hooks/useAvailableUpdate.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import { getUpdateInfo } from '@/api/system'
+import { ONE_DAY, queryKeys } from '@/app/queryKeys'
+import { getVersion } from '@/lib/config'
+import { isNewerVersion } from '@/lib/version'
+
+export interface AvailableUpdate {
+  version: string
+  url: string
+}
+
+// The latest published release when it is strictly newer than this build;
+// null otherwise (current, dev build, check disabled, or feed unavailable).
+export function useAvailableUpdate(): AvailableUpdate | null {
+  const { data } = useQuery({
+    queryKey: queryKeys.updateInfo,
+    queryFn: getUpdateInfo,
+    staleTime: ONE_DAY,
+    refetchOnWindowFocus: false,
+  })
+  if (!data || !isNewerVersion(data.version, getVersion())) {
+    return null
+  }
+  return { version: data.version, url: data.url }
+}

--- a/web/src/lib/version.test.ts
+++ b/web/src/lib/version.test.ts
@@ -1,0 +1,25 @@
+import { isNewerVersion } from './version'
+
+it.each([
+  ['v1.0.2', 'v1.0.1', true],
+  ['v1.1.0', 'v1.0.9', true],
+  ['v2.0.0', 'v1.9.9', true],
+  ['v1.0.2', 'v1.0.2', false],
+  ['v1.0.1', 'v1.0.2', false],
+  ['v1.0.10', 'v1.0.9', true],
+  ['v1.0.2', 'dev', false],
+  ['dev', 'v1.0.2', false],
+  ['', 'v1.0.2', false],
+  ['v1.0.2', '', false],
+  ['1.0.3', 'v1.0.2', false],
+])('isNewerVersion(%s, %s) -> %s', (latest, current, expected) => {
+  expect(isNewerVersion(latest, current)).toBe(expected)
+})
+
+it('dismissed-update version round-trips through localStorage', async () => {
+  const { getDismissedUpdateVersion, setDismissedUpdateVersion } = await import('./version')
+  localStorage.removeItem('econumo.dismissed-update-version')
+  expect(getDismissedUpdateVersion()).toBeNull()
+  setDismissedUpdateVersion('v1.0.2')
+  expect(getDismissedUpdateVersion()).toBe('v1.0.2')
+})

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,0 +1,29 @@
+export const SEMVER = /^v(\d+)\.(\d+)\.(\d+)$/
+
+// True only when BOTH strings are strict vX.Y.Z and latest > current — so a
+// `dev` image, an empty feed, or a custom build tag can never trigger the
+// update surfaces.
+export function isNewerVersion(latest: string, current: string): boolean {
+  const l = SEMVER.exec(latest)
+  const c = SEMVER.exec(current)
+  if (!l || !c) {
+    return false
+  }
+  for (let i = 1; i <= 3; i++) {
+    const d = Number(l[i]) - Number(c[i])
+    if (d !== 0) {
+      return d > 0
+    }
+  }
+  return false
+}
+
+const DISMISSED_KEY = 'econumo.dismissed-update-version'
+
+export function getDismissedUpdateVersion(): string | null {
+  return localStorage.getItem(DISMISSED_KEY)
+}
+
+export function setDismissedUpdateVersion(version: string): void {
+  localStorage.setItem(DISMISSED_KEY, version)
+}

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -159,5 +159,6 @@ export function coreHandlers(overrides: Partial<Record<string, unknown>> = {}) {
     http.get('*/api/v1/currency/get-currency-rate-list', () => envelope({ items: data.rates })),
     http.get('*/api/v1/user/get-user-data', () => envelope({ user: data.user })),
     http.get('*/api/v1/budget/get-budget-list', () => envelope({ items: data.budgets })),
+    http.get('*/api/v1/system/get-update-info', () => envelope({ version: 'v0.0.0', url: 'https://econumo.com/releases/v0.0.0/' })),
   ]
 }


### PR DESCRIPTION
Notifies users when a new Econumo release is available, linking to the release page on econumo.com (not GitHub).

## How it works

- **Website feed** (companion PR: econumo/website#21, ships first): `https://econumo.com/releases/latest.json` → `{version, date, url}`, newest by semver.
- **Backend**: new `internal/system` feature package. The `serve` command polls the feed on boot and every 24h (10s timeout, in-memory cache) and serves it via authenticated `GET /api/v1/system/get-update-info`. Feed payloads are validated at the trust boundary (`version` must be strict `vX.Y.Z`, `url` must start with `https://econumo.com/`) — invalid payloads are dropped, previous value retained, failures log at DEBUG only.
- **Opt-out**: `ECONUMO_CHECK_UPDATES=false` disables the check entirely (default `true`; documented in `.env.example` and CLAUDE.md).
- **Frontend**: the SPA compares the served version against its own build version (`isNewerVersion` — both sides must be strict semver, so `dev` builds never trigger anything) and renders three surfaces:
  1. a dot badge on the Settings gear/link in both sidebar footer variants (persistent),
  2. a dismissible sidebar notice ("Econumo vX.Y.Z is out") — dismissal is per-version in localStorage and reappears for the next release,
  3. a highlighted "New version vX.Y.Z available" link above the Settings page footer.
- **i18n**: new `common.update.*` / `settings.update.*` keys in en + ru (guard tests enforce parity).

Failure is silence throughout: feed unreachable, invalid payload, check disabled, dev build, or query error all render exactly nothing.

## Testing

- TDD throughout: poller unit tests (httptest feed: valid/malformed/bad-version/wrong-origin/non-2xx/empty; failure retains previous value), config test, `isNewerVersion` table tests, component tests for all three surfaces + dismissal semantics.
- apiparity: new `system_reads` scenario + golden; existing goldens byte-identical (verified). `Seams.Updates` keeps every test/CLI path on a disabled, never-polling service.
- `make test` green (Go smoke + sqlite-vs-pgsql engine compare + web) except the pre-existing `ImportCsvDialog.test.tsx` failure that exists on main (msw XHR hang; zero transaction files touched here).
- Live end-to-end check: real server against a stub feed + headless Chromium — endpoint envelope, all three surfaces, dismissal persistence and reappearance verified (11/11).

## Notes

- `make swagger`'s scan list gained `internal/system` (new annotated package); OpenAPI docs regenerated.
- Deferred follow-ups (from final review, no production risk): cap/deny cross-origin redirects in the poller's HTTP client; screen-reader text for the dot badges; drain non-2xx response bodies for connection reuse; explicit shape for the website feed's no-releases edge case.
- Spec: `docs/superpowers/specs/2026-07-17-release-notifications-design.md`; plan: `docs/superpowers/plans/2026-07-17-release-notifications.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsUtJeKdxGrKHh615qMSqX