### PR TITLE
ci: create release branches only from main; fixes flow back at the commit level

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -67,6 +67,23 @@ fixes and nothing else from main. Note the test workflows ignore pushes to `rele
 only the PR route runs tests on the fixes, which is why it is the default; after a direct
 push, run the suites locally before dispatching.
 
+**The fix must reach main too**, or the next release from main regresses the bug. Release
+branches are never merged wholesale into main — they exist to pin what shipped; the fix
+flows back at the commit level. Default direction: the fix lands on main FIRST (normal PR)
+and is cherry-picked onto the release branch, so there is nothing to port back. Only when
+the fix has to be authored on the release branch directly (the code on main has diverged or
+the bug no longer exists there in the same shape) does it need a forward-port: after the
+release, cherry-pick it onto a working branch and PR it into main. Audit that nothing was
+left behind:
+
+```bash
+git log --no-merges --right-only --cherry-pick --oneline main...origin/release/vX.Y.Z
+```
+
+Empty output means every commit on the release branch is patch-equivalent to one on main;
+anything listed still needs a forward-port (or a deliberate decision that main doesn't need
+it — say so in the release notes).
+
 ## 3. Dispatch and watch
 
 ```bash
@@ -174,7 +191,8 @@ The workflow tags v1.1.2 at the branch head and creates no new branch — `relea
 already is the release branch; a future v1.1.3 starts by copying it the same way. No
 `push_latest`: `latest` keeps pointing at the newest line, and the workflow keeps the
 GitHub "Latest" badge off the hotfix release. Notes follow the normal flow with the range
-v1.1.1...v1.1.2.
+v1.1.1...v1.1.2. Afterwards, verify the fix is also on main (it normally started there);
+if it was authored on the release branch, forward-port it now — see step 2.
 
 ## Updating notes on an already-published release
 

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -9,12 +9,13 @@ Releases are cut by the `Publish Release` workflow (`.github/workflows/publish-r
 never by pushing tags or images locally. The workflow's `branch` input selects the source
 branch (`main` by default; a `release/*` branch for hotfixes), and the dispatch itself always
 uses `--ref main` so the workflow definition never comes from a stale branch. The workflow
-does three things in order: auto-creates a `release/vX.Y.Z` branch at the source branch's
-head (the base for future hotfixes to that version) and the annotated git tag on the same
-commit, builds and pushes the multi-arch image to `ghcr.io/econumo/econumo`, and creates the
-GitHub release with auto-generated notes (changelogithub). Your job is to drive it, verify
-each artifact, and then replace the auto-generated notes with notes a human would want to
-read.
+does three things in order: creates the annotated git tag at the source branch's head (a
+release from `main` also leaves a `release/vX.Y.Z` branch at the same commit — the base for
+future hotfixes to that version; a release from a `release/*` source creates no branch,
+because that source is itself the release branch), builds and pushes the multi-arch image
+to `ghcr.io/econumo/econumo`, and creates the GitHub release with auto-generated notes
+(changelogithub). Your job is to drive it, verify each artifact, and then replace the
+auto-generated notes with notes a human would want to read.
 
 Publishing is outward-facing and irreversible in practice (the tag and image are public
 immediately). Only run the dispatch when the user has explicitly asked for a release, and if
@@ -40,23 +41,28 @@ v1.1.1 → v1.1.2), regardless of what has since shipped from main.
 
 ## 2. Prepare the source branch (hotfixes only)
 
-For a normal release there is nothing to prepare — the workflow auto-creates
-`release/vX.Y.Z` at the released commit, so every version leaves a branch behind as the
-base for future fixes.
+For a normal release there is nothing to prepare — releasing from `main` auto-creates
+`release/vX.Y.Z` at the released commit, so every version cut from main leaves a branch
+behind as the base for future fixes.
 
