### PR TITLE
fix: order-tag-list / order-payee-list are owner-only (#108)

### DIFF
--- a/internal/category/order.go
+++ b/internal/category/order.go
@@ -11,11 +11,10 @@ import (
 // OrderCategoryList applies each {id, position} change to the matching category,
 // then returns the full available list.
 //
-// IMPORTANT asymmetry vs tag/payee: reordering iterates the OWNER-ONLY set, so a
-// SHARED category's position is NOT updated — only the user's own categories are.
-// (Tag/payee order, by contrast, reorder the full available set and DO update
-// shared.) The RESPONSE, however, is the full available list (own + shared) via
-// the read view.
+// Reordering iterates the OWNER-ONLY set, so a SHARED category's position is
+// NOT updated — only the user's own categories are (tag/payee order works the
+// same way, see issue #108). The RESPONSE, however, is the full available list
+// (own + shared) via the read view.
 func (s *Service) OrderCategoryList(ctx context.Context, userID vo.Id, req model.OrderCategoryListRequest) (*model.OrderCategoryListResult, error) {
 	positions := make(map[string]int16, len(req.Changes))
 	for _, ch := range req.Changes {

--- a/internal/payee/api/order_shared_test.go
+++ b/internal/payee/api/order_shared_test.go
@@ -1,0 +1,96 @@
+package api_test
+
+// Regression coverage for issue #108: order-payee-list is OWNER-ONLY (mirrors
+// category). A sharee — whatever their role, guest included — must not be able
+// to rewrite the position of the account owner's payees; shared ids in the
+// changes list are silently ignored, exactly like category's order semantics.
+
+import (
+	"net/http"
+	"testing"
+)
+
+const orderSharedAcctID = "aaaa5555-0000-0000-0000-0000000000a5"
+
+// seedForeignPayeeShared seeds a payee owned by otherUserID plus an accepted
+// grant of one of otherUserID's accounts to the caller, so the payee is
+// VISIBLE to the caller via the shared read view.
+func (h *harness) seedForeignPayeeShared(t *testing.T, payeeID string, position int, role int) {
+	t.Helper()
+	h.seedPayee(t, payeeID, otherUserID, "Foreign", position, false)
+	h.seedAccount(t, orderSharedAcctID, otherUserID, "Other's account")
+	h.seedGrant(t, orderSharedAcctID, seedUserID, role)
+}
+
+func (h *harness) payeeRow(t *testing.T, id string) (position int, updatedAt string) {
+	t.Helper()
+	if err := h.db.QueryRow(`SELECT position, updated_at FROM payees WHERE id = ?`, id).Scan(&position, &updatedAt); err != nil {
+		t.Fatalf("query payee %s: %v", id, err)
+	}
+	return position, updatedAt
+}
+
+func TestOrderPayeeList_SharedPayee_NotReordered(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		role int
+	}{
+		{"guest", roleGuest},
+		{"admin", roleAdmin},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			token := h.issueToken(t)
+			h.seedForeignPayeeShared(t, payeeID2, 5, tc.role)
+			_, wantUpdated := h.payeeRow(t, payeeID2)
+
+			status, env := h.do(t, http.MethodPost, "/api/v1/payee/order-payee-list", token, map[string]any{
+				"changes": []map[string]any{{"id": payeeID2, "position": 0}},
+			})
+			if status != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (shared ids are ignored, not an error); body: %s", status, env.raw)
+			}
+
+			pos, updated := h.payeeRow(t, payeeID2)
+			if pos != 5 {
+				t.Errorf("shared payee position = %d, want 5 (sharee must not reorder the owner's payees)", pos)
+			}
+			if updated != wantUpdated {
+				t.Errorf("shared payee updated_at changed (%q -> %q), want untouched", wantUpdated, updated)
+			}
+		})
+	}
+}
+
+func TestOrderPayeeList_MixedChanges_UpdatesOwnOnly(t *testing.T) {
+	h := newHarness(t)
+	token := h.issueToken(t)
+	h.seedPayee(t, payeeID1, seedUserID, "Mine", 0, false)
+	h.seedForeignPayeeShared(t, payeeID2, 5, roleGuest)
+
+	status, env := h.do(t, http.MethodPost, "/api/v1/payee/order-payee-list", token, map[string]any{
+		"changes": []map[string]any{
+			{"id": payeeID1, "position": 3},
+			{"id": payeeID2, "position": 0},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", status, env.raw)
+	}
+
+	if pos, _ := h.payeeRow(t, payeeID1); pos != 3 {
+		t.Errorf("own payee position = %d, want 3", pos)
+	}
+	if pos, _ := h.payeeRow(t, payeeID2); pos != 5 {
+		t.Errorf("shared payee position = %d, want 5 (untouched)", pos)
+	}
+
+	// The response is still the full available list, shared payee included.
+	got := map[string]int{}
+	for _, it := range mustUnmarshal[itemsWrapper](t, env.Data).Items {
+		got[it.ID] = it.Position
+	}
+	if p, ok := got[payeeID2]; !ok || p != 5 {
+		t.Errorf("shared payee in response = (%d, present=%v), want position 5 present", p, ok)
+	}
+}

--- a/internal/payee/order.go
+++ b/internal/payee/order.go
@@ -7,46 +7,38 @@ import (
 	"github.com/econumo/econumo/internal/shared/vo"
 )
 
-// OrderPayeeList applies each {id, position} change to the matching payee in the
-// user's AVAILABLE set (own + shared via account access), saving those that
-// changed, then returns the full ordered list. A SHARED payee's position is
-// updated too.
+// OrderPayeeList applies each {id, position} change to the matching payee, then
+// returns the full available list.
+//
+// Reordering is OWNER-ONLY (mirrors category): the changes iterate the caller's
+// own payees, so a SHARED payee's position is never updated — a sharee, guest
+// included, cannot rewrite the owner's global ordering (issue #108); shared ids
+// in the changes list are silently ignored. The RESPONSE, however, is the full
+// available list (own + shared) via the read view.
 func (s *Service) OrderPayeeList(ctx context.Context, userID vo.Id, req model.OrderPayeeListRequest) (*model.OrderPayeeListResult, error) {
 	positions := make(map[string]int16, len(req.Changes))
-	order := make([]string, 0, len(req.Changes))
 	for _, ch := range req.Changes {
 		id, err := vo.ParseId(ch.Id)
 		if err != nil {
 			return nil, err
-		}
-		if _, seen := positions[id.String()]; !seen {
-			order = append(order, id.String())
 		}
 		positions[id.String()] = int16(ch.Position)
 	}
 
 	var items []model.PayeeResult
 	if err := s.tx.WithTx(ctx, func(txCtx context.Context) error {
-		avail, err := s.read.PayeeListView(txCtx, userID.String())
+		payees, err := s.repo.ListByOwner(txCtx, userID)
 		if err != nil {
 			return err
 		}
-		available := make(map[string]struct{}, len(avail))
-		for _, r := range avail {
-			available[r.ID] = struct{}{}
-		}
 		now := s.clock.Now()
-		for _, idStr := range order {
-			if _, ok := available[idStr]; !ok {
+		for _, p := range payees {
+			pos, ok := positions[p.ID.String()]
+			if !ok {
 				continue
 			}
-			id, _ := vo.ParseId(idStr)
-			p, gerr := s.repo.GetByID(txCtx, id)
-			if gerr != nil {
-				return gerr
-			}
 			before := p.Position
-			p.UpdatePosition(positions[idStr], now)
+			p.UpdatePosition(pos, now)
 			if p.Position != before {
 				if serr := s.repo.Save(txCtx, p); serr != nil {
 					return serr

--- a/internal/tag/api/order_shared_test.go
+++ b/internal/tag/api/order_shared_test.go
@@ -1,0 +1,96 @@
+package api_test
+
+// Regression coverage for issue #108: order-tag-list is OWNER-ONLY (mirrors
+// category). A sharee — whatever their role, guest included — must not be able
+// to rewrite the position of the account owner's tags; shared ids in the
+// changes list are silently ignored, exactly like category's order semantics.
+
+import (
+	"net/http"
+	"testing"
+)
+
+const orderSharedAcctID = "aaaa5555-0000-0000-0000-0000000000a5"
+
+// seedForeignTagShared seeds a tag owned by otherUserID plus an accepted grant
+// of one of otherUserID's accounts to the caller, so the tag is VISIBLE to the
+// caller via the shared read view.
+func (h *harness) seedForeignTagShared(t *testing.T, tagID string, position int, role int) {
+	t.Helper()
+	h.seedTag(t, tagID, otherUserID, "#foreign", position, false)
+	h.seedAccount(t, orderSharedAcctID, otherUserID, "Other's account")
+	h.seedGrant(t, orderSharedAcctID, seedUserID, role)
+}
+
+func (h *harness) tagRow(t *testing.T, id string) (position int, updatedAt string) {
+	t.Helper()
+	if err := h.db.QueryRow(`SELECT position, updated_at FROM tags WHERE id = ?`, id).Scan(&position, &updatedAt); err != nil {
+		t.Fatalf("query tag %s: %v", id, err)
+	}
+	return position, updatedAt
+}
+
+func TestOrderTagList_SharedTag_NotReordered(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		role int
+	}{
+		{"guest", roleGuest},
+		{"admin", roleAdmin},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			token := h.issueToken(t)
+			h.seedForeignTagShared(t, tagID2, 5, tc.role)
+			_, wantUpdated := h.tagRow(t, tagID2)
+
+			status, env := h.do(t, http.MethodPost, "/api/v1/tag/order-tag-list", token, map[string]any{
+				"changes": []map[string]any{{"id": tagID2, "position": 0}},
+			})
+			if status != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (shared ids are ignored, not an error); body: %s", status, env.raw)
+			}
+
+			pos, updated := h.tagRow(t, tagID2)
+			if pos != 5 {
+				t.Errorf("shared tag position = %d, want 5 (sharee must not reorder the owner's tags)", pos)
+			}
+			if updated != wantUpdated {
+				t.Errorf("shared tag updated_at changed (%q -> %q), want untouched", wantUpdated, updated)
+			}
+		})
+	}
+}
+
+func TestOrderTagList_MixedChanges_UpdatesOwnOnly(t *testing.T) {
+	h := newHarness(t)
+	token := h.issueToken(t)
+	h.seedTag(t, tagID1, seedUserID, "#mine", 0, false)
+	h.seedForeignTagShared(t, tagID2, 5, roleGuest)
+
+	status, env := h.do(t, http.MethodPost, "/api/v1/tag/order-tag-list", token, map[string]any{
+		"changes": []map[string]any{
+			{"id": tagID1, "position": 3},
+			{"id": tagID2, "position": 0},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", status, env.raw)
+	}
+
+	if pos, _ := h.tagRow(t, tagID1); pos != 3 {
+		t.Errorf("own tag position = %d, want 3", pos)
+	}
+	if pos, _ := h.tagRow(t, tagID2); pos != 5 {
+		t.Errorf("shared tag position = %d, want 5 (untouched)", pos)
+	}
+
+	// The response is still the full available list, shared tag included.
+	got := map[string]int{}
+	for _, it := range mustUnmarshal[itemsWrapper](t, env.Data).Items {
+		got[it.ID] = it.Position
+	}
+	if p, ok := got[tagID2]; !ok || p != 5 {
+		t.Errorf("shared tag in response = (%d, present=%v), want position 5 present", p, ok)
+	}
+}

--- a/internal/tag/order.go
+++ b/internal/tag/order.go
@@ -7,48 +7,38 @@ import (
 	"github.com/econumo/econumo/internal/shared/vo"
 )
 
-// OrderTagList applies each {id, position} change to the matching tag in the
-// user's AVAILABLE set (own + shared via account access), saving those that
-// actually changed, then returns the full ordered list. A SHARED tag's position
-// is updated too: the changes are restricted to the available id set (an id the
-// user has no access to is ignored), then each is loaded via GetByID (not
-// owner-scoped) and persisted.
+// OrderTagList applies each {id, position} change to the matching tag, then
+// returns the full available list.
+//
+// Reordering is OWNER-ONLY (mirrors category): the changes iterate the caller's
+// own tags, so a SHARED tag's position is never updated — a sharee, guest
+// included, cannot rewrite the owner's global ordering (issue #108); shared ids
+// in the changes list are silently ignored. The RESPONSE, however, is the full
+// available list (own + shared) via the read view.
 func (s *Service) OrderTagList(ctx context.Context, userID vo.Id, req model.OrderTagListRequest) (*model.OrderTagListResult, error) {
 	positions := make(map[string]int16, len(req.Changes))
-	order := make([]string, 0, len(req.Changes))
 	for _, ch := range req.Changes {
 		id, err := vo.ParseId(ch.Id)
 		if err != nil {
 			return nil, err
-		}
-		if _, seen := positions[id.String()]; !seen {
-			order = append(order, id.String())
 		}
 		positions[id.String()] = int16(ch.Position)
 	}
 
 	var items []model.TagResult
 	if err := s.tx.WithTx(ctx, func(ctx context.Context) error {
-		avail, err := s.read.TagListView(ctx, userID.String())
+		tags, err := s.repo.ListByOwner(ctx, userID)
 		if err != nil {
 			return err
 		}
-		available := make(map[string]struct{}, len(avail))
-		for _, r := range avail {
-			available[r.ID] = struct{}{}
-		}
 		now := s.clock.Now()
-		for _, idStr := range order {
-			if _, ok := available[idStr]; !ok {
-				continue // not accessible to this user — ignore
-			}
-			id, _ := vo.ParseId(idStr)
-			t, gerr := s.repo.GetByID(ctx, id)
-			if gerr != nil {
-				return gerr
+		for _, t := range tags {
+			pos, ok := positions[t.ID.String()]
+			if !ok {
+				continue
 			}
 			before := t.Position
-			t.UpdatePosition(positions[idStr], now)
+			t.UpdatePosition(pos, now)
 			if t.Position != before {
 				if serr := s.repo.Save(ctx, t); serr != nil {
 					return serr


### PR DESCRIPTION
## Summary

Fixes #108 — policy option 1 (owner-only), matching `category/order.go`.

Any user holding an accepted share on *any* of the owner's accounts — including a read-only **guest** — could rewrite the position (and `updated_at`) of **all** the owner's tags/payees via `order-tag-list` / `order-payee-list`, because the write allowlist was built from the shared read view (`TagListView` / `PayeeListView`) with no role check. Position is a single global column per entity, so this perturbed the owner's own ordering.

## Changes

- `internal/tag/order.go`, `internal/payee/order.go` — mirror category's owner-only pattern: iterate `repo.ListByOwner` and apply matching position changes. Shared ids in the changes list are silently ignored (200, entity untouched) — the same scoping category has always had. The response stays the full available list (own + shared) via the read view.
- `internal/category/order.go` — comment only: the "asymmetry vs tag/payee" note is now obsolete; all three modules order identically.

No SQL or wire changes. Legitimate flows are unaffected: the SPA reorder UI (`TagsPage`/`PayeesPage`) already restricts dragging to own items, and every apiparity golden is byte-identical.

## Tests

`internal/{tag,payee}/api/order_shared_test.go` drive the real router (TDD — written first, all fail without the fix):
- a guest **and** an admin sharee reordering a shared tag/payee gets 200 but the entity's position and `updated_at` stay untouched;
- a mixed own+shared changes list updates the own entity only, and the response still includes the shared entity at its original position.

`make go-test` green (coverage 79.6%, min 78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)