### PR TITLE
ci: hotfix-capable release process via release/vX.Y.Z branches

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -6,11 +6,15 @@ description: Publish a new Econumo release end-to-end — pick the version, disp
 # Publish an Econumo release
 
 Releases are cut by the `Publish Release` workflow (`.github/workflows/publish-release.yml`),
-never by pushing tags or images locally. The workflow does three things in order: creates the
-annotated git tag, builds and pushes the multi-arch image to `ghcr.io/econumo/econumo`, and
-creates the GitHub release with auto-generated notes (changelogithub). Your job is to drive it,
-verify each artifact, and then replace the auto-generated notes with notes a human would want
-to read.
+never by pushing tags or images locally. The workflow's `branch` input selects the source
+branch (`main` by default; a `release/*` branch for hotfixes), and the dispatch itself always
+uses `--ref main` so the workflow definition never comes from a stale branch. The workflow
+does three things in order: auto-creates a `release/vX.Y.Z` branch at the source branch's
+head (the base for future hotfixes to that version) and the annotated git tag on the same
+commit, builds and pushes the multi-arch image to `ghcr.io/econumo/econumo`, and creates the
+GitHub release with auto-generated notes (changelogithub). Your job is to drive it, verify
+each artifact, and then replace the auto-generated notes with notes a human would want to
+read.
 
 Publishing is outward-facing and irreversible in practice (the tag and image are public
 immediately). Only run the dispatch when the user has explicitly asked for a release, and if
@@ -31,20 +35,54 @@ half-landed work in the log) and that the latest run of the Go tests workflow on
 green (`gh run list --workflow=go-tests.yml --branch main --limit 1`). Surface anything odd
 before dispatching — after dispatch there is no undo.
 
-## 2. Dispatch and watch
+For a **hotfix of an older version** the version is a patch bump of that line (bug in
+v1.1.1 → v1.1.2), regardless of what has since shipped from main.
+
+## 2. Prepare the source branch (hotfixes only)
+
+For a normal release there is nothing to prepare — the workflow auto-creates
+`release/vX.Y.Z` at the released commit, so every version leaves a branch behind as the
+base for future fixes.
+
+For a hotfix, the fixes must be on the source branch BEFORE dispatching. Land them on the
+release branch of the version being fixed (`release/vA.B.C`, auto-created when it was
+released) — cherry-pick the fix commits from main onto a working branch and PR it with the
+release branch as the base (or push the cherry-picks directly if the user prefers). If that
+branch doesn't exist (the version predates auto-created release branches), create it from
+the tag first:
 
 ```bash
-gh workflow run publish-release.yml --ref main -f version=vX.Y.Z -f push_latest=true
+git fetch --tags --quiet
+git push origin 'vA.B.C^{}':refs/heads/release/vA.B.C
 ```
 
-- `push_latest=true` is the norm for a real release from main — the workflow itself guards
-  `latest` to the main branch. Leave it off for pre-releases/betas.
+Confirm with `git log origin/release/vA.B.C` that the branch holds exactly the intended
+fixes and nothing else from main. Note the test workflows ignore pushes to `release/**` —
+only the PR route runs tests on the fixes, which is why it is the default; after a direct
+push, run the suites locally before dispatching.
+
+## 3. Dispatch and watch
+
+```bash
+# Normal release (source defaults to main):
+gh workflow run publish-release.yml --ref main -f version=vX.Y.Z -f push_latest=true
+
+# Hotfix (source = the fixed version's release branch):
+gh workflow run publish-release.yml --ref main -f version=vX.Y.Z -f branch=release/vA.B.C
+```
+
+- Always dispatch with `--ref main`; the `branch` input (default `main`) is what selects the
+  code being released.
+- `push_latest=true` is the norm when releasing the newest version. The workflow enforces it:
+  `latest` only moves when the source branch is `main` or `release/*` AND the version is
+  higher than every existing tag. For a hotfix of an older line, leave it off — the guard
+  would reject it anyway. Leave it off for pre-releases/betas too.
 - The workflow fails fast if the tag already exists.
 - Grab the run id (`gh run list --workflow=publish-release.yml --limit 1`) and watch it in the
   background: `gh run watch <run-id> --exit-status --interval 30` via a background Bash call.
-  The image build is the long step (several minutes) — use that time for step 3.
+  The image build is the long step (several minutes) — use that time for step 4.
 
-## 3. Write the release notes while the build runs
+## 4. Write the release notes while the build runs
 
 The auto-generated notes are just a commit list; always replace them. Gather substance first:
 the commit subjects give you the map, and `gh pr view <n> --json title,body` on the headline