-For a hotfix, the fixes must be on the source branch BEFORE dispatching. Land them on the
-release branch of the version being fixed (`release/vA.B.C`, auto-created when it was
-released) — cherry-pick the fix commits from main onto a working branch and PR it with the
-release branch as the base (or push the cherry-picks directly if the user prefers). If that
-branch doesn't exist (the version predates auto-created release branches), create it from
-the tag first:
+For a hotfix, the workflow creates NO branch (the rule: release branches are only created
+for releases from main) — the new version's branch is prepared by hand. Copy the fixed
+version's release branch to the new version's name, then land the fixes on the copy:
 
 ```bash
-git fetch --tags --quiet
-git push origin 'vA.B.C^{}':refs/heads/release/vA.B.C
+git fetch origin --tags --quiet
+# the new version's branch, copied from the fixed version's release branch:
+git push origin origin/release/vA.B.C:refs/heads/release/vX.Y.Z
+# or, if vA.B.C predates release branches, from its tag:
+git push origin 'vA.B.C^{}':refs/heads/release/vX.Y.Z
 ```
 
-Confirm with `git log origin/release/vA.B.C` that the branch holds exactly the intended
+Land the fixes on `release/vX.Y.Z` — cherry-pick the fix commits from main onto a working
+branch and PR it with that branch as the base (or push the cherry-picks directly if the
+user prefers). The old branch `release/vA.B.C` stays untouched at its released commit, so
+every release branch keeps pointing at exactly what its version shipped.
+
+Confirm with `git log origin/release/vX.Y.Z` that the branch holds exactly the intended
 fixes and nothing else from main. Note the test workflows ignore pushes to `release/**` —
 only the PR route runs tests on the fixes, which is why it is the default; after a direct
 push, run the suites locally before dispatching.
@@ -67,8 +73,8 @@ push, run the suites locally before dispatching.
 # Normal release (source defaults to main):
 gh workflow run publish-release.yml --ref main -f version=vX.Y.Z -f push_latest=true
 
-# Hotfix (source = the fixed version's release branch):
-gh workflow run publish-release.yml --ref main -f version=vX.Y.Z -f branch=release/vA.B.C
+# Hotfix (source = the NEW version's hand-prepared release branch):
+gh workflow run publish-release.yml --ref main -f version=vX.Y.Z -f branch=release/vX.Y.Z
 ```
 
 - Always dispatch with `--ref main`; the `branch` input (default `main`) is what selects the
@@ -156,15 +162,19 @@ user to adjust the wording, since the notes are public-facing prose.
 v1.1.1 is released, main already carries v1.2.0-bound work, and a bug is found in v1.1.1:
 
 ```bash
