### PR TITLE
fix(web): shared accounts offer "Decline" instead of "Delete"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -291,6 +291,10 @@
       "delete_account_modal": {
         "question": "Are you sure you want to delete the account “{account}”?"
       },
+      "decline_access_modal": {
+        "title": "Decline access to the account?",
+        "question": "Are you sure you want to decline access to the account “{account}”?"
+      },
       "preview_account_modal": {
         "header": "Account details"
       }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -291,6 +291,10 @@
       "delete_account_modal": {
         "question": "Вы уверены, что хотите удалить счёт «{account}»?"
       },
+      "decline_access_modal": {
+        "title": "Отклонить доступ к счёту?",
+        "question": "Вы уверены, что хотите отклонить доступ к счёту «{account}»?"
+      },
       "preview_account_modal": {
         "header": "Информация о счёте"
       }

--- a/web/src/features/accounts/AccountsSettingsPage.test.tsx
+++ b/web/src/features/accounts/AccountsSettingsPage.test.tsx
@@ -157,6 +157,37 @@ it('account delete confirm posts and removes; edit opens the account modal', asy
   expect(useUiStore.getState().accountModal?.account?.id).toBe('a2')
 })
 
+it('shared-with-me account row offers Decline instead of Delete; confirming posts delete-account', async () => {
+  const partner = { id: 'u2', avatar: 'pets:sky', name: 'Partner' }
+  const foreign = {
+    id: 'a-foreign', owner: partner, folderId: 'f1', name: 'Shared wallet', position: 5,
+    currency: fixtureUsd, balance: '10', type: 1, icon: 'wallet',
+    sharedAccess: [{ user: { id: 'u1', avatar: 'face:emerald', name: 'Ada' }, role: 'user' }],
+  }
+  let posted: unknown
+  server.use(
+    ...coreHandlers({
+      accounts: [...fixtureAccountsForAccess, foreign],
+      connections: [{ user: partner, sharedAccounts: [] }],
+    }),
+    http.post('*/api/v1/account/delete-account', async ({ request }) => {
+      posted = await request.json()
+      return HttpResponse.json({ success: true, message: '', data: {} })
+    }),
+  )
+  const user = userEvent.setup()
+  renderPage()
+  await screen.findByTestId('folder-General')
+  await user.click(screen.getByRole('button', { name: 'account actions Shared wallet' }))
+  expect(await screen.findByRole('menuitem', { name: 'Decline' })).toBeInTheDocument()
+  expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument()
+  await user.click(screen.getByRole('menuitem', { name: 'Decline' }))
+  expect(await screen.findByText('Are you sure you want to decline access to the account “Shared wallet”?')).toBeInTheDocument()
+  await user.click(screen.getByRole('button', { name: 'Decline' }))
+  await waitFor(() => expect(posted).toEqual({ id: 'a-foreign' }))
+  await waitFor(() => expect(screen.queryByText('Shared wallet')).not.toBeInTheDocument())
+})
+
 it('access control: shared avatars, grant and revoke through the dialogs', async () => {
   const partner = { id: 'u2', avatar: 'pets:sky', name: 'Partner' }
   const sharedAccounts = [
@@ -356,4 +387,6 @@ it('compact: the preview sheet shows a read-only access list to a non-admin memb
   expect(await screen.findByText('Owner')).toBeInTheDocument()
   expect(screen.getByText('Manage transactions')).toBeInTheDocument()
   expect(screen.queryByRole('button', { name: /Partner/ })).toBeNull()
+  expect(screen.getByRole('button', { name: 'Decline' })).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull()
 })

--- a/web/src/features/accounts/AccountsSettingsPage.tsx
+++ b/web/src/features/accounts/AccountsSettingsPage.tsx
@@ -40,6 +40,7 @@ import {
   useShowFolder,
   useOrderFolders,
   useOrderAccounts,
+  useDeclineAccountAccess,
   useDeleteAccount,
 } from './queries'
 import type { FolderBucket } from './accountOrdering'
@@ -51,10 +52,12 @@ const COLLAPSED_FOLDERS_KEY = 'settings.accounts.collapsedFolders'
 
 function AccountRow({
   account,
+  isOwner,
   showAccess,
   onMenu,
 }: {
   account: AccountDto
+  isOwner: boolean
   showAccess: boolean
   onMenu: (action: 'edit' | 'delete' | 'view' | 'access') => void
 }) {
@@ -122,7 +125,7 @@ function AccountRow({
                 </DropdownMenuItem>
               ) : null}
               <DropdownMenuItem variant="destructive" onSelect={() => onMenu('delete')}>
-                {t('common.button.delete.label')}
+                {t(isOwner ? 'common.button.delete.label' : 'common.button.decline.label')}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -284,11 +287,13 @@ export function AccountsSettingsPage() {
   const orderFolders = useOrderFolders()
   const orderAccounts = useOrderAccounts()
   const deleteAccount = useDeleteAccount()
+  const declineAccountAccess = useDeclineAccountAccess()
 
   const [createOpen, setCreateOpen] = useState(false)
   const [renameTarget, setRenameTarget] = useState<FolderDto | null>(null)
   const [deleteFolderTarget, setDeleteFolderTarget] = useState<FolderDto | null>(null)
   const [deleteAccountTarget, setDeleteAccountTarget] = useState<AccountDto | null>(null)
+  const [declineAccountTarget, setDeclineAccountTarget] = useState<AccountDto | null>(null)
   const [previewAccount, setPreviewAccount] = useState<AccountDto | null>(null)
   const [accessAccountId, setAccessAccountId] = useState<string | null>(null)
   const [levelTarget, setLevelTarget] = useState<{ accountId: string; entry: ShareEntry } | null>(null)
@@ -471,12 +476,17 @@ export function AccountsSettingsPage() {
                     <AccountRow
                       key={account.id}
                       account={account}
+                      isOwner={account.owner.id === user?.id}
                       showAccess={user ? hasAccountAdminAccess(account, user.id) : false}
                       onMenu={(action) => {
                         if (action === 'edit') {
                           openAccountModal({ account })
                         } else if (action === 'delete') {
-                          setDeleteAccountTarget(account)
+                          if (account.owner.id === user?.id) {
+                            setDeleteAccountTarget(account)
+                          } else {
+                            setDeclineAccountTarget(account)
+                          }
                         } else if (action === 'access') {
                           setAccessAccountId(account.id)
                         } else {
@@ -610,6 +620,21 @@ export function AccountsSettingsPage() {
         destructive
       />
 
+      <ConfirmDialog
+        open={declineAccountTarget !== null}
+        onClose={() => setDeclineAccountTarget(null)}
+        onConfirm={() => {
+          if (declineAccountTarget) {
+            declineAccountAccess.mutate(declineAccountTarget.id, { onSettled: () => setDeclineAccountTarget(null) })
+          }
+        }}
+        title={t('settings.accounts.decline_access_modal.title')}
+        question={t('settings.accounts.decline_access_modal.question', { account: declineAccountTarget?.name ?? '' })}
+        confirmLabel={t('common.button.decline.label')}
+        cancelLabel={t('common.button.cancel.label')}
+        destructive
+      />
+
       {previewLive ? (
         <ResponsiveDialog
           open
@@ -659,11 +684,15 @@ export function AccountsSettingsPage() {
               type="button"
               variant="destructive"
               onClick={() => {
-                setDeleteAccountTarget(previewLive)
+                if (previewLive.owner.id === user?.id) {
+                  setDeleteAccountTarget(previewLive)
+                } else {
+                  setDeclineAccountTarget(previewLive)
+                }
                 setPreviewAccount(null)
               }}
             >
-              {t('common.button.delete.label')}
+              {t(previewLive.owner.id === user?.id ? 'common.button.delete.label' : 'common.button.decline.label')}
             </Button>
             <Button
               type="button"

--- a/web/src/features/accounts/queries.ts
+++ b/web/src/features/accounts/queries.ts
@@ -89,6 +89,22 @@ export function useDeleteAccount() {
   })
 }
 
+// delete-account from a non-owner drops only the caller's own access; the
+// server never deletes a shared account, so this is safe to expose as "decline".
+export function useDeclineAccountAccess() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: accountApi.deleteAccount,
+    onSuccess: (_result, id) => {
+      queryClient.setQueryData<AccountDto[]>(queryKeys.accounts, (prev) => (prev ?? []).filter((a) => a.id !== id))
+      queryClient.setQueryData<TransactionDto[]>(queryKeys.transactions, (prev) =>
+        (prev ?? []).filter((t) => t.accountId !== id && t.accountRecipientId !== id),
+      )
+      trackEvent(METRICS.ACCOUNT_DECLINE_ACCESS)
+    },
+  })
+}
+
 export function useOrderAccounts() {
   const queryClient = useQueryClient()
   return useMutation({

--- a/web/src/lib/metrics.ts
+++ b/web/src/lib/metrics.ts
@@ -30,6 +30,7 @@ export const METRICS = {
   ACCOUNT_CREATE: 'appAccountCreate',
   ACCOUNT_UPDATE: 'appAccountUpdate',
   ACCOUNT_DELETE: 'appAccountDelete',
+  ACCOUNT_DECLINE_ACCESS: 'appAccountDeclineAccess',
   ACCOUNT_ORDER_LIST: 'appApiAccountOrderList',
   ACCOUNT_FOLDER_EXPAND: 'appAccountFolderExpand',
   ACCOUNT_FOLDER_COLLAPSE: 'appAccountFolderCollapse',


### PR DESCRIPTION
## Summary
- An account shared with you showed the same **Delete** action and "delete the account?" confirmation as an owned account, even though the backend's `delete-account` only drops the caller's own access grant for non-owners. Scary wording, no actual data loss — but the UI implied one.
- Both accounts-settings surfaces (row context menu + compact preview sheet) now branch on ownership: non-owners see **Decline** with a "Decline access to the account?" confirmation (new `settings.accounts.decline_access_modal` keys, en + ru), owners keep the delete flow unchanged.
- The decline path goes through a new `useDeclineAccountAccess` hook — same `delete-account` endpoint and cache cleanup, but a distinct `appAccountDeclineAccess` analytics event so declines aren't miscounted as deletions.
- Budgets already behaved this way (`BudgetsPage` decline flow); no backend changes.

## Test plan
- [x] New test: shared account row shows Decline (not Delete), confirming posts `delete-account` and removes the row
- [x] Compact preview sheet test now asserts Decline/not-Delete for a non-owned account
- [x] Full web suite green (95 files, 525 tests), `tsc -b` clean, oxlint unchanged
- [x] Go i18n catalogue guards pass (en/ru parity, placeholder parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)