### PR TITLE
fix: budget edit mode misaligns the spent column between a parent and its children

### DIFF
--- a/web/src/features/budgets/BudgetPage.tsx
+++ b/web/src/features/budgets/BudgetPage.tsx
@@ -459,7 +459,7 @@ export function BudgetPage() {
       return (
         <span className="flex items-center gap-1.5 sm:gap-2">
           {plus}
-          <span className="size-9" />
+          <span className="size-8" />
         </span>
       )
     }
@@ -490,34 +490,33 @@ export function BudgetPage() {
     )
   }
 
-  const elementActions = (element: BudgetElementDto) =>
-    editMode ? (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button type="button" variant="ghost" size="icon" aria-label={`element actions ${element.name}`}>
-            <MoreVertical className="size-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {element.type !== BudgetElementType.ENVELOPE ? (
-            <DropdownMenuItem onSelect={() => setCurrencyTarget(element)}>
-              {t('budgets.page.budget.structure.element.action.change_currency')}
+  const elementActions = (element: BudgetElementDto) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" aria-label={`element actions ${element.name}`}>
+          <MoreVertical className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {element.type !== BudgetElementType.ENVELOPE ? (
+          <DropdownMenuItem onSelect={() => setCurrencyTarget(element)}>
+            {t('budgets.page.budget.structure.element.action.change_currency')}
+          </DropdownMenuItem>
+        ) : (
+          <>
+            <DropdownMenuItem onSelect={() => setEnvelopeDialog({ open: true, envelope: element, folderId: element.folderId })}>
+              {t('common.button.edit.label')}
             </DropdownMenuItem>
-          ) : (
-            <>
-              <DropdownMenuItem onSelect={() => setEnvelopeDialog({ open: true, envelope: element, folderId: element.folderId })}>
-                {t('common.button.edit.label')}
+            {canDeleteEnvelope(budget.meta, user?.id) ? (
+              <DropdownMenuItem variant="destructive" onSelect={() => setDeleteEnvelopeTarget(element)}>
+                {t('common.button.delete.label')}
               </DropdownMenuItem>
-              {canDeleteEnvelope(budget.meta, user?.id) ? (
-                <DropdownMenuItem variant="destructive" onSelect={() => setDeleteEnvelopeTarget(element)}>
-                  {t('common.button.delete.label')}
-                </DropdownMenuItem>
-              ) : null}
-            </>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    ) : null
+            ) : null}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
 
   return (
     <div className="flex h-full flex-col gap-3 p-2.5 sm:p-4">
@@ -635,7 +634,7 @@ export function BudgetPage() {
                 renderFolderHandle={editMode ? (bucket) => (bucket.folder ? <FolderGrip name={bucket.folder.name} /> : null) : undefined}
                 // only in edit mode — its presence also swaps the folder currency symbol for the plus slot
                 renderFolderActions={editMode ? folderActions : undefined}
-                renderActions={elementActions}
+                renderActions={editMode ? elementActions : undefined}
                 renderBudgetCell={
                   limitsEditable && !editMode && !isCompact
                     ? (element) => (

--- a/web/src/features/budgets/BudgetTable.test.tsx
+++ b/web/src/features/budgets/BudgetTable.test.tsx
@@ -161,6 +161,31 @@ it('the available pill is not a button without onAvailableClick', async () => {
   expect(within(food).queryByRole('button', { name: 'limit Food' })).not.toBeInTheDocument()
 })
 
+it('edit mode reserves the actions column on headers, children, archive rows and totals', async () => {
+  const user = userEvent.setup()
+  renderTable(undefined, {
+    renderActions: (element) => <button type="button" aria-label={`element actions ${element.name}`} className="size-8" />,
+  })
+  const living = await screen.findByTestId('element-env-1')
+  await user.click(within(living).getByText('Living'))
+  const child = await screen.findByTestId('child-cat-rent')
+  expect(within(child).getByTestId('actions-spacer')).toBeInTheDocument()
+  expect(within(screen.getByTestId('column-headers')).getByTestId('actions-spacer')).toBeInTheDocument()
+  expect(within(screen.getByTestId('budget-totals')).getByTestId('actions-spacer')).toBeInTheDocument()
+  // archive rows carry no per-element actions menu — they pad the slot instead
+  const archive = screen.getByTestId('budget-folder-Archived')
+  expect(within(archive).getAllByTestId('actions-spacer').length).toBeGreaterThan(0)
+})
+
+it('without renderActions no actions-column spacers render', async () => {
+  const user = userEvent.setup()
+  renderTable()
+  const living = await screen.findByTestId('element-env-1')
+  await user.click(within(living).getByText('Living'))
+  await screen.findByTestId('child-cat-rent')
+  expect(screen.queryAllByTestId('actions-spacer')).toHaveLength(0)
+})
+
 it('totals row sums all buckets in the budget currency', async () => {
   renderTable()
   const totals = await screen.findByTestId('budget-totals')

--- a/web/src/features/budgets/BudgetTable.tsx
+++ b/web/src/features/budgets/BudgetTable.tsx
@@ -73,6 +73,12 @@ function StatCells({ stats, currency, hideSymbol = false }: { stats: BucketStats
 }
 
 
+/* edit mode appends a w-8 actions button to element rows; every row without
+   one must pad the slot or its amount columns drift out of alignment */
+function ActionsSpacer() {
+  return <span data-testid="actions-spacer" className="w-8 shrink-0" />
+}
+
 function ElementRow({
   element,
   bucket,
@@ -80,6 +86,7 @@ function ElementRow({
   currencies,
   accessById,
   extras,
+  actionsColumn = false,
   hideChildren = false,
 }: {
   element: BudgetElementDto
@@ -88,6 +95,8 @@ function ElementRow({
   currencies: CurrencyDto[]
   accessById: Map<string, UserDto>
   extras: ElementRowExtras
+  /** the table renders an actions column (edit mode): rows without their own actions pad it */
+  actionsColumn?: boolean
   hideChildren?: boolean
 }) {
   const { t } = useTranslation()
@@ -185,7 +194,7 @@ function ElementRow({
           )}
         </span>
         <span className="hidden w-6 text-center text-xs text-muted-foreground sm:block">{currency?.symbol}</span>
-        {extras.renderActions?.(element, bucket)}
+        {extras.renderActions ? extras.renderActions(element, bucket) : actionsColumn ? <ActionsSpacer /> : null}
       </div>
       {expandable && unfolded ? (
         <ul className="pb-1">
@@ -210,6 +219,7 @@ function ElementRow({
                 </span>
                 <span className="w-20 sm:w-24" />
                 <span className="hidden w-6 sm:block" />
+                {actionsColumn ? <ActionsSpacer /> : null}
               </li>
             )
           })}
@@ -226,6 +236,7 @@ export function BudgetTable({ budget, buckets, renderFolderActions, renderFolder
   const { data: currencies = [] } = useCurrencies()
   const budgetCurrency = currencies.find((c) => c.id === budget.meta.currencyId)
   const totals = budgetTotals(buckets)
+  const actionsColumn = !!extras.renderActions
   const opts = cellOpts(budgetCurrency)
   const accessById = new Map(budget.meta.access.map((a) => [a.user.id, a.user]))
 
@@ -244,6 +255,7 @@ export function BudgetTable({ budget, buckets, renderFolderActions, renderFolder
         <span className="w-20 text-center sm:w-24">{t('budgets.page.budget.structure.tab.spent')}</span>
         <span className="w-20 text-center sm:w-24">{t('budgets.page.budget.structure.tab.available')}</span>
         <span className="hidden w-6 sm:block" />
+        {actionsColumn ? <ActionsSpacer /> : null}
       </div>
 
       {sections.map((section) => {
@@ -271,6 +283,7 @@ export function BudgetTable({ budget, buckets, renderFolderActions, renderFolder
                 />
               ) : null}
               {!isArchiveSection ? renderFolderActions?.(section.bucket, section.folderIndex ?? -1, realFolders.length) : null}
+              {isArchiveSection && actionsColumn ? <ActionsSpacer /> : null}
             </header>
             {hideContents ? null : section.bucket.elements.length === 0 ? (
               <p className="px-2 py-1 text-xs text-muted-foreground">{t('budgets.page.budget.structure.empty_folder.note')}</p>
@@ -284,6 +297,7 @@ export function BudgetTable({ budget, buckets, renderFolderActions, renderFolder
                   currencies={currencies}
                   accessById={accessById}
                   extras={isArchiveSection ? { onSpentClick: extras.onSpentClick } : extras}
+                  actionsColumn={actionsColumn}
                   hideChildren={hideChildren}
                 />
               ))
@@ -307,6 +321,7 @@ export function BudgetTable({ budget, buckets, renderFolderActions, renderFolder
           <AvailablePill available={totals.available} currency={budgetCurrency} />
         </span>
         <span className="w-6 text-center text-xs text-muted-foreground">{budgetCurrency?.symbol}</span>
+        {actionsColumn ? <ActionsSpacer /> : null}
       </div>
 
       {/* the phone table hides the budget column, so the totals unfold into


### PR DESCRIPTION
## Summary
- In **edit structure** mode, every element row gets a trailing 32px actions (⋮) button after the amount columns, but expanded envelope/tag child rows — plus the Budget/Spent/Available header row, the desktop Total row, and the archive section — never reserved that slot, so a parent's spent sat ~40px left of its children's. Preview mode has no actions button, which is why it looked fine there.
- `BudgetTable` now renders a `w-8` `ActionsSpacer` in the actions slot on child rows, the column headers, the totals row, the archive folder header, and archive rows (which deliberately have no per-element menu) whenever the table has an actions column.
- `BudgetPage` passes `renderActions` only in edit mode (it previously always passed a function that returned `null` outside edit mode), so the table can reliably detect the actions column; also fixes the Default-folder header pad from `size-9` to `size-8` — the icon button it stands in for is 32px, so those numbers were 4px off.

Before (edit mode, children/headers/Total 40px right of parent):

| | parent spent | child spent |
|---|---|---|
| preview | aligned | aligned |
| edit (before) | shifted left | unmoved |
| edit (after) | aligned | aligned |

## Test plan
- [x] New `BudgetTable` tests: edit mode renders the actions spacer on headers, children, archive rows, and totals; preview mode renders none (written failing-first)
- [x] Full frontend suite: 548 tests / 97 files pass; `tsc -b` clean; oxlint unchanged
- [x] Verified end-to-end on a scratch instance (seeded envelope with two spending categories): before/after screenshots show parent, children, SPENT header, and Total on one column in edit mode; preview mode pixel-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)