### PR TITLE
test: fix always-failing BudgetTable edit-mode actions-column test

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -1,0 +1,47 @@
+name: Web tests
+
+# Guards the React SPA on every push + PR: oxlint, the tsc type-check
+# (neither oxlint nor vitest type-checks), and the vitest suite.
+# locales/ is included because the SPA imports the shared catalogues.
+on:
+    push:
+        paths:
+            - "web/**"
+            - "locales/**"
+            - ".github/workflows/web-tests.yml"
+    pull_request:
+        paths:
+            - "web/**"
+            - "locales/**"
+            - ".github/workflows/web-tests.yml"
+
+permissions:
+    contents: read
+
+jobs:
+    test:
+        name: Lint + type-check + vitest
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: web
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+              with:
+                  package_json_file: web/package.json
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 26
+                  cache: pnpm
+                  cache-dependency-path: web/pnpm-lock.yaml
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+            - name: Lint (oxlint)
+              run: pnpm lint
+            - name: Type-check (tsc -b)
+              run: pnpm exec tsc -b
+            # jsdom tests are load-sensitive on shared runners; give them
+            # headroom over vitest's 5s default so CI doesn't flake.
+            - name: Tests (vitest)
+              run: pnpm test --testTimeout=15000

--- a/web/src/features/budgets/BudgetTable.test.tsx
+++ b/web/src/features/budgets/BudgetTable.test.tsx
@@ -193,9 +193,15 @@ it('the available pill is not a button without onAvailableClick', async () => {
 
 it('edit mode reserves the actions column on headers, children, archive rows and totals', async () => {
   const user = userEvent.setup()
-  renderTable(undefined, {
-    renderActions: (element) => <button type="button" aria-label={`element actions ${element.name}`} className="size-8" />,
-  })
+  // seed a nonzero archived element so the Archived section is visible (all-zero archive hides)
+  renderTable(
+    (budget) => {
+      budget.structure.elements.push({ ...budget.structure.elements[2], id: 'tag-carry', name: 'aaa-carry', available: 7 })
+    },
+    {
+      renderActions: (element) => <button type="button" aria-label={`element actions ${element.name}`} className="size-8" />,
+    },
+  )
   const living = await screen.findByTestId('element-env-1')
   await user.click(within(living).getByText('Living'))
   const child = await screen.findByTestId('child-cat-rent')


### PR DESCRIPTION
## Summary
- **Test fix:** the test "edit mode reserves the actions column on headers, children, archive rows and totals" (added in #107) has been failing since it landed: it asserts on the `budget-folder-Archived` section using the default fixture, whose only archived element is all-zero — and per the #104 visibility rule an all-zero archive section hides entirely. The fix seeds a nonzero archived element before rendering (the same recipe the neighboring archive-visibility test uses); the component behavior was already correct.
- **CI:** adds `.github/workflows/web-tests.yml` so the frontend suite gates pushes and PRs — this failure shipped because only the Go workflow ran. The job runs oxlint, `tsc -b` (neither oxlint nor vitest type-checks), and vitest for changes under `web/`, the shared `locales/` catalogues, or the workflow itself, with a raised test timeout (15s) for slow shared runners.

## Test plan
- [x] `pnpm vitest run src/features/budgets/BudgetTable.test.tsx` — 20/20 pass
- [x] Full frontend suite `pnpm test` — 552/552 across 97 files
- [x] `pnpm exec tsc -b` — clean
- [x] `make go-test` — passed (coverage 79.6%, min 78%)
- [x] The new **Web tests** workflow ran green on this PR (~2 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)