@@ -95,23 +133,41 @@ a "with Claude (...) co-authoring" note rather than a separate contributor entry
 
 Draft the notes into a scratchpad file so `gh release edit --notes-file` can consume it.
 
-## 4. Verify, then apply the notes
+## 5. Verify, then apply the notes
 
 After the workflow succeeds (all three jobs green):
 
 ```bash
 gh release view vX.Y.Z --json tagName,isDraft,url        # release exists, not draft
-gh release edit vX.Y.Z --notes-file <notes.md> --latest  # replace notes, mark as latest
+gh release edit vX.Y.Z --notes-file <notes.md>           # replace notes
 docker buildx imagetools inspect ghcr.io/econumo/econumo:vX.Y.Z | grep Digest
 docker buildx imagetools inspect ghcr.io/econumo/econumo:latest  | grep Digest
 ```
 
-The two digests must match — that is the proof `latest` actually moved. Report the release
-URL, the digest check, and a summary of what the notes say; invite the user to adjust the
-wording, since the notes are public-facing prose.
+The workflow already aligns the GitHub "Latest" badge with `push_latest` — don't pass
+`--latest`/`--latest=false` yourself. When `push_latest` was set, the two digests must
+match — that is the proof `latest` actually moved; for a hotfix of an older line, verify
+the OPPOSITE: `latest` must still point at the newest version's digest, not the hotfix's.
+Report the release URL, the digest check, and a summary of what the notes say; invite the
+user to adjust the wording, since the notes are public-facing prose.
+
+## Hotfix example
+
+v1.1.1 is released, main already carries v1.2.0-bound work, and a bug is found in v1.1.1:
+
+```bash
+# land the fix on release/v1.1.1 (cherry-pick PR based on it; create the branch
+# from the v1.1.1 tag first only if the release predates auto-created branches), then:
+gh workflow run publish-release.yml --ref main -f version=v1.1.2 -f branch=release/v1.1.1
+```
+
+The workflow tags v1.1.2 on the fix commit and auto-creates `release/v1.1.2` there — the
+base for a future v1.1.3. No `push_latest`: `latest` keeps pointing at the newest line, and
+the workflow keeps the GitHub "Latest" badge off the hotfix release. Notes follow the
+normal flow with the range v1.1.1...v1.1.2.
 
 ## Updating notes on an already-published release
 
