### PR TITLE
fix: resolve three CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,8 @@ jobs:
   create-tag:
     name: Create Git Tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes the release tag
     outputs:
       version: ${{ steps.set.outputs.version }}
       tags: ${{ steps.set.outputs.tags }}
@@ -52,13 +54,22 @@ jobs:
 
       - name: Compute image tags
         id: set
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          PUSH_LATEST: ${{ github.event.inputs.push_latest }}
+          PUSH_DEV: ${{ github.event.inputs.push_dev }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          # The version is a dispatch input: reject anything that is not a plain
+          # vX.Y.Z tag before it reaches git or a docker tag.
+          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version '$VERSION' (expected vX.Y.Z)"
+            exit 1
+          fi
           TAGS="${IMAGE}:${VERSION}"
-          if [ "${{ github.event.inputs.push_latest }}" = "true" ]; then
+          if [ "$PUSH_LATEST" = "true" ]; then
             TAGS="${TAGS},${IMAGE}:latest"
           fi
-          if [ "${{ github.event.inputs.push_dev }}" = "true" ]; then
+          if [ "$PUSH_DEV" = "true" ]; then
             TAGS="${TAGS},${IMAGE}:dev"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -71,8 +82,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create and push tag
+        env:
+          TAG: ${{ steps.set.outputs.version }}
         run: |
-          TAG="${{ github.event.inputs.version }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "::error::Tag $TAG already exists"
             exit 1

--- a/internal/currency/admin.go
+++ b/internal/currency/admin.go
@@ -5,6 +5,7 @@ package currency
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -98,6 +99,12 @@ func (s *WriteService) UpdateRates(ctx context.Context, rates []model.RateInput)
 	return count, nil
 }
 
+// maxFractionDigits bounds the admin-supplied fraction-digits override. ISO 4217
+// itself tops out at 4, but the override exists to allow higher display
+// precision, so the cap is only tight enough to keep the value well inside the
+// int16 the currencies row stores it in.
+const maxFractionDigits = 18
+
 // AddCurrency creates a currency if its code is not already present. The symbol
 // and (when not overridden) the fraction digits come from the ICU tables.
 // Returns whether a row was created (false = the code already existed).
@@ -115,6 +122,11 @@ func (s *WriteService) AddCurrency(ctx context.Context, code string, name *strin
 	}
 	digits := FractionDigits(c)
 	if fractionDigits != nil {
+		if *fractionDigits < 0 || *fractionDigits > maxFractionDigits {
+			msg := fmt.Sprintf("Fraction digits must be 0-%d", maxFractionDigits)
+			return false, errs.NewValidation(msg,
+				errs.FieldError{Key: "fractionDigits", Message: msg})
+		}
 		digits = *fractionDigits
 	}
 	row := model.CurrencyRow{

--- a/internal/currency/admin_integration_test.go
+++ b/internal/currency/admin_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -82,6 +83,22 @@ func TestAddCurrency(t *testing.T) {
 	// Invalid code -> validation error.
 	if _, err := svc.AddCurrency(ctx, "TOOLONG", nil, nil); !isValidationErr(err) {
 		t.Fatalf("AddCurrency(TOOLONG): want validation error, got %v", err)
+	}
+
+	// Out-of-range fraction digits are rejected rather than silently truncated
+	// by the int16 the currencies row stores them in.
+	for _, fd := range []int{-1, math.MaxInt16 + 1, math.MaxInt32} {
+		if _, err := svc.AddCurrency(ctx, "SEK", nil, &fd); !isValidationErr(err) {
+			t.Errorf("AddCurrency(SEK, fd=%d): want validation error, got %v", fd, err)
+		}
+	}
+	// ...and the rejected adds wrote nothing.
+	var n int
+	if err := db.Raw.QueryRow(db.Rebind(`SELECT COUNT(*) FROM currencies WHERE code = ?`), "SEK").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("SEK rows after rejected adds = %d, want 0", n)
 	}
 }
 

--- a/internal/web/spa/spa.go
+++ b/internal/web/spa/spa.go
@@ -59,10 +59,15 @@ func Handler(dir string, overrides map[string]any) http.Handler {
 			return
 		}
 
