### PR TITLE
fix(transaction): accept account-owner category/payee/tag on shared accounts

### DIFF
--- a/internal/transaction/api/shared_access_test.go
+++ b/internal/transaction/api/shared_access_test.go
@@ -21,6 +21,11 @@ const (
 	ownerTwoEmail = "owner2@example.test"
 	ownerTwoSalt  = "0000000000000000000000000000000000000002"
 	sharedAcctID  = "aaaa2222-0000-0000-0000-0000000000a2"
+	// A category/payee owned by the shared account's OWNER (ownerTwo), not by the
+	// caller — this is what the SPA presents on a shared account (its picker
+	// filters to the account owner's entities).
+	ownerCatID   = "cccc2222-0000-0000-0000-0000000000c2"
+	ownerPayeeID = "dddd2222-0000-0000-0000-0000000000d2"
 
 	// roles (admin=0, user=1, guest=2) — matches connection.Role.
 	roleAdmin = 0
@@ -37,6 +42,10 @@ func (h *harness) shareAccount(t *testing.T, role int, grant bool) {
 	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite", TX: txm}).WithCrypto(testDataSalt)
 	f.User(fixture.User{ID: ownerTwoID, Email: ownerTwoEmail, Name: "Owner Two", Avatar: "https://avatar.test/o2", Password: "pw", Salt: ownerTwoSalt})
 	f.Account(fixture.Account{ID: sharedAcctID, UserID: ownerTwoID, CurrencyID: usdID, Name: "Shared"})
+	// The owner's own category/payee — the SPA presents these (not the caller's)
+	// when categorizing a transaction on the shared account.
+	f.Category(fixture.Category{ID: ownerCatID, UserID: ownerTwoID, Name: "Owner Food", Type: 0, Icon: "local_offer"})
+	f.Payee(fixture.Payee{ID: ownerPayeeID, UserID: ownerTwoID, Name: "Owner Market"})
 	if grant {
 		f.AccountAccess(sharedAcctID, seedUserID, role)
 	}
@@ -78,6 +87,32 @@ func TestCreateTransaction_SharedAccount_UserRole_Succeeds(t *testing.T) {
 	h.shareAccount(t, roleUser, true)
 	tok := h.token(t)
 	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok, sharedCreateReq(txID1, "10"))
+	if status != http.StatusOK {
+		t.Fatalf("status=%d want 200; body: %s", status, env.raw)
+	}
+	res := mustUnmarshal[writeResult](t, env.Data)
+	if res.Item.AccountID != sharedAcctID {
+		t.Fatalf("accountId = %q, want shared account %q", res.Item.AccountID, sharedAcctID)
+	}
+}
+
+// TestCreateTransaction_SharedAccount_UsesOwnerCategory_Succeeds reproduces the
+// real shared-account flow: the caller (user-role grantee) categorizes a
+// transaction on the shared account with the ACCOUNT OWNER's category/payee —
+// exactly what the SPA presents there. The reference check must accept entities
+// owned by the account owner, not only the caller's own. Regression guard
+// against the owner-only requireOwnedEntity check that rejected these with
+// transaction.item_not_available.
+func TestCreateTransaction_SharedAccount_UsesOwnerCategory_Succeeds(t *testing.T) {
+	h := newHarness(t)
+	h.shareAccount(t, roleUser, true)
+	tok := h.token(t)
+	req := map[string]any{
+		"id": txID1, "type": "expense", "amount": "10", "accountId": sharedAcctID,
+		"categoryId": ownerCatID, "payeeId": ownerPayeeID,
+		"date": "2024-03-01 10:00:00", "description": "shared",
+	}
+	status, env := h.do(t, http.MethodPost, "/api/v1/transaction/create-transaction", tok, req)
 	if status != http.StatusOK {
 		t.Fatalf("status=%d want 200; body: %s", status, env.raw)
 	}

--- a/internal/transaction/usecase.go
+++ b/internal/transaction/usecase.go
@@ -80,47 +80,74 @@ func notAvailableCode(msg string) string {
 //   - a transfer's recipient account needs the SAME write access as the source,
 //     else a caller could inject a leg into a stranger's account (its balance is
 //     SUM(amount_recipient) over that account id);
-//   - an optional category/payee/tag must belong to the CALLER — a caller
-//     categorizes a transaction (even one on a shared account) with their own
-//     entities, so a foreign category/payee/tag id is rejected.
+//   - an optional category/payee/tag must belong to the CALLER or to the OWNER
+//     of the account the transaction is on. On a shared account the SPA
+//     categorizes with the account owner's entities (its picker filters to the
+//     account owner), so a caller-only check would reject a legitimate
+//     co-sharer's transaction; a truly foreign (unconnected) id is still
+//     rejected.
 func (s *Service) checkReferences(ctx context.Context, userID vo.Id, st model.NewState) error {
 	if st.AccountRecipID != nil {
 		if err := s.checkWriteAccess(ctx, userID, *st.AccountRecipID, "account.account.not_available"); err != nil {
 			return err
 		}
 	}
+	// The account owner (== userID for an own account) whose entities are also
+	// acceptable references. Write access to st.AccountID is already verified by
+	// the caller, so the lookup resolves.
+	ownerID, err := s.accounts.AccountOwner(ctx, st.AccountID)
+	if err != nil {
+		return &errs.ValidationError{Msg: "account.account.not_available", MsgCode: errs.CodeTransactionAccountNotAvailable}
+	}
 	if st.CategoryID != nil {
-		if err := s.requireOwnedEntity(ctx, userID, *st.CategoryID, s.importer.CategoriesByOwner); err != nil {
+		if err := s.requireAvailableEntity(ctx, userID, ownerID, *st.CategoryID, s.importer.CategoriesByOwner); err != nil {
 			return err
 		}
 	}
 	if st.PayeeID != nil {
-		if err := s.requireOwnedEntity(ctx, userID, *st.PayeeID, s.importer.PayeesByOwner); err != nil {
+		if err := s.requireAvailableEntity(ctx, userID, ownerID, *st.PayeeID, s.importer.PayeesByOwner); err != nil {
 			return err
 		}
 	}
 	if st.TagID != nil {
-		if err := s.requireOwnedEntity(ctx, userID, *st.TagID, s.importer.TagsByOwner); err != nil {
+		if err := s.requireAvailableEntity(ctx, userID, ownerID, *st.TagID, s.importer.TagsByOwner); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// requireOwnedEntity confirms id is among ownerID's entities (the list is
-// owner-scoped, so membership IS the ownership check). A foreign or unknown id
-// yields the frozen item-not-available validation error.
-func (s *Service) requireOwnedEntity(ctx context.Context, ownerID, id vo.Id, list func(context.Context, vo.Id) ([]model.ImportNamed, error)) error {
-	items, err := list(ctx, ownerID)
-	if err != nil {
+// requireAvailableEntity confirms id belongs to the caller or to the account
+// owner (each list is owner-scoped, so membership IS the ownership check). A
+// foreign or unknown id yields the frozen item-not-available validation error.
+func (s *Service) requireAvailableEntity(ctx context.Context, callerID, accountOwnerID, id vo.Id, list func(context.Context, vo.Id) ([]model.ImportNamed, error)) error {
+	if ok, err := ownsEntity(ctx, callerID, id, list); err != nil {
 		return err
+	} else if ok {
+		return nil
 	}
-	for _, it := range items {
-		if it.ID == id.String() {
+	if !accountOwnerID.Equal(callerID) {
+		if ok, err := ownsEntity(ctx, accountOwnerID, id, list); err != nil {
+			return err
+		} else if ok {
 			return nil
 		}
 	}
 	return &errs.ValidationError{Msg: "transaction.transaction.not_available", MsgCode: errs.CodeTransactionItemNotAvailable}
+}
+
+// ownsEntity reports whether id is among ownerID's owner-scoped entities.
+func ownsEntity(ctx context.Context, ownerID, id vo.Id, list func(context.Context, vo.Id) ([]model.ImportNamed, error)) (bool, error) {
+	items, err := list(ctx, ownerID)
+	if err != nil {
+		return false, err
+	}
+	for _, it := range items {
+		if it.ID == id.String() {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // checkViewAccess verifies the user may VIEW the account's transactions: owner


### PR DESCRIPTION
## Summary

Fixes a regression from the IDOR hardening in #106 that broke transaction creation for every co-sharer on every shared account.

- `requireOwnedEntity` checked the referenced category/payee/tag against the **caller's** owner-scoped list only. On a shared account, the SPA legitimately presents the **account owner's** entities (`TransactionDialog` filters the pickers to `account.owner.id`; create-for-account assigns ownership to the account owner), so a partner's create/update was rejected with `400 transaction.item_not_available`.
- `checkReferences` now resolves the owner of the transaction's account and accepts entities owned by the caller **or** that account owner — exactly mirroring what the SPA can present.
- The IDOR protection is intact: the relaxation is scoped to the owner of the specific account the transaction is on, so a foreign entity on an own account is still denied (existing `idor_test.go` guards still pass).

## Root cause detail

The passing shared-account tests in #106 used a category owned by the caller, so the realistic case — partner using the owner's shared-budget category — was never covered. The new test seeds the owner's category+payee and reproduces the exact production failure envelope before the fix.

## Test plan

- [x] New `TestCreateTransaction_SharedAccount_UsesOwnerCategory_Succeeds` — red (400 `transaction.item_not_available`) before, green after
- [x] Existing IDOR guards (`TestCreateTransaction_ForeignCategory_Denied`, `ForeignTag`, `ForeignPayee`) still pass
- [x] `go test ./...` — 69 packages, 0 failures
- [x] apiparity + mcpparity goldens byte-identical
- [x] `gofmt` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)