-Skip steps 1–2. Build the notes exactly as in step 3 (fetch tags first if the tag isn't
+Skip steps 1–3. Build the notes exactly as in step 4 (fetch tags first if the tag isn't
 local), then `gh release edit <tag> --notes-file <notes.md>`. Don't pass `--latest` unless
 the release should also become the latest one.

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -6,6 +6,10 @@ name: Go tests
 #                 Postgres service container
 on:
     push:
+        # release/* branches are cut by the publish workflow at already-tested
+        # commits; hotfix changes reach them via pull_request, which still runs.
+        branches-ignore:
+            - "release/**"
         paths:
             - "cmd/**"
             - "internal/**"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,11 +1,19 @@
 name: Publish Release
 
 # Publishes the Go backend image to ghcr.io/econumo/econumo ONLY.
-# - Always pushes the version tag (e.g. v1.2.3).
-# - Also pushes/moves "latest" only when push_latest is checked AND the workflow
-#   is dispatched from the main branch.
+# Dispatch from main (the dispatch ref only selects the workflow DEFINITION);
+# the code that gets tagged and built comes from the "branch" input — main by
+# default, or a release/vX.Y.Z branch for hotfixes of older versions.
+# - Always pushes the version tag (e.g. v1.2.3), and auto-creates a
+#   release/vX.Y.Z branch at the released commit (the base for future hotfixes
+#   to that version) when it does not already exist.
+# - Also pushes/moves "latest" only when push_latest is checked AND the source
+#   branch is main or release/* AND the version is the highest released so far
+#   (a hotfix to an old line can never move "latest").
 # - Also pushes/moves "dev" when push_dev is checked (any branch). Unlike
 #   `make publish-dev`, the UI version label is the release version, not "dev".
+# - The GitHub release's "Latest" badge follows push_latest, so an old-line
+#   hotfix published after a newer version is never badged as latest.
 
 on:
   workflow_dispatch:
@@ -13,6 +21,10 @@ on:
       version:
         description: "Version tag to publish (e.g., v1.2.3)"
         required: true
+      branch:
+        description: "Source branch to release from (e.g., release/v1.2.3)"
+        required: false
+        default: "main"
       push_latest:
         description: "Publish Latest"
         required: false
@@ -36,26 +48,22 @@ jobs:
     name: Create Git Tag
     runs-on: ubuntu-latest
     permissions:
-      contents: write # pushes the release tag
+      contents: write # pushes the release tag + release/vX.Y.Z branch
     outputs:
       version: ${{ steps.set.outputs.version }}
       tags: ${{ steps.set.outputs.tags }}
     steps:
-      - name: Guard "latest" to the main branch
-        if: ${{ github.event.inputs.push_latest == 'true' && github.ref_name != 'main' }}
-        run: |
-          echo "::error::'latest' can only be published from the main branch (dispatched from '${{ github.ref_name }}')."
-          exit 1
-
-      - name: Checkout code
+      - name: Checkout source branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
       - name: Compute image tags
         id: set
         env:
           VERSION: ${{ github.event.inputs.version }}
+          BRANCH: ${{ github.event.inputs.branch }}
           PUSH_LATEST: ${{ github.event.inputs.push_latest }}
           PUSH_DEV: ${{ github.event.inputs.push_dev }}
         run: |
@@ -64,6 +72,23 @@ jobs:
           if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Invalid version '$VERSION' (expected vX.Y.Z)"
             exit 1
+          fi
+          if [ "$PUSH_LATEST" = "true" ]; then
+            # "latest" must stay on the newest line: only main/release/* sources,
+            # and only a version above every tag released so far — a hotfix to an
+            # older line can never move it.
+            case "$BRANCH" in
+              main | release/*) ;;
+              *)
+                echo "::error::'latest' can only be published from main or a release/* branch (source branch is '$BRANCH')."
+                exit 1
+                ;;
+            esac
+            HIGHEST="$(git tag -l 'v[0-9]*' | sort -V | tail -n 1)"
+            if [ -n "$HIGHEST" ] && [ "$(printf '%s\n%s\n' "$HIGHEST" "$VERSION" | sort -V | tail -n 1)" != "$VERSION" ]; then
+              echo "::error::'latest' requires the highest version: $VERSION is not above the highest existing tag $HIGHEST."
+              exit 1
+            fi
           fi
           TAGS="${IMAGE}:${VERSION}"
           if [ "$PUSH_LATEST" = "true" ]; then
@@ -81,12 +106,27 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create and push tag
+      - name: Create release branch and tag
         env:
           TAG: ${{ steps.set.outputs.version }}
         run: |
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+          # Every release leaves a release/<version> branch at the released
+          # commit — the base for future hotfixes to that version. Created
+          # before the tag so a failed tag push can be re-run safely.
+          BRANCH_REF="refs/heads/release/${TAG}"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          EXISTING="$(git ls-remote origin "$BRANCH_REF" | cut -f1)"
+          if [ -z "$EXISTING" ]; then
+            git push origin "HEAD:${BRANCH_REF}"
+            echo "Created release/${TAG} at ${HEAD_SHA}"
+          elif [ "$EXISTING" = "$HEAD_SHA" ]; then
+            echo "release/${TAG} already exists at ${HEAD_SHA}; skipping creation"
+          else
+            echo "::error::release/${TAG} already exists at ${EXISTING}, which is not the commit being released (${HEAD_SHA})."
             exit 1
           fi
           git tag -a "$TAG" -m "Release $TAG"
@@ -152,3 +192,17 @@ jobs:
         run: npx changelogithub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub badges the newest CREATED release as "Latest" by default, which
+      # would mislabel a hotfix to an older line published after a newer version.
+      - name: Align the "Latest" badge with push_latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.create-tag.outputs.version }}
+          PUSH_LATEST: ${{ github.event.inputs.push_latest }}
+        run: |
+          if [ "$PUSH_LATEST" = "true" ]; then
+            gh release edit "$TAG" --latest
+          else
+            gh release edit "$TAG" --latest=false
+          fi

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -5,6 +5,10 @@ name: Web tests
 # locales/ is included because the SPA imports the shared catalogues.
 on:
     push:
+        # release/* branches are cut by the publish workflow at already-tested
+        # commits; hotfix changes reach them via pull_request, which still runs.
+        branches-ignore:
+            - "release/**"
         paths:
             - "web/**"
             - "locales/**"

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -3,6 +3,9 @@ name: Web tests
 # Guards the React SPA on every push + PR: oxlint, the tsc type-check
 # (neither oxlint nor vitest type-checks), and the vitest suite.
 # locales/ is included because the SPA imports the shared catalogues.
+# Backend paths are included too: the SPA talks to the API the backend
+# serves, so backend changes also run the frontend suite (the reverse is
+# not true — frontend changes never trigger the Go tests).
 on:
     push:
         # release/* branches are cut by the publish workflow at already-tested
@@ -12,11 +15,19 @@ on:
         paths:
             - "web/**"
             - "locales/**"
+            - "cmd/**"
+            - "internal/**"
+            - "go.mod"
+            - "go.sum"
             - ".github/workflows/web-tests.yml"
     pull_request:
         paths:
             - "web/**"
             - "locales/**"
+            - "cmd/**"
+            - "internal/**"
+            - "go.mod"
+            - "go.sum"
             - ".github/workflows/web-tests.yml"
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,12 @@ make publish-dev   # build + push the multi-arch `dev` image to ghcr.io/econumo/
 
 Releases (`latest` + `vX.Y.Z`) are cut by the GitHub release workflow
 (`.github/workflows/publish-release.yml`), not locally; its "Publish Dev"
-checkbox can also move the `dev` tag. Everything publishes to
-`ghcr.io/econumo/econumo` only.
+checkbox can also move the `dev` tag. The workflow's `branch` input selects
+the source branch (default `main`; a `release/*` branch for hotfixes of older
+versions), it auto-creates `release/vX.Y.Z` at every released commit as the
+base for future hotfixes, and `latest` only moves for the highest version
+released so far. See `.claude/skills/publish-release` for the full process.
+Everything publishes to `ghcr.io/econumo/econumo` only.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ base for future hotfixes, and `latest` only moves for the highest version
 released so far. See `.claude/skills/publish-release` for the full process.
 Everything publishes to `ghcr.io/econumo/econumo` only.
 
+### Branch naming
+
+- `feature/<slug>` — feature work, and the default for EVERY change that is
+  not a bug fix (chores, docs, refactors, CI, dependency bumps).
+- `bug/<slug>` — bug fixes.
+- `release/vX.Y.Z` — reserved for the release workflow (auto-created at each
+  released commit); never used for development work.
+
 ## Architecture
 
 ### Feature packages (vertical slices)

--- a/docs/superpowers/specs/2026-07-20-release-branches-design.md
+++ b/docs/superpowers/specs/2026-07-20-release-branches-design.md
@@ -1,0 +1,92 @@
+# Release branches (hotfix-capable release process)
+
+**Date:** 2026-07-20
+**Status:** Approved (autonomous session; decisions recorded for review)
+
+## Problem
+
+Releases are tagged straight off `main`. Once newer work lands on `main` (e.g.
+changes intended for v1.2.0), there is no way to ship a fix for an older
+version (e.g. a bug found in v1.1.1) without also shipping everything that came
+after it. The `Publish Release` workflow also hard-guards the `latest` image
+tag to dispatches from `main`, which makes releasing from any other branch a
+second-class path.
+
+## Decision
+
+### Process
+
+1. **Every release auto-creates its `release/vX.Y.Z` branch**: the workflow
+   pushes `release/<version>` at the released commit (skipped when it already
+   exists there; an existing branch at a *different* commit is an error), so
+   every version leaves a branch behind as the base for future fixes. Nothing
+   to prepare for a normal release from `main`.
+2. **Hotfix of an older version**: land the fixes on the fixed version's
+   release branch (`release/vA.B.C`; if the version predates auto-created
+   branches, create it from the tag:
+   `git push origin 'vA.B.C^{}':refs/heads/release/vA.B.C`), then dispatch
+   with `branch=release/vA.B.C` and the bumped `version`. The workflow tags
+   the fix commit and auto-creates the new version's branch there.
+3. **Dispatch the workflow from `main`** in all cases. Dispatching from `main`
+   means the workflow *definition* always comes from `main`, so hotfix
+   branches cut from old tags never run a stale copy of the pipeline; the
+   `branch` input alone selects the code being released.
+
+Release branches are kept after the release; they are the base for future
+fixes to that line.
+
+### Pipeline (`.github/workflows/publish-release.yml`)
+
+- New `workflow_dispatch` input **`branch`** (default `main`): the ref the
+  `create-tag` job checks out, tags, and the later jobs build. The default
+  keeps the pre-existing "release what's on main" flow working unchanged.
+- The `create-tag` job pushes `release/<version>` at the checked-out head
+  before tagging (duplicate-tag check first, then branch, then tag — so a
+  failed tag push can be re-run safely: an existing branch at the same commit
+  is skipped, at a different commit it fails the run).
+- The old guard ("`latest` only when dispatched from `main`") is **replaced** —
+  under the new model releases come from `release/*` branches, so it would
+  block every `latest`. New `push_latest` guard, checked in `create-tag`:
+  1. the source branch is `main` or `release/*`, and
+  2. the version is the highest `v*` tag in the repo by semver order
+     (`sort -V`) — so a hotfix to an old line can never move `latest`.
+- New step in `create-github-release`: after changelogithub creates the
+  release, set the GitHub **"Latest release" badge** to match `push_latest`
+  (`gh release edit --latest` / `--latest=false`). GitHub otherwise badges
+  the newest *created* release as latest, which would mislabel an old-line
+  hotfix published after a newer version.
+- The test workflows (`go-tests.yml`, `web-tests.yml`) ignore pushes to
+  `release/**`: those branches are cut at already-tested commits, and hotfix
+  changes reach them via pull requests, whose `pull_request` checks still run.
+  (Auto-created branches wouldn't trigger CI anyway — `GITHUB_TOKEN` pushes
+  never start workflows — but the filter also covers manual pushes.)
+
+### Docs
+
+- `.claude/skills/publish-release/SKILL.md`: branch-creation step, the
+  `branch` dispatch flag, a hotfix walkthrough, and dropping the manual
+  `--latest` (the workflow now owns the badge).
+- `CLAUDE.md` Publishing section: one-line mention of release branches.
+
+## Alternatives considered
+
+- **Use the native `workflow_dispatch` ref as the source branch** (no input;
+  `gh workflow run --ref release/vX.Y.Z`). Rejected: a hotfix branch cut from
+  an old tag carries the workflow file as of that tag, so old releases would
+  run old pipeline code (missing guards/fixes). The explicit input keeps one
+  pipeline definition (main's) for all releases.
+- **Per-minor-line branches (`release/v1.1`)** holding all patch tags of a
+  line. Standard elsewhere and fewer branches, but the user specified
+  `release/vX.X.X` (per-version) naming; per-version is also unambiguous about
+  what each branch produced. Revisit if branch count becomes a nuisance.
+- **Manual release-branch creation before every dispatch** (the first
+  iteration of this design). Replaced at the user's request by auto-creation
+  inside the workflow: normal releases need no manual step, and every version
+  reliably leaves its branch behind. Hotfix *fixes* still land before dispatch
+  by construction — they go on the fixed version's already-existing branch.
+
+## Not changing
+
+- Tag creation, image build/push, changelogithub notes, `push_dev`, the
+  version-format validation, and the duplicate-tag check all stay as they are.
+- The `dev` tag remains publishable from any branch.


### PR DESCRIPTION
## Summary

Makes it possible to ship patch releases for older versions after main has moved on (e.g. fix a bug in v1.1.1 while v1.2.0-bound work is already merged).

- **`Publish Release` gains a `branch` input** (default `main`) selecting the code to tag and build; dispatches always use `--ref main` so the workflow definition never comes from a stale branch.
- **Every release auto-creates `release/vX.Y.Z`** at the released commit — the base for future hotfixes to that version. Idempotent on re-runs; a pre-existing branch at a different commit fails the run before tagging.
- **New `latest` guard** (replaces "only from main", which the branch model would break): `push_latest` requires a `main`/`release/*` source *and* a version above every existing tag — an old-line hotfix can never move the `latest` image tag.
- **GitHub "Latest" badge follows `push_latest`** — GitHub otherwise badges the newest *created* release as latest, mislabeling hotfixes published after a newer version.
- **Test workflows ignore pushes to `release/**`** — those branches are cut at already-tested commits; hotfix changes reach them via PRs, whose checks still run.
- **Test-trigger rules**: backend tests run only on backend changes; the frontend suite runs on both frontend and backend changes (the SPA consumes the API); changes touching neither run no tests.
- Docs: publish-release skill (incl. a hotfix walkthrough), CLAUDE.md (release process + new `feature/` / `bug/` branch-naming convention), and a design doc under `docs/superpowers/specs/`.

## Hotfix flow (after this lands)

```bash
# fixes land on the fixed version's branch via a PR based on release/v1.1.1, then:
gh workflow run publish-release.yml --ref main -f version=v1.1.2 -f branch=release/v1.1.1
```

## Verification

- All three workflow files parse (yaml).
- The `push_latest` guard and the branch+tag creation step were exercised locally against simulated tag sets / a bare remote: hotfix-with-latest rejected, new-highest accepted (incl. `sort -V` ordering), duplicate tag aborts first, mismatched pre-existing branch aborts before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
