### PR TITLE
fix(web): update-check failure must be silence, not an amber sync icon

### DIFF
--- a/web/src/api/system.test.ts
+++ b/web/src/api/system.test.ts
@@ -1,0 +1,36 @@
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw'
+import { getUpdateInfo } from './system'
+
+beforeEach(() => {
+  localStorage.clear()
+  window.econumoConfig = {}
+})
+
+it('returns the update info from the envelope', async () => {
+  server.use(
+    http.get('*/api/v1/system/get-update-info', () =>
+      HttpResponse.json({ success: true, message: '', data: { version: 'v1.2.3', url: 'https://econumo.com/releases/v1.2.3' } }),
+    ),
+  )
+  await expect(getUpdateInfo()).resolves.toEqual({ version: 'v1.2.3', url: 'https://econumo.com/releases/v1.2.3' })
+})
+
+// A reverse proxy that blocks the path (observed: nginx 403 HTML in front of a
+// live instance) must read as "no update known" — a rejection here paints the
+// sync icon amber and keeps it spinning through retry cycles forever.
+it('resolves null when the endpoint is blocked by a proxy', async () => {
+  server.use(
+    http.get('*/api/v1/system/get-update-info', () =>
+      HttpResponse.html('<html><body>403 Forbidden</body></html>', { status: 403 }),
+    ),
+  )
+  await expect(getUpdateInfo()).resolves.toBeNull()
+})
+
+it('resolves null when the response is not the JSON envelope', async () => {
+  server.use(
+    http.get('*/api/v1/system/get-update-info', () => HttpResponse.html('<html>captive portal</html>')),
+  )
+  await expect(getUpdateInfo()).resolves.toBeNull()
+})

--- a/web/src/api/system.ts
+++ b/web/src/api/system.ts
@@ -5,7 +5,15 @@ interface Envelope<T> {
   data: T
 }
 
-export async function getUpdateInfo(): Promise<UpdateInfoDto> {
-  const response = await api.get<Envelope<UpdateInfoDto>>(apiUrl('/api/v1/system/get-update-info'))
-  return response.data.data
+// The update check is decorative and its failure must be silence (same
+// contract as the backend poller): a rejection would mark the shared query
+// cache as sync-failing (amber icon) and re-run retry cycles on every
+// invalidate — observed live behind a reverse proxy that 403s this path.
+export async function getUpdateInfo(): Promise<UpdateInfoDto | null> {
+  try {
+    const response = await api.get<Envelope<UpdateInfoDto>>(apiUrl('/api/v1/system/get-update-info'))
+    return response.data.data ?? null
+  } catch {
+    return null
+  }
 }


### PR DESCRIPTION
## Summary

On an instance whose reverse proxy blocks `/api/v1/system/*` (observed live on beta: the host nginx returns a 403 HTML page for exactly that path prefix while every other API path reaches the Go server), the SPA's update check rejected — and because the `updateInfo` query lives in the shared query cache:

- `useSyncFailing` (ApplicationLayout) treats **any** errored/retrying query as a sync failure, so the sync icon turned permanently amber;
- every boot-restore `invalidateQueries`, Settings visit, and click on the (amber, inviting) sync button re-ran a 4-attempt retry cycle, keeping the icon spinning.

The backend poller's documented contract is "failure here is silence, never an error" (`internal/system/updates.go`); this makes the frontend mirror it: `getUpdateInfo` now resolves `null` ("no update known") on any failure — blocked proxy, offline, non-envelope body — so the decorative check can never poison the sync indicator.

Note: the beta 403 itself is a host nginx rule and needs fixing on the server; this PR makes the app robust to any such proxy.

## Test plan

- New `web/src/api/system.test.ts`: happy path, the observed 403-HTML proxy block, and a captive-portal-style 200 HTML response (the latter two assert a silent `null`). The 403 case fails against the old code.
- Full frontend suite: 524/524 passing; `tsc -b` clean; lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)