-# land the fix on release/v1.1.1 (cherry-pick PR based on it; create the branch
-# from the v1.1.1 tag first only if the release predates auto-created branches), then:
-gh workflow run publish-release.yml --ref main -f version=v1.1.2 -f branch=release/v1.1.1
+# copy the fixed version's branch to the new version's name (from the v1.1.1
+# tag instead if the release predates release branches):
+git fetch origin --tags --quiet
+git push origin origin/release/v1.1.1:refs/heads/release/v1.1.2
+# land the fix on release/v1.1.2 (cherry-pick PR based on it), then:
+gh workflow run publish-release.yml --ref main -f version=v1.1.2 -f branch=release/v1.1.2
 ```
 
-The workflow tags v1.1.2 on the fix commit and auto-creates `release/v1.1.2` there — the
-base for a future v1.1.3. No `push_latest`: `latest` keeps pointing at the newest line, and
-the workflow keeps the GitHub "Latest" badge off the hotfix release. Notes follow the
-normal flow with the range v1.1.1...v1.1.2.
+The workflow tags v1.1.2 at the branch head and creates no new branch — `release/v1.1.2`
+already is the release branch; a future v1.1.3 starts by copying it the same way. No
+`push_latest`: `latest` keeps pointing at the newest line, and the workflow keeps the
+GitHub "Latest" badge off the hotfix release. Notes follow the normal flow with the range
+v1.1.1...v1.1.2.
 
 ## Updating notes on an already-published release
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,9 +4,11 @@ name: Publish Release
 # Dispatch from main (the dispatch ref only selects the workflow DEFINITION);
 # the code that gets tagged and built comes from the "branch" input — main by
 # default, or a release/vX.Y.Z branch for hotfixes of older versions.
-# - Always pushes the version tag (e.g. v1.2.3), and auto-creates a
-#   release/vX.Y.Z branch at the released commit (the base for future hotfixes
-#   to that version) when it does not already exist.
+# - Always pushes the version tag (e.g. v1.2.3). When the source branch is
+#   main, also creates a release/vX.Y.Z branch at the released commit (the
+#   base for future hotfixes to that version). Any other source creates no
+#   branch — a release/* source IS the release branch, prepared by hand
+#   before dispatch (copied from the previous release branch of that line).
 # - Also pushes/moves "latest" only when push_latest is checked AND the source
 #   branch is main or release/* AND the version is the highest released so far
 #   (a hotfix to an old line can never move "latest").
@@ -109,25 +111,33 @@ jobs:
       - name: Create release branch and tag
         env:
           TAG: ${{ steps.set.outputs.version }}
+          BRANCH: ${{ github.event.inputs.branch }}
         run: |
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "::error::Tag $TAG already exists"
             exit 1
           fi
-          # Every release leaves a release/<version> branch at the released
-          # commit — the base for future hotfixes to that version. Created
-          # before the tag so a failed tag push can be re-run safely.
-          BRANCH_REF="refs/heads/release/${TAG}"
-          HEAD_SHA="$(git rev-parse HEAD)"
-          EXISTING="$(git ls-remote origin "$BRANCH_REF" | cut -f1)"
-          if [ -z "$EXISTING" ]; then
-            git push origin "HEAD:${BRANCH_REF}"
-            echo "Created release/${TAG} at ${HEAD_SHA}"
-          elif [ "$EXISTING" = "$HEAD_SHA" ]; then
-            echo "release/${TAG} already exists at ${HEAD_SHA}; skipping creation"
+          # A release from main leaves a release/<version> branch at the
+          # released commit — the base for future hotfixes to that version.
+          # Any other source creates no branch: a release/* source is itself
+          # the release branch, prepared by hand before dispatch. The branch
+          # is created before the tag so a failed tag push can be re-run
+          # safely.
+          if [ "$BRANCH" = "main" ]; then
+            BRANCH_REF="refs/heads/release/${TAG}"
+            HEAD_SHA="$(git rev-parse HEAD)"
+            EXISTING="$(git ls-remote origin "$BRANCH_REF" | cut -f1)"
+            if [ -z "$EXISTING" ]; then
+              git push origin "HEAD:${BRANCH_REF}"
+              echo "Created release/${TAG} at ${HEAD_SHA}"
+            elif [ "$EXISTING" = "$HEAD_SHA" ]; then
+              echo "release/${TAG} already exists at ${HEAD_SHA}; skipping creation"
+            else
+              echo "::error::release/${TAG} already exists at ${EXISTING}, which is not the commit being released (${HEAD_SHA})."
+              exit 1
+            fi
           else
-            echo "::error::release/${TAG} already exists at ${EXISTING}, which is not the commit being released (${HEAD_SHA})."
-            exit 1
+            echo "Source branch '${BRANCH}' is not main; not creating a release branch"
           fi
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,10 @@ Releases (`latest` + `vX.Y.Z`) are cut by the GitHub release workflow
 (`.github/workflows/publish-release.yml`), not locally; its "Publish Dev"
 checkbox can also move the `dev` tag. The workflow's `branch` input selects
 the source branch (default `main`; a `release/*` branch for hotfixes of older
-versions), it auto-creates `release/vX.Y.Z` at every released commit as the
-base for future hotfixes, and `latest` only moves for the highest version
+versions). A release from `main` auto-creates `release/vX.Y.Z` at the released
+commit as the base for future hotfixes; a hotfix dispatches from a new
+`release/*` branch copied by hand from the fixed version's branch, and the
+workflow then creates no branch. `latest` only moves for the highest version
 released so far. See `.claude/skills/publish-release` for the full process.
 Everything publishes to `ghcr.io/econumo/econumo` only.
 
@@ -72,8 +74,9 @@ Everything publishes to `ghcr.io/econumo/econumo` only.
 - `feature/<slug>` — feature work, and the default for EVERY change that is
   not a bug fix (chores, docs, refactors, CI, dependency bumps).
 - `bug/<slug>` — bug fixes.
-- `release/vX.Y.Z` — reserved for the release workflow (auto-created at each
-  released commit); never used for development work.
+- `release/vX.Y.Z` — reserved for releases (auto-created when releasing from
+  `main`; copied by hand from the previous release branch of the line for
+  hotfixes); never used for development work.
 
 ## Architecture
 

--- a/docs/superpowers/specs/2026-07-20-release-branches-design.md
+++ b/docs/superpowers/specs/2026-07-20-release-branches-design.md
@@ -36,6 +36,15 @@ second-class path.
    means the workflow *definition* always comes from `main`, so hotfix
    branches cut from old tags never run a stale copy of the pipeline; the
    `branch` input alone selects the code being released.
+4. **No fix is lost to a release branch**: release branches are never merged
+   wholesale into `main` — the fix flows back at the commit level. Default
+   direction is main-first (the fix lands on `main`, then is cherry-picked
+   onto the release branch), so there is nothing to port back; a fix authored
+   directly on a release branch is forward-ported to `main` with a cherry-pick
+   PR after the release. Audit for leftovers with
+   `git log --no-merges --right-only --cherry-pick main...release/vX.Y.Z`
+   (patch-equivalence, so cherry-picked commits with different SHAs don't
+   show up as missing).
 
 Release branches are kept after the release; they are the base for future
 fixes to that line.
@@ -96,6 +105,14 @@ fixes to that line.
   the hotfix branch is a hand-made copy of the old release branch under the
   new version's name, the workflow only tags it, and old release branches
   never drift past the commit their version shipped.
+
+- **Merging release branches back into `main`** (git-flow style) to guarantee
+  no fix is lost. Rejected: most hotfix commits are cherry-picks *from* main,
+  so a merge is empty-or-conflicting noise, and a release branch also carries
+  the old line's history, which a merge would entangle with main's. The
+  commit-level flow above (main-first by default, forward-port cherry-pick
+  PR otherwise, patch-equivalence audit) keeps main complete without ever
+  merging a release branch.
 
 ## Not changing
 

--- a/docs/superpowers/specs/2026-07-20-release-branches-design.md
+++ b/docs/superpowers/specs/2026-07-20-release-branches-design.md
@@ -16,17 +16,22 @@ second-class path.
 
 ### Process
 
-1. **Every release auto-creates its `release/vX.Y.Z` branch**: the workflow
-   pushes `release/<version>` at the released commit (skipped when it already
-   exists there; an existing branch at a *different* commit is an error), so
-   every version leaves a branch behind as the base for future fixes. Nothing
-   to prepare for a normal release from `main`.
-2. **Hotfix of an older version**: land the fixes on the fixed version's
-   release branch (`release/vA.B.C`; if the version predates auto-created
-   branches, create it from the tag:
-   `git push origin 'vA.B.C^{}':refs/heads/release/vA.B.C`), then dispatch
-   with `branch=release/vA.B.C` and the bumped `version`. The workflow tags
-   the fix commit and auto-creates the new version's branch there.
+1. **A release from `main` auto-creates its `release/vX.Y.Z` branch**: the
+   workflow pushes `release/<version>` at the released commit (skipped when it
+   already exists there; an existing branch at a *different* commit is an
+   error), so every version cut from main leaves a branch behind as the base
+   for future fixes. Nothing to prepare for a normal release from `main`.
+   A release from any other source branch creates **no** branch — the rule is
+   "create a release branch only when releasing from main; never when the
+   dispatch already names a release branch".
+2. **Hotfix of an older version**: copy the fixed version's release branch to
+   the new version's name
+   (`git push origin origin/release/vA.B.C:refs/heads/release/vX.Y.Z`; if the
+   version predates release branches, from the tag:
+   `git push origin 'vA.B.C^{}':refs/heads/release/vX.Y.Z`), land the fixes on
+   the copy, then dispatch with `branch=release/vX.Y.Z` and the same
+   `version`. The workflow tags the branch head and creates nothing — the old
+   branch stays pinned at exactly what its version shipped.
 3. **Dispatch the workflow from `main`** in all cases. Dispatching from `main`
    means the workflow *definition* always comes from `main`, so hotfix
    branches cut from old tags never run a stale copy of the pipeline; the
@@ -41,9 +46,11 @@ fixes to that line.
   `create-tag` job checks out, tags, and the later jobs build. The default
   keeps the pre-existing "release what's on main" flow working unchanged.
 - The `create-tag` job pushes `release/<version>` at the checked-out head
-  before tagging (duplicate-tag check first, then branch, then tag — so a
-  failed tag push can be re-run safely: an existing branch at the same commit
-  is skipped, at a different commit it fails the run).
+  before tagging, but only when the `branch` input is `main` (duplicate-tag
+  check first, then branch, then tag — so a failed tag push can be re-run
+  safely: an existing branch at the same commit is skipped, at a different
+  commit it fails the run). Any other source skips branch creation with a
+  log notice.
 - The old guard ("`latest` only when dispatched from `main`") is **replaced** —
   under the new model releases come from `release/*` branches, so it would
   block every `latest`. New `push_latest` guard, checked in `create-tag`:
@@ -81,9 +88,14 @@ fixes to that line.
   what each branch produced. Revisit if branch count becomes a nuisance.
 - **Manual release-branch creation before every dispatch** (the first
   iteration of this design). Replaced at the user's request by auto-creation
-  inside the workflow: normal releases need no manual step, and every version
-  reliably leaves its branch behind. Hotfix *fixes* still land before dispatch
-  by construction — they go on the fixed version's already-existing branch.
+  inside the workflow for main releases: normal releases need no manual step.
+- **Auto-creating the new version's branch on every release, hotfixes
+  included** (the second iteration: fixes land on the *fixed* version's
+  branch, and the workflow creates `release/<new-version>` at the fix
+  commit). Replaced at the user's request by the create-only-from-main rule:
+  the hotfix branch is a hand-made copy of the old release branch under the
+  new version's name, the workflow only tags it, and old release branches
+  never drift past the commit their version shipped.
 
 ## Not changing
 


### PR DESCRIPTION
## Summary

Refines the hotfix-capable release process merged in #134 with two rules that came out of walking through the hotfix flow:

- **Release branches are created only by releases from `main`.** The workflow pushes `release/vX.Y.Z` at the released commit only when the `branch` input is `main`. A dispatch that already names a `release/*` branch creates **nothing** — that branch *is* the release branch, prepared by hand as a copy of the fixed version's branch (`git push origin origin/release/vA.B.C:refs/heads/release/vX.Y.Z`) with the fixes landed on the copy. Every release branch therefore stays pinned at exactly the commit its version shipped, instead of the old line's branch drifting past its tag when a hotfix is cut from it.
- **Nothing is lost to a release branch.** Release branches are never merged wholesale into main — fixes flow back at the commit level. Default direction is main-first (the fix lands on main, cherry-picked onto the release branch — nothing to port back); a fix authored directly on a release branch is forward-ported via a cherry-pick PR after the release. A patch-equivalence audit proves completeness: `git log --no-merges --right-only --cherry-pick main...release/vX.Y.Z` (empty output = every fix is on main in some form).

The `publish-release` skill's hotfix walkthrough, CLAUDE.md's Publishing/branch-naming sections, and the design doc are updated to the copy-first flow (including the rejected git-flow merge-back alternative and why).

## Test plan

- [x] YAML parses; every embedded `run:` script passes `bash -n`
- [x] `branch=main` dispatch path unchanged from #134 apart from the (already-idempotent) branch push now being main-only
- [ ] Real-world check on the next hotfix: dispatch from a copied `release/*` branch and confirm the workflow creates no extra branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)