### PR TITLE
fix: reject non-numeric amount input and stop emitting "-0" on the wire

### DIFF
--- a/internal/shared/vo/decimal.go
+++ b/internal/shared/vo/decimal.go
@@ -329,12 +329,9 @@ func normalizeDecimal(num string) string {
 		num = "0" + num
 	}
 
-	// A leading "-" is PRESERVED even when the magnitude is zero: only the literal
-	// inputs "" and "0" are caught by the early return (before sign handling), so a
-	// stored "-0" / "-0.00000000" normalizes to "-0"
-	// (not "0"). SQLite's SUM() yields "-0" for some netted-to-zero account
-	// balances, and the API emits that byte-for-byte. Do NOT suppress the sign.
-	if negative {
+	// A zero magnitude drops the sign: SQLite's SUM() yields "-0" for some
+	// netted-to-zero account balances, and the API must emit an unsigned "0".
+	if negative && num != "0" {
 		return "-" + num
 	}
 	return num

--- a/internal/shared/vo/decimal_test.go
+++ b/internal/shared/vo/decimal_test.go
@@ -26,12 +26,11 @@ func TestNewDecimal_Normalize(t *testing.T) {
 		{"0", "0"},
 		{"0.00000000", "0"},
 		{"0.0", "0"},
-		// negative-zero PRESERVES the sign: "-0" stays "-0". Only the literal ""
-		// and "0" inputs collapse to "0" (caught before sign handling). SQLite
-		// SUM() emits "-0" for some netted-to-zero balances and the API surfaces
-		// that, so this must match byte-for-byte.
-		{"-0", "-0"},
-		{"-0.00000000", "-0"},
+		// negative zero collapses to unsigned "0": SQLite's SUM() emits "-0" for
+		// some netted-to-zero balances and the API must never surface a signed zero.
+		{"-0", "0"},
+		{"-0.00000000", "0"},
+		{"-0.0", "0"},
 		// negatives keep the sign.
 		{"-12.34000000", "-12.34"},
 		{"-0.50000000", "-0.5"},

--- a/web/src/lib/decimal.ts
+++ b/web/src/lib/decimal.ts
@@ -48,8 +48,7 @@ export function tryNormalize(raw: string): string | null {
 
 export function normalize(v: Numeric): string {
   // big(v) already truncates at scale 8; no need to truncate again.
-  // Note: -0 collapses to 0 during truncation (deliberate divergence from backend's
-  // wire contract preservation, since the UI never renders -0 to users).
+  // Note: -0 collapses to 0 during truncation (matching backend vo normalization).
   return toPlain(big(v))
 }
 

--- a/web/src/lib/validation.test.ts
+++ b/web/src/lib/validation.test.ts
@@ -1,4 +1,4 @@
-import { isValidHttpUrl, isValidEmail, isValidName, isValidPassword, isNotEmpty, isValidRecoveryCode, isValidDecimalNumber } from './validation'
+import { isValidHttpUrl, isValidEmail, isValidName, isValidPassword, isNotEmpty, isValidRecoveryCode, isValidDecimalNumber, isValidFormula } from './validation'
 
 it('validates http(s) urls only', () => {
   expect(isValidHttpUrl('https://a.test')).toBe(true)
@@ -26,6 +26,25 @@ it('treats empty as valid decimal and enforces up to 8 fraction digits', () => {
   expect(isValidDecimalNumber('')).toBe(true)
   expect(isValidDecimalNumber('-12.12345678')).toBe(true)
   expect(isValidDecimalNumber('1.123456789')).toBe(false)
+})
+
+it('isValidFormula accepts numbers and formulas', () => {
+  expect(isValidFormula('10.50')).toBe(true)
+  expect(isValidFormula('-5')).toBe(true)
+  expect(isValidFormula('9,99')).toBe(true)
+  expect(isValidFormula('5+5')).toBe(true)
+  expect(isValidFormula('5 + 5*2')).toBe(true)
+  expect(isValidFormula('5+5=')).toBe(true)
+  expect(isValidFormula('')).toBe(true)
+})
+
+it('isValidFormula rejects text that is not a number or formula', () => {
+  expect(isValidFormula('abc')).toBe(false)
+  expect(isValidFormula('12abc')).toBe(false)
+  expect(isValidFormula('$5')).toBe(false)
+  expect(isValidFormula('...')).toBe(false)
+  expect(isValidFormula('=')).toBe(false)
+  expect(isValidFormula('5+')).toBe(false)
 })
 
 it('isNotEmpty rejects empty string and null', () => {

--- a/web/src/lib/validation.ts
+++ b/web/src/lib/validation.ts
@@ -78,7 +78,20 @@ export function isValidRecoveryCode(value: string): boolean {
 }
 
 export function isValidFormula(value: string): boolean {
-  return validateFormula(sanitizeInput(value))
+  if (value.trim() === '') {
+    return true
+  }
+  // sanitizeInput silently strips foreign characters, so "abc" would sanitize
+  // to "" and validate as an empty (valid) formula — reject the raw text first
+  if (/[^0-9+\-*/=.,\s]/.test(value)) {
+    return false
+  }
+  const sanitized = sanitizeInput(value)
+  // non-empty input must still hold a number after sanitizing ("...", "=")
+  if (sanitized.replace(/=/g, '') === '') {
+    return false
+  }
+  return validateFormula(sanitized)
 }
 
 export function hasIncompleteFormula(value: string): boolean {


### PR DESCRIPTION
## What changed

**1. Transaction amount input accepts any text (frontend)**

`isValidFormula` ran `sanitizeInput` *before* validating, and sanitize strips all foreign characters — so `"abc"` became `""`, which validates as an empty (valid) formula, and the dialog silently submitted a **0-amount transaction**. The validator now:

- rejects raw input containing anything outside the number/formula alphabet (digits, `+ - * / = . ,`, whitespace) — matching the existing error copy *"Only numbers and operators (+, -, *, /, . and =) are allowed"*;
- rejects degenerate inputs that sanitize away to nothing (`"..."`, `"="`).

Valid input is untouched: `10.50`, `9,99`, `-5`, `5 + 5*2`, `5+5=` (still evaluates to `10`). The fix lives in the shared validator, so the account balance dialog (same hole) is covered too. The budget limit editor uses a different path (`limitAmountFromInput`) that already rejects unparseable input.

**2. Backend emits `-0` for netted-to-zero balances**

`vo.normalizeDecimal` deliberately preserved the sign on zero, surfacing SQLite `SUM()`'s `"-0"` byte-for-byte. Zero now always renders unsigned (`"0"`, also for `-0.0` / `-0.00000000`) at the single choke point every DB-sourced decimal passes through (account balances, budget hand-built SQL, everything). The frozen-contract expectations in `decimal_test.go` are flipped accordingly.

## Why

- Garbage amount input created real 0-amount transactions with no feedback.
- A signed zero on the wire is a leftover parity artifact from the PHP port; no client wants it.

## Reviewer notes

- This is a deliberate wire-contract change for the `-0` case only; apiparity goldens are byte-identical (no golden ever contained `-0`).
- Verified: full frontend suite (612 tests), `make go-test` (coverage 79.7%, min 78%), plus a live browser check of the transaction dialog against the demo DB (error shown for `abc`/`12abc`, formulas still evaluate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)