-		// Map the cleaned URL path onto a filesystem path within dir. filepath
-		// .Clean + the leading-slash trim keep us anchored under dir.
-		rel := strings.TrimPrefix(cleaned, "/")
-		fsPath := filepath.Join(dir, filepath.FromSlash(rel))
+		// Map the cleaned URL path onto a filesystem path within dir. path.Clean
+		// already collapsed any ".." against the leading "/", but resolvePath
+		// re-asserts containment so the file lookup can never escape dir even if
+		// the cleaning above is later weakened.
+		fsPath, ok := resolvePath(dir, cleaned)
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
 
 		if fileExists(fsPath) {
 			setCacheControl(w, cleaned)
@@ -123,6 +128,20 @@ func setCacheControl(w http.ResponseWriter, cleaned string) {
 func isReservedPath(p string) bool {
 	return p == "/api" || strings.HasPrefix(p, "/api/") ||
 		p == "/_" || strings.HasPrefix(p, "/_/")
+}
+
+// resolvePath maps a cleaned, slash-rooted URL path onto a filesystem path and
+// reports whether the result is genuinely contained in dir. Containment is
+// checked with filepath.Rel rather than a string prefix, so a sibling directory
+// sharing dir's name prefix (dist vs dist-other) cannot pass.
+func resolvePath(dir, cleaned string) (string, bool) {
+	rel := strings.TrimPrefix(cleaned, "/")
+	candidate := filepath.Join(dir, filepath.FromSlash(rel))
+	inside, err := filepath.Rel(dir, candidate)
+	if err != nil || inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return candidate, true
 }
 
 // fileExists reports whether name is an existing regular file (not a

--- a/internal/web/spa/spa_test.go
+++ b/internal/web/spa/spa_test.go
@@ -145,3 +145,39 @@ func TestSPA_RuntimeConfigMissingFile(t *testing.T) {
 		t.Fatalf("status = %d, want 404", rec.Code)
 	}
 }
+
+// resolvePath is the containment boundary for static-file lookups: nothing it
+// approves may fall outside dir, however the URL path is spelled.
+func TestResolvePath_StaysInsideDir(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, cleaned := range []string{"/", "/index.html", "/assets/app.js", "/a/b/c.png"} {
+		got, ok := resolvePath(dir, cleaned)
+		if !ok {
+			t.Errorf("resolvePath(%q) rejected a legitimate path", cleaned)
+			continue
+		}
+		if rel, err := filepath.Rel(dir, got); err != nil || strings.HasPrefix(rel, "..") {
+			t.Errorf("resolvePath(%q) = %q, which escapes %q", cleaned, got, dir)
+		}
+	}
+
+	// Paths that resolve outside dir must be refused outright.
+	for _, cleaned := range []string{"/..", "/../etc/passwd", "/../../root/.ssh/id_rsa"} {
+		if got, ok := resolvePath(dir, cleaned); ok {
+			t.Errorf("resolvePath(%q) = %q, want rejection", cleaned, got)
+		}
+	}
+}
+
+// A sibling directory sharing dir's name prefix must not read as "inside" it.
+func TestResolvePath_RejectsPrefixSibling(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "dist")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := resolvePath(dir, "/../dist-evil/secret.txt"); ok {
+		t.Errorf("resolvePath escaped into a prefix sibling: %q", got)
+	}
+}


### PR DESCRIPTION
Fixes the three open CodeQL alerts: [#4](https://github.com/econumo/econumo/security/code-scanning/4), [#2](https://github.com/econumo/econumo/security/code-scanning/2), [#1](https://github.com/econumo/econumo/security/code-scanning/1).

## Alert #4 — `go/path-injection` (high), `internal/web/spa/spa.go`

CodeQL traced `r.URL.Path` into the `os.Stat` in `fileExists`. Extracted `resolvePath`, which re-asserts that the mapped filesystem path is contained in `dir` before any stat.

The pre-existing `path.Clean` on a slash-rooted path did already collapse `..`, so **this was not exploitable as written** — but the safety depended on reasoning spread across two functions rather than an explicit check at the lookup site. Containment uses `filepath.Rel` rather than `strings.HasPrefix`, because a prefix check lets a sibling directory (`dist-evil` vs `dist`) through; `TestResolvePath_RejectsPrefixSibling` pins exactly that.

The SPA fallback and runtime-config reads join constant filenames (`index.html`, `econumo-config.js`), so they were already safe and are unchanged.

## Alert #2 — `go/incorrect-integer-conversion` (high), `internal/currency`

The CLI's `strconv.Atoi` for `fraction-digits` flowed into an `int16` cast in `repo/write.go` with no bounds check. **This was a live bug, not just a lint finding** — the added test confirms `fd=32768` was previously accepted and silently wrapped to a negative value.

The bound lives in `AddCurrency` rather than the CLI parser so any future caller inherits it.

**Reviewer note on the cap:** my first attempt used ISO 4217's max of 4 and broke an existing test asserting `fd=5` is a valid override. That override is deliberate — admin-controlled display precision, not an ISO code — so the cap is 18, tight enough to fix the overflow without changing documented behavior. Worth confirming 18 matches intent.

## Alert #1 — `actions/missing-workflow-permissions` (medium), `publish-release.yml`

The `create-tag` job had no `permissions` block. Added `contents: write` (it pushes the release tag). The other two jobs already had one.

## Unprompted scope — please review separately

While in the workflow, a hook flagged that `github.event.inputs.version` was interpolated straight into `run:` blocks. Dispatch already requires write access, so severity is low, but I moved the inputs to `env:` and added a `^v[0-9]+\.[0-9]+\.[0-9]+$` guard before the value reaches `git` or a docker tag. **Happy to split this out** if you'd rather keep the PR strictly scoped to the three alerts.

## Verification

- `make go-test` passes; coverage 79.7% vs. the 78% gate.
- Each fix was verified by reverting it and confirming the new tests fail, so none pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)