### PR TITLE
feat: single-binary deployment — embedded SPA, release binaries, systemd

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ ECONUMO_TRIAL=none
 # ECONUMO_API_URL=https://api.example.com
 # ECONUMO_ALLOW_CUSTOM_API=false
 
+# Serve the web UI from a directory on disk instead of the SPA embedded in
+# the binary (dev override / separately-built frontend). Unset = embedded.
+# ECONUMO_WEB_DIST=web/dist
+
 # CORS allowlist for cross-origin browser requests. Empty (default) = same-domain
 # only: the bundled SPA and API share an origin, so no extra config is needed.
 # Set a comma-separated list of allowed origins when the frontend is hosted on a

--- a/.env.example
+++ b/.env.example
@@ -26,16 +26,23 @@ ECONUMO_ALLOW_REGISTRATION=true
 # Trial granted at registration: none (default) | end-of-next-month
 ECONUMO_TRIAL=none
 
-# Optional web-UI overrides, merged into the SPA's runtime config. Unset =
-# keep the value baked into the SPA build. API_URL points the web UI at an
-# API served on another origin; ALLOW_CUSTOM_API shows/hides the
-# "use my own server" toggle on the login and registration pages.
+# Optional web-UI overrides. The SPA itself is always embedded in the binary;
+# these values are merged into the served econumo-config.js at runtime. Each
+# mirrors a window.econumoConfig key under the ECONUMO_<KEY> name, and the
+# backend value overwrites the embedded default only when set (leave a value
+# blank to keep the built-in default).
+#   API_URL           point the web UI at an API on another origin
+#   ALLOW_CUSTOM_API  show/hide the "use my own server" toggle on login/register
+#   LILTAG_CONFIG_URL load the liltag tag config from a URL instead of the
+#                     bundled liltag-config.json (e.g. a remote/CDN config)
+#   LILTAG_CACHE_TTL  liltag config cache TTL in seconds
+#   VERSION           override the UI version label (defaults to the binary
+#                     version; handy for demo/staging environments)
 # ECONUMO_API_URL=https://api.example.com
 # ECONUMO_ALLOW_CUSTOM_API=false
-
-# Serve the web UI from a directory on disk instead of the SPA embedded in
-# the binary (dev override / separately-built frontend). Unset = embedded.
-# ECONUMO_WEB_DIST=web/dist
+# ECONUMO_LILTAG_CONFIG_URL=https://cdn.example.com/liltag-config.json
+# ECONUMO_LILTAG_CACHE_TTL=3600
+# ECONUMO_VERSION=demo
 
 # CORS allowlist for cross-origin browser requests. Empty (default) = same-domain
 # only: the bundled SPA and API share an origin, so no extra config is needed.

--- a/.env.example
+++ b/.env.example
@@ -26,23 +26,10 @@ ECONUMO_ALLOW_REGISTRATION=true
 # Trial granted at registration: none (default) | end-of-next-month
 ECONUMO_TRIAL=none
 
-# Optional web-UI overrides. The SPA itself is always embedded in the binary;
-# these values are merged into the served econumo-config.js at runtime. Each
-# mirrors a window.econumoConfig key under the ECONUMO_<KEY> name, and the
-# backend value overwrites the embedded default only when set (leave a value
-# blank to keep the built-in default).
-#   API_URL           point the web UI at an API on another origin
-#   ALLOW_CUSTOM_API  show/hide the "use my own server" toggle on login/register
-#   LILTAG_CONFIG_URL load the liltag tag config from a URL instead of the
-#                     bundled liltag-config.json (e.g. a remote/CDN config)
-#   LILTAG_CACHE_TTL  liltag config cache TTL in seconds
-#   VERSION           override the UI version label (defaults to the binary
-#                     version; handy for demo/staging environments)
-# ECONUMO_API_URL=https://api.example.com
-# ECONUMO_ALLOW_CUSTOM_API=false
-# ECONUMO_LILTAG_CONFIG_URL=https://cdn.example.com/liltag-config.json
-# ECONUMO_LILTAG_CACHE_TTL=3600
-# ECONUMO_VERSION=demo
+# Optional web-UI overrides (ECONUMO_API_URL, ECONUMO_ALLOW_CUSTOM_API,
+# ECONUMO_LILTAG_CONFIG_URL, ECONUMO_LILTAG_CACHE_TTL, ECONUMO_VERSION): the SPA
+# is always embedded, and each ECONUMO_<KEY> is merged into the served
+# econumo-config.js when set. See CLAUDE.md for the full list.
 
 # CORS allowlist for cross-origin browser requests. Empty (default) = same-domain
 # only: the bundled SPA and API share an origin, so no extra config is needed.

--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,12 @@ ECONUMO_ALLOW_REGISTRATION=true
 # Trial granted at registration: none (default) | end-of-next-month
 ECONUMO_TRIAL=none
 
-# Optional web-UI overrides (ECONUMO_API_URL, ECONUMO_ALLOW_CUSTOM_API,
-# ECONUMO_LILTAG_CONFIG_URL, ECONUMO_LILTAG_CACHE_TTL, ECONUMO_VERSION): the SPA
-# is always embedded, and each ECONUMO_<KEY> is merged into the served
-# econumo-config.js when set. See CLAUDE.md for the full list.
+# Optional web-UI overrides, merged into the served econumo-config.js when set
+# (the SPA is always embedded). API_URL points the web UI at an API on another
+# origin; ALLOW_CUSTOM_API shows/hides the "use my own server" toggle on the
+# login and registration pages.
+# ECONUMO_API_URL=https://api.example.com
+# ECONUMO_ALLOW_CUSTOM_API=false
 
 # CORS allowlist for cross-origin browser requests. Empty (default) = same-domain
 # only: the bundled SPA and API share an origin, so no extra config is needed.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,6 @@
 name: Publish Release
 
-# Publishes the Go backend image to ghcr.io/econumo/econumo ONLY.
+# Publishes the Go backend image to ghcr.io/econumo/econumo and attaches single-file linux binaries (SPA embedded) to the GitHub release.
 # Dispatch from main (the dispatch ref only selects the workflow DEFINITION);
 # the code that gets tagged and built comes from the "branch" input — main by
 # default, or a release/vX.Y.Z branch for hotfixes of older versions.
@@ -179,9 +179,60 @@ jobs:
           build-args: |
             ECONUMO_VERSION=${{ needs.create-tag.outputs.version }}
 
+  build-binaries:
+    name: Build Release Binaries
+    needs: create-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      # Mirrors the Dockerfile's frontend stage: the SPA build lands in
+      # web/dist, where web/embed.go embeds it into the Go binaries below.
+      - name: Build SPA
+        env:
+          ECONUMO_VERSION: ${{ needs.create-tag.outputs.version }}
+        run: |
+          npm install -g pnpm@11
+          cd web
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        env:
+          VERSION: ${{ needs.create-tag.outputs.version }}
+        run: |
+          mkdir -p release-out
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
+              go build -trimpath \
+              -ldflags "-s -w -X github.com/econumo/econumo/internal/version.Version=${VERSION}" \
+              -o "release-out/econumo-linux-${arch}" ./cmd/econumo
+          done
+          cd release-out && sha256sum econumo-linux-amd64 econumo-linux-arm64 > SHA256SUMS
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: release-out/
+          if-no-files-found: error
+
   create-github-release:
     name: Create GitHub Release
-    needs: [create-tag, publish]
+    needs: [create-tag, publish, build-binaries]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -202,6 +253,23 @@ jobs:
         run: npx changelogithub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binaries
+          path: release-out
+
+      - name: Attach binaries to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.create-tag.outputs.version }}
+        run: |
+          gh release upload "$TAG" \
+            release-out/econumo-linux-amd64 \
+            release-out/econumo-linux-arm64 \
+            release-out/SHA256SUMS \
+            --clobber
 
       # GitHub badges the newest CREATED release as "Latest" by default, which
       # would mislabel a hotfix to an older line published after a newer version.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Go build/test artifacts
 /econumo
+/release-out/
 coverage.out
 
 # Local dev-machine -> homelab transfer script (contains the homelab host/path).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Econumo is a self-hosted personal finance and budgeting application. It consists
 > edition is shipped (there is no separate "ce" edition).
 
 The production artifact is a single self-contained Go binary in a distroless image
-(`ghcr.io/econumo/econumo`) that serves both the JSON API and the built SPA, and
+(`ghcr.io/econumo/econumo`) that serves both the JSON API and the built SPA (SPA embedded via `go:embed` — `web/embed.go`); releases additionally attach standalone `econumo-linux-{amd64,arm64}` binaries + `SHA256SUMS` for Docker-free hosting, and
 runs database migrations on boot.
 
 ## Development Commands
@@ -387,7 +387,10 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `0` on a count disables that check (the window must be positive). Over-limit requests get HTTP 429 with the standard error envelope
   (message `"Too many attempts. Try again later."`, frozen). State is in-memory (resets on
   restart); a malformed value fails at boot.
-- `ECONUMO_WEB_DIST` — path to the built SPA the binary serves.
+- `ECONUMO_WEB_DIST` — disk path to a built SPA, overriding the build embedded
+  in the binary (`web/embed.go`). Unset (default) = serve the embedded SPA,
+  falling back to `web/dist` on disk when no build is embedded (source
+  checkout). The binary logs the chosen source at boot (`spa_source`).
 - `ECONUMO_LOG_LEVEL` — base slog level `debug|info|warn|error` (default `info`). Every command
   (`serve` and all resource:action commands) also accepts `-v`/`-vv`/`-vvv` (force DEBUG; `-vvv` adds source)
   and `-q` (quiet); flags override `ECONUMO_LOG_LEVEL`. Resolution lives in `internal/logging`.
@@ -584,6 +587,10 @@ data unreadable. Most are also asserted by the test suite.
 - Image: `ghcr.io/econumo/econumo` (GitHub Container Registry only).
   - `:dev` — published locally via `make publish-dev`, or by the release workflow's "Publish Dev" checkbox.
   - `:latest` + `:vX.Y.Z` — published by the GitHub release workflow (latest only from `main`).
+- Docker-free: each release attaches single-file linux binaries (SPA embedded)
+  + `SHA256SUMS`; reference systemd unit in `deployment/systemd/econumo.service`,
+  walkthrough in the README ("Run without Docker"). `make release-binaries`
+  builds the same artifacts locally.
 - Self-hosting: see the root `docker-compose.yml` (+ `.env.example`, copied to `.env`)
   and the README quick-start. The Dockerfile is `deployment/docker/Dockerfile`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,8 +600,8 @@ data unreadable. Most are also asserted by the test suite.
   - `:latest` + `:vX.Y.Z` — published by the GitHub release workflow (latest only from `main`).
 - Docker-free: each release attaches single-file linux binaries (SPA embedded)
   + `SHA256SUMS`; reference systemd unit in `deployment/systemd/econumo.service`,
-  walkthrough in the README ("Run without Docker"). `make release-binaries`
-  builds the same artifacts locally.
+  walkthrough in `docs/run-without-docker.md` (linked from the README).
+  `make release-binaries` builds the same artifacts locally.
 - Self-hosting: see the root `docker-compose.yml` (+ `.env.example`, copied to `.env`)
   and the README quick-start. The Dockerfile is `deployment/docker/Dockerfile`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,10 +389,19 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `0` on a count disables that check (the window must be positive). Over-limit requests get HTTP 429 with the standard error envelope
   (message `"Too many attempts. Try again later."`, frozen). State is in-memory (resets on
   restart); a malformed value fails at boot.
-- `ECONUMO_WEB_DIST` — disk path to a built SPA, overriding the build embedded
-  in the binary (`web/embed.go`). Unset (default) = serve the embedded SPA,
-  falling back to `web/dist` on disk when no build is embedded (source
-  checkout). The binary logs the chosen source at boot (`spa_source`).
+- **Web UI config** — the SPA is ALWAYS embedded in the binary (`web/embed.go`,
+  `//go:embed all:dist`); there is no disk-serving mode. Instance-specific
+  values reach the frontend by being merged into the served `econumo-config.js`
+  at runtime (the `Object.assign(window.econumoConfig, …)` suffix in
+  `internal/web/spa`). One rule: the backend value overwrites the embedded
+  default when present. Each key maps to `ECONUMO_<KEY>`: `ECONUMO_API_URL`,
+  `ECONUMO_ALLOW_CUSTOM_API`, `ECONUMO_LILTAG_CONFIG_URL` (load liltag config
+  from a URL instead of the bundled `liltag-config.json`),
+  `ECONUMO_LILTAG_CACHE_TTL`, and `ECONUMO_VERSION` (UI version label; defaults
+  to the binary's `internal/version.Version`, overridable for demo/staging).
+  Flags (`ANALYTICS`, `ALLOW_REGISTRATION`) and `BILLING_URL` are always merged
+  (server truth); text/URL keys merge only when non-empty. The composition root
+  resolves the FS (`web.DistFS`) and version once in `server.BuildAPI`.
 - `ECONUMO_LOG_LEVEL` — base slog level `debug|info|warn|error` (default `info`). Every command
   (`serve` and all resource:action commands) also accepts `-v`/`-vv`/`-vvv` (force DEBUG; `-vvv` adds source)
   and `-q` (quiet); flags override `ECONUMO_LOG_LEVEL`. Resolution lives in `internal/logging`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,10 @@ Econumo is a self-hosted personal finance and budgeting application. It consists
 > edition is shipped (there is no separate "ce" edition).
 
 The production artifact is a single self-contained Go binary in a distroless image
-(`ghcr.io/econumo/econumo`) that serves both the JSON API and the built SPA (SPA embedded via `go:embed` — `web/embed.go`); releases additionally attach standalone `econumo-linux-{amd64,arm64}` binaries + `SHA256SUMS` for Docker-free hosting, and
-runs database migrations on boot.
+(`ghcr.io/econumo/econumo`) that serves both the JSON API and the built SPA (embedded
+via `go:embed` — `web/embed.go`) and runs database migrations on boot. Releases
+additionally attach standalone `econumo-linux-{amd64,arm64}` binaries + `SHA256SUMS`
+for Docker-free hosting.
 
 ## Development Commands
 

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,10 @@ web-bundle:
 # Depends on `swagger` so the embedded OpenAPI docs are always regenerated from
 # the current handler annotations before the binary is built.
 # Note: this does NOT build the frontend; the binary embeds whatever is in
-# web/dist (go:embed). For live frontend reload during dev, keep web/dist empty
-# (unset ECONUMO_WEB_DIST then serves the disk default) or point ECONUMO_WEB_DIST
-# at your build; run `make release-binaries` to embed a freshly built SPA.
+# web/dist (go:embed) — the committed placeholder on a fresh checkout. For live
+# frontend work use the Vite dev server (`make web-run`), which serves the SPA
+# itself and proxies /api here; run `make release-binaries` to embed a freshly
+# built SPA into standalone binaries.
 go-build: swagger
 	CGO_ENABLED=0 go build -o econumo ./cmd/econumo
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help web-install web-run web-test web-bundle web-lint go-build go-run go-test test-cover go-lint test test-engines test-repo-pgsql pg-ensure docker-up docker-down publish-dev publish-buildx-ensure swagger swagger-check
+.PHONY: help web-install web-run web-test web-bundle web-lint go-build go-run go-test test-cover go-lint test test-engines test-repo-pgsql pg-ensure docker-up docker-down publish-dev publish-buildx-ensure swagger swagger-check release-binaries
 
 # Default target
 .DEFAULT_GOAL := help
@@ -13,11 +13,14 @@ help:
 	@echo "  make swagger      - Regenerate the OpenAPI docs (internal/web/apidoc/docs)"
 	@echo ""
 	@echo "Frontend (web/):"
-	@echo "  make web-install  - Install web dependencies"
-	@echo "  make web-run      - Start web development server"
-	@echo "  make web-test     - Run web tests"
-	@echo "  make web-lint     - Run web linter"
-	@echo "  make web-bundle   - Bundle web for production"
+	@echo "  make web-install      - Install web dependencies"
+	@echo "  make web-run          - Start web development server"
+	@echo "  make web-test         - Run web tests"
+	@echo "  make web-lint         - Run web linter"
+	@echo "  make web-bundle       - Bundle web for production"
+	@echo ""
+	@echo "Releases:"
+	@echo "  make release-binaries - Cross-compile the downloadable release binaries (SPA embedded)"
 	@echo ""
 	@echo "Suite & stack:"
 	@echo "  make test         - ALL tests: Go smoke + sqlite-vs-pgsql regression + frontend"
@@ -55,6 +58,21 @@ web-bundle:
 # the current handler annotations before the binary is built.
 go-build: swagger
 	CGO_ENABLED=0 go build -o econumo ./cmd/econumo
+
+# Cross-compile the downloadable release binaries exactly as the release
+# workflow does: build the SPA with the version label (embedded via
+# web/embed.go), then linux/amd64 + linux/arm64 binaries (CGO off, version
+# stamped through ldflags) and SHA256SUMS into release-out/. VERSION
+# defaults to dev for local verification of the artifact shape.
+VERSION ?= dev
+RELEASE_LDFLAGS = -s -w -X github.com/econumo/econumo/internal/version.Version=$(VERSION)
+
+release-binaries: swagger
+	cd web && pnpm install --frozen-lockfile && ECONUMO_VERSION=$(VERSION) pnpm run build
+	rm -rf release-out && mkdir -p release-out
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "$(RELEASE_LDFLAGS)" -o release-out/econumo-linux-amd64 ./cmd/econumo
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "$(RELEASE_LDFLAGS)" -o release-out/econumo-linux-arm64 ./cmd/econumo
+	cd release-out && sha256sum econumo-linux-amd64 econumo-linux-arm64 > SHA256SUMS
 
 # Run the server locally without Docker. All configuration (PORT, DATABASE_URL, …)
 # comes from ./.env, which the binary auto-loads — copy .env.example to .env first.

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ web-bundle:
 # pure-Go sqlite/pgx drivers are linked in, matching the production build.
 # Depends on `swagger` so the embedded OpenAPI docs are always regenerated from
 # the current handler annotations before the binary is built.
+# Note: this does NOT build the frontend; the binary embeds whatever is in
+# web/dist (go:embed). For live frontend reload during dev, keep web/dist empty
+# (unset ECONUMO_WEB_DIST then serves the disk default) or point ECONUMO_WEB_DIST
+# at your build; run `make release-binaries` to embed a freshly built SPA.
 go-build: swagger
 	CGO_ENABLED=0 go build -o econumo ./cmd/econumo
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,54 @@ inside the container, e.g.:
 $ docker compose exec econumo /app/econumo user:create "Name" user@example.com password
 ```
 
+### Run without Docker (single binary)
+
+Every release also ships self-contained Linux binaries — the web UI is
+embedded, so one file is the whole app. Grab the binary for your
+architecture plus `SHA256SUMS` from the
+[latest release](https://github.com/econumo/econumo/releases/latest) and
+verify it:
+
+```console
+$ curl -LO https://github.com/econumo/econumo/releases/latest/download/econumo-linux-amd64
+$ curl -LO https://github.com/econumo/econumo/releases/latest/download/SHA256SUMS
+$ sha256sum --check --ignore-missing SHA256SUMS
+```
+
+A reference systemd unit lives in
+[`deployment/systemd/econumo.service`](deployment/systemd/econumo.service):
+
+```console
+$ sudo useradd --system --home-dir /var/lib/econumo --shell /usr/sbin/nologin econumo
+$ sudo mkdir -p /opt/econumo /var/lib/econumo /etc/econumo
+$ sudo chown econumo:econumo /var/lib/econumo
+$ sudo install -m 0755 econumo-linux-amd64 /opt/econumo/econumo
+$ sudoedit /etc/econumo/env
+$ sudo cp deployment/systemd/econumo.service /etc/systemd/system/
+$ sudo systemctl daemon-reload && sudo systemctl enable --now econumo
+```
+
+A minimal `/etc/econumo/env` (all other settings from
+[`.env.example`](.env.example) work here too):
+
+```
+DATABASE_URL=sqlite:///var/lib/econumo/db.sqlite
+PORT=8181
+```
+
+**Upgrades:** replace `/opt/econumo/econumo` with the new release binary and
+`sudo systemctl restart econumo` — database migrations run on boot, exactly
+as in the Docker image. `/opt/econumo/econumo version` prints the installed
+version.
+
+**Management commands** need the same environment as the service:
+
+```console
+$ sudo -u econumo sh -c 'set -a; . /etc/econumo/env; exec /opt/econumo/econumo user:create "Name" user@example.com password'
+```
+
+**Back up** `/var/lib/econumo` (the SQLite database is the only state).
+
 ### Localization
 
 All translations live in [`locales/`](locales/) — one JSON catalogue per

--- a/README.md
+++ b/README.md
@@ -78,51 +78,10 @@ $ docker compose exec econumo /app/econumo user:create "Name" user@example.com p
 
 ### Run without Docker (single binary)
 
-Every release also ships self-contained Linux binaries — the web UI is
-embedded, so one file is the whole app. Grab the binary for your
-architecture plus `SHA256SUMS` from the
-[latest release](https://github.com/econumo/econumo/releases/latest) and
-verify it:
-
-```console
-$ curl -LO https://github.com/econumo/econumo/releases/latest/download/econumo-linux-amd64
-$ curl -LO https://github.com/econumo/econumo/releases/latest/download/SHA256SUMS
-$ sha256sum --check --ignore-missing SHA256SUMS
-```
-
-A reference systemd unit lives in
-[`deployment/systemd/econumo.service`](deployment/systemd/econumo.service):
-
-```console
-$ sudo useradd --system --home-dir /var/lib/econumo --shell /usr/sbin/nologin econumo
-$ sudo mkdir -p /opt/econumo /var/lib/econumo /etc/econumo
-$ sudo chown econumo:econumo /var/lib/econumo
-$ sudo install -m 0755 econumo-linux-amd64 /opt/econumo/econumo
-$ sudoedit /etc/econumo/env
-$ sudo cp deployment/systemd/econumo.service /etc/systemd/system/
-$ sudo systemctl daemon-reload && sudo systemctl enable --now econumo
-```
-
-A minimal `/etc/econumo/env` (all other settings from
-[`.env.example`](.env.example) work here too):
-
-```
-DATABASE_URL=sqlite:///var/lib/econumo/db.sqlite
-PORT=8181
-```
-
-**Upgrades:** replace `/opt/econumo/econumo` with the new release binary and
-`sudo systemctl restart econumo` — database migrations run on boot, exactly
-as in the Docker image. `/opt/econumo/econumo version` prints the installed
-version.
-
-**Management commands** need the same environment as the service:
-
-```console
-$ sudo -u econumo sh -c 'set -a; . /etc/econumo/env; exec /opt/econumo/econumo user:create "Name" user@example.com password'
-```
-
-**Back up** `/var/lib/econumo` (the SQLite database is the only state).
+Prefer not to use Docker? Every release also ships self-contained Linux
+binaries with the web UI embedded, runnable under systemd on a single host.
+See [docs/run-without-docker.md](docs/run-without-docker.md) for the full
+walkthrough.
 
 ### Localization
 

--- a/cmd/econumo/main.go
+++ b/cmd/econumo/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/econumo/econumo/internal/logging"
 	"github.com/econumo/econumo/internal/server"
 	"github.com/econumo/econumo/internal/system"
+	"github.com/econumo/econumo/internal/version"
 
 	"github.com/joho/godotenv"
 
@@ -77,6 +78,10 @@ func main() {
 		// `-healthcheck` is kept as an alias for any older healthcheck config.
 		os.Exit(healthcheck())
 
+	case "version", "-version", "--version":
+		fmt.Println("econumo " + version.Version)
+		os.Exit(0)
+
 	case "help", "-h", "--help":
 		printUsage(os.Stdout)
 		os.Exit(0)
@@ -99,6 +104,7 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, "Server:")
 	fmt.Fprintf(w, "  %-40s %s\n", "serve", "Start the HTTP API + SPA server")
 	fmt.Fprintf(w, "  %-40s %s\n", "healthcheck", "Probe a running server's health endpoint (exit 0/1)")
+	fmt.Fprintf(w, "  %-40s %s\n", "version", "Print the binary version")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Management commands:")
 	cli.WriteCommandList(w)
@@ -157,6 +163,7 @@ func run(serveArgs []string) error {
 	slog.Info("configuration loaded",
 		"database_driver", cfg.DatabaseDriver,
 		"spa_dir", cfg.SPADir,
+		"version", version.Version,
 	)
 	// The API ignores ECONUMO_DATA_SALT (it always runs salt-free). If the salt is
 	// still set, a database written with it has unreadable emails / mismatched

--- a/cmd/econumo/main.go
+++ b/cmd/econumo/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/econumo/econumo/internal/server"
 	"github.com/econumo/econumo/internal/system"
 	"github.com/econumo/econumo/internal/version"
-	"github.com/econumo/econumo/web"
 
 	"github.com/joho/godotenv"
 
@@ -161,10 +160,8 @@ func run(serveArgs []string) error {
 	// cfg.LogLevel (default info), raised to DEBUG by -v/-vv/-vvv on the serve
 	// command line (flags win); -q silences. From here on every log honors it.
 	logging.Setup(cfg.LogLevel, serveArgs)
-	_, spaSource := web.SelectFS(cfg.SPADir, cfg.SPADirSet)
 	slog.Info("configuration loaded",
 		"database_driver", cfg.DatabaseDriver,
-		"spa_source", spaSource,
 		"version", version.Version,
 	)
 	// The API ignores ECONUMO_DATA_SALT (it always runs salt-free). If the salt is

--- a/cmd/econumo/main.go
+++ b/cmd/econumo/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/econumo/econumo/internal/server"
 	"github.com/econumo/econumo/internal/system"
 	"github.com/econumo/econumo/internal/version"
+	"github.com/econumo/econumo/web"
 
 	"github.com/joho/godotenv"
 
@@ -160,9 +161,10 @@ func run(serveArgs []string) error {
 	// cfg.LogLevel (default info), raised to DEBUG by -v/-vv/-vvv on the serve
 	// command line (flags win); -q silences. From here on every log honors it.
 	logging.Setup(cfg.LogLevel, serveArgs)
+	_, spaSource := web.SelectFS(cfg.SPADir, cfg.SPADirSet)
 	slog.Info("configuration loaded",
 		"database_driver", cfg.DatabaseDriver,
-		"spa_dir", cfg.SPADir,
+		"spa_source", spaSource,
 		"version", version.Version,
 	)
 	// The API ignores ECONUMO_DATA_SALT (it always runs salt-free). If the salt is

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Econumo backend: one static Go binary serving the JSON API + SPA on a single port.
+# Econumo backend: one static Go binary serving the JSON API + SPA on a single port, SPA embedded via go:embed.
 # Build context is the repo root:
 #   docker build -f deployment/docker/Dockerfile -t ghcr.io/econumo/econumo:latest .
 # DATABASE_URL comes from the environment (.env), not baked in. Mount a volume
@@ -36,20 +36,26 @@ COPY internal/ ./internal/
 # internal/infra/i18n imports github.com/econumo/econumo/locales, which lives
 # at the module root alongside cmd/ and internal/.
 COPY locales/ ./locales/
+# The built SPA is embedded into the binary (web/embed.go, go:embed): the
+# image and the downloadable release binary share one code path, and the
+# runtime stage no longer carries a separate /app/web.
+COPY web/embed.go ./web/embed.go
+COPY --from=frontend /build/web/dist ./web/dist
 ARG TARGETOS TARGETARCH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /app/econumo ./cmd/econumo
+ARG ECONUMO_VERSION=""
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X github.com/econumo/econumo/internal/version.Version=${ECONUMO_VERSION:-dev}" \
+    -o /app/econumo ./cmd/econumo
 # Pre-create runtime dirs owned by the non-root user (distroless can't mkdir on boot).
 RUN mkdir -p /out/var/db
 
 # --- 3. Runtime (distroless: no shell, minimal surface) ---
 FROM gcr.io/distroless/static-debian12 AS prod
 COPY --from=gobuild /app/econumo /app/econumo
-COPY --from=frontend /build/web/dist /app/web
 # Runtime data dir (sqlite db); mount a volume here to persist.
 COPY --from=gobuild --chown=nonroot:nonroot /out/var /app/var
 
-ENV ECONUMO_WEB_DIST=/app/web \
-    PORT=80
+ENV PORT=80
 
 EXPOSE 80
 WORKDIR /app

--- a/deployment/systemd/econumo.service
+++ b/deployment/systemd/econumo.service
@@ -1,0 +1,30 @@
+# Reference unit for running the single-file Econumo binary without Docker.
+# Assumes: binary at /opt/econumo/econumo, env at /etc/econumo/env (modeled on
+# .env.example; at minimum DATABASE_URL and PORT), a dedicated system user
+# `econumo`, and SQLite data under /var/lib/econumo. See the README section
+# "Run without Docker (single binary)" for the setup walkthrough.
+
+[Unit]
+Description=Econumo personal finance server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=econumo
+Group=econumo
+WorkingDirectory=/var/lib/econumo
+EnvironmentFile=/etc/econumo/env
+ExecStart=/opt/econumo/econumo serve
+Restart=on-failure
+RestartSec=5
+
+# Hardening: the process only ever writes its database directory.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths=/var/lib/econumo
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/run-without-docker.md
+++ b/docs/run-without-docker.md
@@ -1,0 +1,70 @@
+# Run without Docker (single binary)
+
+Every release ships self-contained Linux binaries alongside the Docker image.
+The web UI is embedded in the binary, so a single file is the whole app — no
+separate frontend to serve, no runtime assets to mount.
+
+## Download and verify
+
+Grab the binary for your architecture plus `SHA256SUMS` from the
+[latest release](https://github.com/econumo/econumo/releases/latest) and verify
+it:
+
+```console
+$ curl -LO https://github.com/econumo/econumo/releases/latest/download/econumo-linux-amd64
+$ curl -LO https://github.com/econumo/econumo/releases/latest/download/SHA256SUMS
+$ sha256sum --check --ignore-missing SHA256SUMS
+```
+
+Binaries are published for `linux/amd64` and `linux/arm64`.
+
+## Install as a systemd service
+
+A reference unit lives in
+[`deployment/systemd/econumo.service`](../deployment/systemd/econumo.service):
+
+```console
+$ sudo useradd --system --home-dir /var/lib/econumo --shell /usr/sbin/nologin econumo
+$ sudo mkdir -p /opt/econumo /var/lib/econumo /etc/econumo
+$ sudo chown econumo:econumo /var/lib/econumo
+$ sudo install -m 0755 econumo-linux-amd64 /opt/econumo/econumo
+$ sudoedit /etc/econumo/env
+$ sudo cp deployment/systemd/econumo.service /etc/systemd/system/
+$ sudo systemctl daemon-reload && sudo systemctl enable --now econumo
+```
+
+A minimal `/etc/econumo/env` (all other settings from
+[`.env.example`](../.env.example) work here too):
+
+```
+DATABASE_URL=sqlite:///var/lib/econumo/db.sqlite
+PORT=8181
+```
+
+## Configuration
+
+Everything is configured through environment variables — see
+[`.env.example`](../.env.example) for the full, commented reference. The web UI
+is embedded, so there is no directory to point at; instance-specific frontend
+values (analytics, billing URL, liltag config, the version label, …) are set
+through `ECONUMO_*` variables and merged into the served config at runtime.
+
+## Upgrades
+
+Replace `/opt/econumo/econumo` with the new release binary and
+`sudo systemctl restart econumo` — database migrations run on boot, exactly as
+in the Docker image. `/opt/econumo/econumo version` prints the installed
+version.
+
+## Management commands
+
+CLI commands (create users, update currency rates, …) need the same environment
+as the service:
+
+```console
+$ sudo -u econumo sh -c 'set -a; . /etc/econumo/env; exec /opt/econumo/econumo user:create "Name" user@example.com password'
+```
+
+## Backups
+
+Back up `/var/lib/econumo` — the SQLite database is the only state.

--- a/docs/superpowers/plans/2026-07-22-single-binary-deployment.md
+++ b/docs/superpowers/plans/2026-07-22-single-binary-deployment.md
@@ -1,0 +1,1193 @@
+# Single-Binary Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship self-contained Linux release binaries (SPA embedded via `go:embed`) attached to every GitHub release, plus a systemd-based bare-metal deployment story, with the Docker image converging on the same embedded-SPA code path.
+
+**Architecture:** A new repo-root `web` Go package embeds `web/dist`; `internal/web/spa` refactors from disk paths onto `fs.FS`; the composition root selects embedded-vs-disk (`ECONUMO_WEB_DIST` override wins). A new `internal/version` package is stamped by ldflags. The release workflow gains a `build-binaries` job whose artifacts are uploaded to the GitHub release.
+
+**Tech Stack:** Go stdlib (`embed`, `io/fs`, `http.FileServerFS`), GitHub Actions, systemd. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-single-binary-deployment-design.md`
+
+**Branch:** work on `feature/single-binary-deployment` (the spec is on `feature/single-binary-deployment-spec`, PR #138 — branch the implementation from `main` once that merges, or stack on the spec branch).
+
+## Global Constraints
+
+- Platforms: `linux/amd64` + `linux/arm64` only. `CGO_ENABLED=0` everywhere.
+- Artifact names are frozen: `econumo-linux-amd64`, `econumo-linux-arm64`, `SHA256SUMS`.
+- ldflags variable path (exact): `github.com/econumo/econumo/internal/version.Version`.
+- SPA serving semantics are frozen (history fallback, asset-ext 404, reserved `/api` `/_` 404, cache headers, `econumo-config.js` merge) — the `fs.FS` refactor must not change any observable behavior; existing test assertions carry over verbatim.
+- Runtime SPA source selection (exact order): explicit non-empty `ECONUMO_WEB_DIST` → embedded dist if it contains `index.html` → disk `web/dist` default.
+- Comments: only non-obvious why (repo comment policy); Swagger `@` blocks untouched.
+- `make go-test` must pass with NO frontend build present (the placeholder embed keeps Go builds frontend-free).
+- Run `make go-test` before every commit that touches Go code.
+
+---
+
+### Task 1: `internal/version` package + `version` subcommand
+
+**Files:**
+- Create: `internal/version/version.go`
+- Create: `internal/version/version_test.go`
+- Modify: `cmd/econumo/main.go` (command switch ~line 62, `printUsage` ~line 98, `run()` boot log ~line 157)
+
+**Interfaces:**
+- Produces: `version.Version` (package-level `var Version string`, default `"dev"`), stamped via `-ldflags "-X github.com/econumo/econumo/internal/version.Version=vX.Y.Z"`. Tasks 5–7 use this exact path in build commands.
+- Produces: `econumo version` subcommand printing `econumo <version>\n` to stdout, exit 0.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/version/version_test.go`:
+
+```go
+package version
+
+import "testing"
+
+func TestDefaultIsDev(t *testing.T) {
+	if Version != "dev" {
+		t.Fatalf("Version = %q, want %q (the unstamped default)", Version, "dev")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/version/`
+Expected: FAIL — `no Go files in .../internal/version` (package doesn't exist yet)
+
+- [ ] **Step 3: Create the package**
+
+Create `internal/version/version.go`:
+
+```go
+// Package version carries the build-stamped binary version. Release builds
+// overwrite the default at link time:
+//
+//	go build -ldflags "-X github.com/econumo/econumo/internal/version.Version=v1.2.3"
+package version
+
+// Version is "dev" unless stamped by -ldflags at build time.
+var Version = "dev"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/version/`
+Expected: PASS
+
+- [ ] **Step 5: Wire the subcommand, usage line, and boot-log field**
+
+In `cmd/econumo/main.go`:
+
+a) Add to the import block: `"github.com/econumo/econumo/internal/version"`
+
+b) In the `switch args[0]` in `main()`, add a case after the `"healthcheck"` case:
+
+```go
+	case "version", "-version", "--version":
+		fmt.Println("econumo " + version.Version)
+		os.Exit(0)
+```
+
+c) In `printUsage`, after the `healthcheck` line, add:
+
+```go
+	fmt.Fprintf(w, "  %-40s %s\n", "version", "Print the binary version")
+```
+
+d) In `run()`, extend the `configuration loaded` log line with the version field:
+
+```go
+	slog.Info("configuration loaded",
+		"database_driver", cfg.DatabaseDriver,
+		"spa_dir", cfg.SPADir,
+		"version", version.Version,
+	)
+```
+
+- [ ] **Step 6: Verify the subcommand end-to-end**
+
+Run: `go run ./cmd/econumo version`
+Expected output: `econumo dev`
+
+Run: `go run ./cmd/econumo help | grep -A1 healthcheck`
+Expected: the `version   Print the binary version` line appears.
+
+Run: `go build -ldflags "-X github.com/econumo/econumo/internal/version.Version=v9.9.9" -o /tmp/econumo-vtest ./cmd/econumo && /tmp/econumo-vtest version && rm /tmp/econumo-vtest`
+Expected output: `econumo v9.9.9`
+
+- [ ] **Step 7: Smoke suite + commit**
+
+Run: `make go-test`
+Expected: PASS (coverage gate included)
+
+```bash
+git add internal/version/ cmd/econumo/main.go
+git commit -m "feat: version subcommand with ldflags-stamped internal/version"
+```
+
+---
+
+### Task 2: `web` embed package (`DistFS`/`SelectFS`) + placeholder
+
+**Files:**
+- Create: `web/embed.go`
+- Create: `web/embed_test.go`
+- Create: `web/dist/.gitkeep` (empty file, committed)
+- Create: `web/public/.gitkeep` (empty file, committed)
+- Modify: `web/.gitignore` (the `dist` line)
+
+**Interfaces:**
+- Produces: `web.DistFS() (fs.FS, bool)` — embedded SPA rooted at `dist/`; bool = a real build is present (`index.html` exists).
+- Produces: `web.SelectFS(dir string, explicit bool) (fs.FS, string)` — the FS to serve and a log label (`"embedded"` or the dir path). Task 4 calls this from `internal/server` and `cmd/econumo`.
+
+**Why two `.gitkeep` files:** `go:embed all:dist` fails to compile if `dist/` has no files, so a placeholder must be committed at `web/dist/.gitkeep`. But `pnpm build` empties `dist/` before writing — which would delete the tracked placeholder and leave the worktree dirty after every frontend build. Vite copies `web/public/` verbatim into `dist/`, so a second empty `.gitkeep` in `public/` makes every build regenerate the identical placeholder: worktree stays clean.
+
+- [ ] **Step 1: Placeholders + gitignore**
+
+```bash
+touch web/dist/.gitkeep web/public/.gitkeep
+```
+
+In `web/.gitignore`, replace the line `dist` with:
+
+```
+dist/*
+!dist/.gitkeep
+```
+
+(The `dist-ssr` line below it stays. The old bare `dist` pattern ignored the whole directory, and git cannot re-include a file inside a wholly-ignored directory; `dist/*` ignores the contents instead, letting the `!` exception through.)
+
+Verify: `git check-ignore web/dist/anything; git check-ignore web/dist/.gitkeep || echo "gitkeep tracked"`
+Expected: first prints `web/dist/anything`; second prints `gitkeep tracked`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `web/embed_test.go`:
+
+```go
+package web
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// The committed placeholder (.gitkeep) must not read as a real SPA build —
+// otherwise a source-checkout binary would serve an empty shell instead of
+// falling back to the disk dist.
+func TestDistFS_PlaceholderIsNotABuild(t *testing.T) {
+	sub, ok := DistFS()
+	if sub == nil {
+		t.Fatal("DistFS returned a nil fs")
+	}
+	if _, err := fs.Stat(sub, "index.html"); err == nil {
+		// A dev machine with a built SPA embeds the real thing; the placeholder
+		// assertion only applies to a frontend-free checkout (CI smoke).
+		if !ok {
+			t.Fatal("index.html embedded but DistFS reported no build")
+		}
+		t.Skip("real SPA build present in web/dist")
+	}
+	if ok {
+		t.Fatal("DistFS reported a real build for a placeholder-only embed")
+	}
+}
+
+func TestSelectFS(t *testing.T) {
+	// An explicitly configured directory always wins, embed or not.
+	if _, label := SelectFS("/some/dir", true); label != "/some/dir" {
+		t.Fatalf("explicit dir: label = %q, want /some/dir", label)
+	}
+	// Without an explicit dir the outcome depends on whether a build is
+	// embedded (dev machines may have one); label and DistFS must agree.
+	fsys, label := SelectFS("web/dist", false)
+	if fsys == nil {
+		t.Fatal("SelectFS returned a nil fs")
+	}
+	if _, ok := DistFS(); ok && label != "embedded" {
+		t.Fatalf("embedded build present but label = %q", label)
+	} else if !ok && label != "web/dist" {
+		t.Fatalf("no embedded build but label = %q, want web/dist", label)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./web/`
+Expected: FAIL — `no Go files in .../web` (package doesn't exist yet)
+
+- [ ] **Step 4: Implement the embed package**
+
+Create `web/embed.go`:
+
+```go
+// Package web embeds the built SPA (dist/, the pnpm build output) so a
+// release binary is fully self-contained. A source checkout without a
+// frontend build embeds only the committed placeholder, which DistFS
+// reports as "no build".
+package web
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+)
+
+//go:embed all:dist
+var dist embed.FS
+
+// DistFS returns the embedded SPA rooted at dist/ and whether a real build
+// is present (a placeholder-only embed has no index.html).
+func DistFS() (fs.FS, bool) {
+	sub, err := fs.Sub(dist, "dist")
+	if err != nil {
+		return nil, false
+	}
+	_, err = fs.Stat(sub, "index.html")
+	return sub, err == nil
+}
+
+// SelectFS picks the filesystem the SPA is served from: an explicitly
+// configured directory always wins (dev override, separately-hosted SPA);
+// otherwise the embedded build when present; otherwise the disk default —
+// a source checkout with a built SPA but a placeholder-only binary. The
+// returned label names the source for the boot log.
+func SelectFS(dir string, explicit bool) (fs.FS, string) {
+	if !explicit {
+		if sub, ok := DistFS(); ok {
+			return sub, "embedded"
+		}
+	}
+	return os.DirFS(dir), dir
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./web/`
+Expected: PASS (or SKIP on the placeholder test if a local `web/dist` build exists — both are green)
+
+- [ ] **Step 6: Smoke suite + commit**
+
+Run: `make go-test`
+Expected: PASS
+
+```bash
+git add web/embed.go web/embed_test.go web/dist/.gitkeep web/public/.gitkeep web/.gitignore
+git commit -m "feat: embed the built SPA via go:embed (web package, placeholder-safe)"
+```
+
+---
+
+### Task 3: Refactor `internal/web/spa` onto `fs.FS`
+
+**Files:**
+- Modify: `internal/web/spa/spa.go` (full rewrite below)
+- Modify: `internal/web/spa/spa_test.go` (full rewrite below)
+- Modify: `internal/web/router/router.go:151` (call site — interim `os.DirFS`, replaced in Task 4)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `spa.Handler(fsys fs.FS, overrides map[string]any) http.Handler` — Task 4 passes it the FS selected by `web.SelectFS`.
+
+- [ ] **Step 1: Rewrite the tests against `fs.FS` fixtures**
+
+Replace the entire content of `internal/web/spa/spa_test.go` with:
+
+```go
+package spa
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// newSPAFS builds a minimal built-SPA layout (index.html + one real asset)
+// as an in-memory fs.FS.
+func newSPAFS(t *testing.T) fstest.MapFS {
+	t.Helper()
+	return fstest.MapFS{
+		"index.html":                {Data: []byte("<!doctype html><title>spa</title>")},
+		"assets/econumo.abc123.svg": {Data: []byte("<svg/>")},
+		"econumo-config.js":         {Data: []byte("window.econumoConfig={}")},
+	}
+}
+
+func get(t *testing.T, h http.Handler, path string) (int, string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	return rec.Code, rec.Body.String()
+}
+
+func TestSPA_Serving(t *testing.T) {
+	h := Handler(newSPAFS(t), nil)
+
+	cases := []struct {
+		name     string
+		path     string
+		wantCode int
+		wantBody string // substring; "" = don't check
+	}{
+		{"existing asset", "/assets/econumo.abc123.svg", http.StatusOK, "<svg/>"},
+		{"index served at root", "/", http.StatusOK, "<title>spa</title>"},
+		{"client route -> index.html", "/accounts", http.StatusOK, "<title>spa</title>"},
+		{"nested client route -> index.html", "/budget/123", http.StatusOK, "<title>spa</title>"},
+		// The regression: a MISSING asset-looking path must 404, not return the SPA
+		// shell — otherwise <object data>/<img> fallbacks break (the app logo bug).
+		{"missing svg -> 404", "/~assets/econumo.svg", http.StatusNotFound, ""},
+		{"missing js -> 404", "/assets/missing.js", http.StatusNotFound, ""},
+		{"missing png -> 404", "/img/nope.png", http.StatusNotFound, ""},
+		// API / internal routes never masquerade as the SPA shell.
+		{"api 404", "/api/v1/whatever", http.StatusNotFound, ""},
+		{"reserved internal 404", "/_/anything", http.StatusNotFound, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := get(t, h, tc.path)
+			if code != tc.wantCode {
+				t.Errorf("%s: code = %d, want %d", tc.path, code, tc.wantCode)
+			}
+			if tc.wantBody != "" && !strings.Contains(body, tc.wantBody) {
+				t.Errorf("%s: body %q missing %q", tc.path, body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// Without an explicit Cache-Control, iOS home-screen web apps heuristically
+// cache index.html across launches and keep serving a stale shell (pointing at
+// old hashed bundles) long after a deploy. The shell and other non-fingerprinted
+// files must force revalidation; Vite-fingerprinted /assets/ files are immutable.
+func TestSPA_CacheHeaders(t *testing.T) {
+	h := Handler(newSPAFS(t), nil)
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"index at root revalidates", "/", "no-cache"},
+		{"index direct revalidates", "/index.html", "no-cache"},
+		{"client route fallback revalidates", "/accounts", "no-cache"},
+		{"runtime config revalidates", "/econumo-config.js", "no-cache"},
+		{"hashed asset immutable", "/assets/econumo.abc123.svg", "public, max-age=31536000, immutable"},
+		{"missing asset 404 not immutable", "/assets/missing.js", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if got := rec.Header().Get("Cache-Control"); got != tc.want {
+				t.Errorf("%s: Cache-Control = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSPA_RuntimeConfigOverride(t *testing.T) {
+	h := Handler(newSPAFS(t), map[string]any{"ANALYTICS": false, "ALLOW_REGISTRATION": true})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/econumo-config.js", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.HasPrefix(body, "window.econumoConfig={}") {
+		t.Fatalf("body does not start with the dist config: %q", body)
+	}
+	// encoding/json sorts map keys, so the merge line is deterministic.
+	want := `Object.assign(window.econumoConfig, {"ALLOW_REGISTRATION":true,"ANALYTICS":false});`
+	if !strings.Contains(body, want) {
+		t.Fatalf("body missing %q: %q", want, body)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("Cache-Control = %q, want %q", got, "no-cache")
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/javascript; charset=utf-8" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+}
+
+func TestSPA_RuntimeConfigNoOverrides(t *testing.T) {
+	h := Handler(newSPAFS(t), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/econumo-config.js", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "window.econumoConfig={}" {
+		t.Fatalf("body = %q, want the dist file verbatim", got)
+	}
+}
+
+func TestSPA_RuntimeConfigMissingFile(t *testing.T) {
+	h := Handler(fstest.MapFS{}, map[string]any{"ANALYTICS": true})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/econumo-config.js", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// fs.ValidPath is the containment boundary now: path.Clean collapses ".."
+// against the leading "/", and any name that still is not a valid rooted fs
+// path is refused before lookup. Nothing may escape fsys, however the URL
+// path is spelled.
+func TestSPA_TraversalAttempts(t *testing.T) {
+	h := Handler(newSPAFS(t), nil)
+	for _, p := range []string{"/../etc/passwd", "/..", "/a/../../etc/passwd", "/%2e%2e/etc/passwd"} {
+		code, body := get(t, h, p)
+		// Legal outcomes: 404, or the SPA shell for an extensionless clean
+		// result — never file content from outside the fixture FS.
+		if code == http.StatusOK && !strings.Contains(body, "<title>spa</title>") {
+			t.Errorf("%s: served unexpected content: %q", p, body)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/web/spa/`
+Expected: FAIL to compile — `Handler` still takes a `string` dir.
+
+- [ ] **Step 3: Rewrite the handler onto `fs.FS`**
+
+Replace the entire content of `internal/web/spa/spa.go` with:
+
+```go
+// Package spa serves the built single-page application from an fs.FS (the
+// SPA embedded in the binary, or a directory on disk) with SPA history-mode
+// fallback: any request that does not map to an existing file and is not an
+// API or internal route is served index.html so the client-side router can
+// take over.
+package spa
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+)
+
+// indexFile is the SPA entrypoint served for client-routed paths.
+const indexFile = "index.html"
+
+// Handler returns an http.Handler that serves static files from fsys, falling
+// back to index.html for unknown paths (SPA history mode). Requests under /api
+// or /_ are never rewritten to index.html (they should be handled by the API /
+// internal routes; if they reach here they 404 honestly rather than masquerade
+// as the SPA shell).
+func Handler(fsys fs.FS, overrides map[string]any) http.Handler {
+	fileServer := http.FileServerFS(fsys)
+
+	// The runtime config is the one templated response: the dist file plus a
+	// merge of the server-owned keys, so the instance's environment genuinely
+	// controls the shipped SPA. Overrides are fixed for the process lifetime,
+	// so the merge line is built once here (encoding/json sorts map keys —
+	// the output is deterministic). Keys the server does not own stay
+	// whatever the dist file says.
+	var configSuffix []byte
+	if len(overrides) > 0 {
+		merged, err := json.Marshal(overrides)
+		if err != nil {
+			panic(fmt.Sprintf("spa: unmarshalable config overrides: %v", err))
+		}
+		configSuffix = fmt.Appendf(nil, "\nObject.assign(window.econumoConfig, %s);\n", merged)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Clean the request path to prevent directory traversal. path.Clean on
+		// an absolute-rooted path collapses ".." segments safely.
+		upath := r.URL.Path
+		if !strings.HasPrefix(upath, "/") {
+			upath = "/" + upath
+		}
+		cleaned := path.Clean(upath)
+
+		// API and internal routes must not fall back to the SPA shell.
+		if isReservedPath(cleaned) {
+			http.NotFound(w, r)
+			return
+		}
+
+		if cleaned == "/econumo-config.js" && configSuffix != nil {
+			serveRuntimeConfig(w, r, fsys, configSuffix)
+			return
+		}
+
+		// Map the cleaned URL path onto an fs.FS name. path.Clean already
+		// collapsed any ".." against the leading "/", but fs.ValidPath
+		// re-asserts containment (rooted, no ".."), so the lookup can never
+		// escape fsys even if the cleaning above is later weakened.
+		name := strings.TrimPrefix(cleaned, "/")
+		if name == "" {
+			name = "."
+		}
+		if !fs.ValidPath(name) {
+			http.NotFound(w, r)
+			return
+		}
+
+		if fileExists(fsys, name) {
+			setCacheControl(w, cleaned)
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+
+		// A missing path that LOOKS like a static asset (has a file extension) must
+		// 404, not fall back to the SPA shell. Returning index.html (200) for a
+		// missing .svg/.js/.png masks the error: an <object data="...">, <img>, or
+		// fetch() for that asset receives HTML with a 200 and never triggers its
+		// error/fallback path. (Concretely: the app-header logo uses
+		// <object data="~assets/econumo.svg"> with an <img> fallback; under nginx
+		// the missing data URL 404'd so the <img> rendered, but the SPA-shell
+		// fallback hid that 404 and the logo vanished.) Client routes are
+		// extensionless and still fall through to index.html below.
+		if path.Ext(cleaned) != "" {
+			http.NotFound(w, r)
+			return
+		}
+
+		// SPA fallback: serve index.html for client-side routes.
+		setCacheControl(w, "/"+indexFile)
+		http.ServeFileFS(w, r, fsys, indexFile)
+	})
+}
+
+func serveRuntimeConfig(w http.ResponseWriter, r *http.Request, fsys fs.FS, configSuffix []byte) {
+	content, err := fs.ReadFile(fsys, "econumo-config.js")
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Write(content)
+	w.Write(configSuffix)
+}
+
+// setCacheControl picks the caching policy by path. Vite-fingerprinted files
+// under /assets/ are content-addressed, so they never change and cache forever.
+// Everything else (index.html, econumo-config.js, manifest, icons) keeps its
+// name across deploys and must revalidate on every load: without an explicit
+// Cache-Control, iOS home-screen web apps heuristically cache the shell across
+// launches and keep running the old bundle until the icon is re-added.
+// no-cache still allows storing — revalidation is a cheap 304 via
+// Last-Modified/If-Modified-Since.
+func setCacheControl(w http.ResponseWriter, cleaned string) {
+	if strings.HasPrefix(cleaned, "/assets/") {
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-cache")
+}
+
+// isReservedPath reports whether the path belongs to a server-side route group
+// (API or internal) that must never be served the SPA shell.
+func isReservedPath(p string) bool {
+	return p == "/api" || strings.HasPrefix(p, "/api/") ||
+		p == "/_" || strings.HasPrefix(p, "/_/")
+}
+
+// fileExists reports whether name is an existing regular file (not a
+// directory). Directories fall through to the SPA fallback so that e.g.
+// "/accounts" does not accidentally serve a directory listing.
+func fileExists(fsys fs.FS, name string) bool {
+	info, err := fs.Stat(fsys, name)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+```
+
+(Deliberately gone: `resolvePath` and the `os`/`path/filepath` imports — `fs.ValidPath` plus the rooted `fs.FS` make directory escape structurally impossible.)
+
+- [ ] **Step 4: Update the router call site (interim)**
+
+In `internal/web/router/router.go`, change line 151 from:
+
+```go
+	root.Handle("/", spa.Handler(deps.Cfg.SPADir, overrides))
+```
+
+to:
+
+```go
+	root.Handle("/", spa.Handler(os.DirFS(deps.Cfg.SPADir), overrides))
+```
+
+and add `"os"` to the router's import block. (Behavior is identical to today; Task 4 replaces this with the composition-root selection.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/web/spa/ ./internal/web/router/`
+Expected: PASS
+
+- [ ] **Step 6: Smoke suite + commit**
+
+Run: `make go-test`
+Expected: PASS (apiparity goldens unchanged — the SPA wire behavior is identical)
+
+```bash
+git add internal/web/spa/ internal/web/router/router.go
+git commit -m "refactor: serve the SPA from an fs.FS (disk or embedded)"
+```
+
+---
+
+### Task 4: Runtime source selection (config + router + server + boot log)
+
+**Files:**
+- Modify: `internal/config/config.go` (Config struct ~line 65, `Load` ~line 98)
+- Test: `internal/config/config_test.go` (add one test to the existing file)
+- Modify: `internal/web/router/router.go` (Deps struct ~line 61, SPA call site from Task 4, imports)
+- Modify: `internal/server/server.go` (~line 283, where `router.Deps` is built)
+- Modify: `cmd/econumo/main.go` (`run()` boot log)
+
+**Interfaces:**
+- Consumes: `web.SelectFS(dir string, explicit bool) (fs.FS, string)` from Task 2; `spa.Handler(fs.FS, map[string]any)` from Task 3.
+- Produces: `config.Config.SPADirSet bool`; `router.Deps.SPA fs.FS`.
+
+- [ ] **Step 1: Write the failing config test**
+
+In `internal/config/config_test.go`, add (test env is clean; `Load` hard-requires only `DATABASE_URL` — if this repo's existing config tests use a shared setenv helper, reuse it for these two `Load` calls):
+
+```go
+func TestSPADirExplicit(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/econumo-test.sqlite")
+
+	// Unset (and set-empty, matching getEnv semantics) = the default, not explicit.
+	t.Setenv("ECONUMO_WEB_DIST", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SPADirSet || cfg.SPADir != "web/dist" {
+		t.Fatalf("unset: SPADir = %q, SPADirSet = %v; want web/dist, false", cfg.SPADir, cfg.SPADirSet)
+	}
+
+	t.Setenv("ECONUMO_WEB_DIST", "/srv/spa")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.SPADirSet || cfg.SPADir != "/srv/spa" {
+		t.Fatalf("set: SPADir = %q, SPADirSet = %v; want /srv/spa, true", cfg.SPADir, cfg.SPADirSet)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestSPADirExplicit`
+Expected: FAIL to compile — `cfg.SPADirSet undefined`
+
+- [ ] **Step 3: Add the config field**
+
+In `internal/config/config.go`, change the SPA section of the struct:
+
+```go
+	// SPA
+	SPADir    string // disk path to a built SPA (dev default web/dist)
+	SPADirSet bool   // ECONUMO_WEB_DIST was set: the disk dir overrides the embedded SPA
+```
+
+and in `Load`, next to the existing `SPADir:` line, add to the struct literal:
+
+```go
+		SPADirSet:              os.Getenv("ECONUMO_WEB_DIST") != "",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/`
+Expected: PASS
+
+- [ ] **Step 5: Thread the selected FS through router deps**
+
+a) In `internal/web/router/router.go`, add to the `Deps` struct:
+
+```go
+	// SPA is the filesystem the SPA catch-all serves — the embedded build or
+	// a disk directory, selected by the composition root (web.SelectFS).
+	// Nil falls back to Cfg.SPADir on disk.
+	SPA fs.FS
+```
+
+with `"io/fs"` added to the imports.
+
+b) Replace the Task 3 interim call site:
+
+```go
+	spaFS := deps.SPA
+	if spaFS == nil {
+		spaFS = os.DirFS(deps.Cfg.SPADir)
+	}
+	root.Handle("/", spa.Handler(spaFS, overrides))
+```
+
+(`"os"` stays imported for the fallback.)
+
+c) In `internal/server/server.go`, in `BuildAPI` where `router.Deps` is built (~line 283), add the field and the selection:
+
+```go
+	spaFS, _ := web.SelectFS(cfg.SPADir, cfg.SPADirSet)
+	return router.New(router.Deps{
+		Cfg:                cfg,
+		DB:                 pinger{db},
+		RegisterAPI:        registerAPI,
+		SupportedLanguages: i18n.Supported,
+		MCP:                mcpHandler,
+		SPA:                spaFS,
+	}), adminHandler
+```
+
+with `"github.com/econumo/econumo/web"` added to the server's imports.
+
+d) In `cmd/econumo/main.go` `run()`, replace the `"spa_dir", cfg.SPADir` log field with the selected source (add `"github.com/econumo/econumo/web"` to imports):
+
+```go
+	_, spaSource := web.SelectFS(cfg.SPADir, cfg.SPADirSet)
+	slog.Info("configuration loaded",
+		"database_driver", cfg.DatabaseDriver,
+		"spa_source", spaSource,
+		"version", version.Version,
+	)
+```
+
+- [ ] **Step 6: Smoke suite (includes archtest) + commit**
+
+Run: `make go-test`
+Expected: PASS — archtest must not object to `internal/server` and `cmd` importing the repo-root `web` package (it is not a feature package; if archtest flags it, the fix is adding the `web` module-root package to archtest's infrastructure allowlist, NOT weakening the feature rules).
+
+Manual check: `go run ./cmd/econumo serve` from the repo root with a valid `.env`, then confirm the boot line logs `spa_source=web/dist` (no embed, env unset) or `spa_source=embedded` (after a `make web-bundle` + rebuild), and `curl -s localhost:8181/ | head -1` returns the SPA shell. Stop the server.
+
+```bash
+git add internal/config/ internal/web/router/router.go internal/server/server.go cmd/econumo/main.go
+git commit -m "feat: select SPA source at boot - explicit dir, embedded build, disk default"
+```
+
+---
+
+### Task 5: Dockerfile convergence (embed the SPA, stamp the version)
+
+**Files:**
+- Modify: `deployment/docker/Dockerfile`
+
+**Interfaces:**
+- Consumes: `web/embed.go` (Task 2), `internal/version` ldflags path (Task 1).
+
+- [ ] **Step 1: Move the dist into the Go build and stamp the version**
+
+In the `gobuild` stage, after `COPY locales/ ./locales/`, replace:
+
+```dockerfile
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /app/econumo ./cmd/econumo
+```
+
+with:
+
+```dockerfile
+# The built SPA is embedded into the binary (web/embed.go, go:embed): the
+# image and the downloadable release binary share one code path, and the
+# runtime stage no longer carries a separate /app/web.
+COPY web/embed.go ./web/embed.go
+COPY --from=frontend /build/web/dist ./web/dist
+ARG TARGETOS TARGETARCH
+ARG ECONUMO_VERSION=""
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags="-s -w -X github.com/econumo/econumo/internal/version.Version=${ECONUMO_VERSION:-dev}" \
+    -o /app/econumo ./cmd/econumo
+```
+
+- [ ] **Step 2: Slim the runtime stage**
+
+In the `prod` stage, delete these two lines:
+
+```dockerfile
+COPY --from=frontend /build/web/dist /app/web
+```
+
+and change:
+
+```dockerfile
+ENV ECONUMO_WEB_DIST=/app/web \
+    PORT=80
+```
+
+to:
+
+```dockerfile
+ENV PORT=80
+```
+
+Also update the file's header comment first paragraph to say the SPA is embedded in the binary (it currently says "one static Go binary serving the JSON API + SPA" — append ", SPA embedded via go:embed").
+
+- [ ] **Step 3: Verify the image builds and serves the embedded SPA**
+
+```bash
+docker build -f deployment/docker/Dockerfile --build-arg ECONUMO_VERSION=v0.0.0-embedtest -t econumo:embedtest .
+docker run --rm econumo:embedtest version
+```
+
+Expected: `econumo v0.0.0-embedtest`
+
+```bash
+docker run --rm -d --name econumo-embedtest -p 8182:80 -e DATABASE_URL=sqlite:///app/var/db/db.sqlite econumo:embedtest serve
+sleep 2
+curl -sf localhost:8182/ | grep -o '<title>[^<]*</title>'
+curl -sf localhost:8182/econumo-config.js | tail -1
+docker logs econumo-embedtest 2>&1 | grep spa_source
+docker stop econumo-embedtest
+```
+
+Expected: an HTML `<title>`, an `Object.assign(window.econumoConfig, …)` line, and `spa_source=embedded` in the boot log.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deployment/docker/Dockerfile
+git commit -m "feat: docker image serves the embedded SPA, drops /app/web"
+```
+
+---
+
+### Task 6: `make release-binaries` + gitignore
+
+**Files:**
+- Modify: `Makefile` (`.PHONY` line 1, help text ~line 9, new target after `go-build`)
+- Modify: `.gitignore` (root)
+
+**Interfaces:**
+- Consumes: `internal/version` ldflags path (Task 1), the embed (Task 2).
+- Produces: `release-out/econumo-linux-{amd64,arm64}` + `release-out/SHA256SUMS` — the exact filenames Task 7's workflow job replicates and uploads.
+
+- [ ] **Step 1: Add the target**
+
+In `Makefile`: add `release-binaries` to the `.PHONY` list, add a help line `@echo "  make release-binaries - Cross-compile the downloadable release binaries (SPA embedded)"`, and add after the `go-build` target:
+
+```make
+# Cross-compile the downloadable release binaries exactly as the release
+# workflow does: build the SPA with the version label (embedded via
+# web/embed.go), then linux/amd64 + linux/arm64 binaries (CGO off, version
+# stamped through ldflags) and SHA256SUMS into release-out/. VERSION
+# defaults to dev for local verification of the artifact shape.
+VERSION ?= dev
+RELEASE_LDFLAGS = -s -w -X github.com/econumo/econumo/internal/version.Version=$(VERSION)
+
+release-binaries: swagger
+	cd web && pnpm install --frozen-lockfile && ECONUMO_VERSION=$(VERSION) pnpm run build
+	rm -rf release-out && mkdir -p release-out
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "$(RELEASE_LDFLAGS)" -o release-out/econumo-linux-amd64 ./cmd/econumo
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "$(RELEASE_LDFLAGS)" -o release-out/econumo-linux-arm64 ./cmd/econumo
+	cd release-out && sha256sum econumo-linux-amd64 econumo-linux-arm64 > SHA256SUMS
+```
+
+In root `.gitignore`, under the `# Go build/test artifacts` section, add:
+
+```
+/release-out/
+```
+
+- [ ] **Step 2: Build and verify the artifacts end-to-end**
+
+Run: `make release-binaries VERSION=v0.0.0-local`
+Expected: `release-out/` contains the two binaries + `SHA256SUMS`; `cd release-out && sha256sum -c SHA256SUMS` passes.
+
+Boot the amd64 binary from a scratch dir (so the repo `.env` is not picked up, and no disk dist exists — proving the embed):
+
+```bash
+mkdir -p /tmp/econumo-bare && cd /tmp/econumo-bare
+PORT=8899 DATABASE_URL=sqlite:///tmp/econumo-bare/db.sqlite \
+  /path/to/repo/release-out/econumo-linux-amd64 serve &
+sleep 2
+/path/to/repo/release-out/econumo-linux-amd64 version
+curl -sf localhost:8899/ | grep -o '<title>[^<]*</title>'
+curl -sf localhost:8899/health
+kill %1
+```
+
+Expected: `econumo v0.0.0-local`, the SPA `<title>`, a healthy `/health` — and the boot log line shows `spa_source=embedded`.
+
+- [ ] **Step 3: Restore the worktree and commit**
+
+`make release-binaries` rebuilt `web/dist` — confirm `git status` shows ONLY the Makefile and `.gitignore` changes (the `public/.gitkeep` copy keeps `dist/.gitkeep` stable; if `.gitkeep` shows as deleted, the Task 2 vite-copy premise failed — stop and fix that instead of committing).
+
+```bash
+git add Makefile .gitignore
+git commit -m "feat: make release-binaries cross-compiles the single-file artifacts"
+```
+
+---
+
+### Task 7: Release workflow — build and attach binaries
+
+**Files:**
+- Modify: `.github/workflows/publish-release.yml` (new `build-binaries` job after `publish`; `create-github-release` job ~line 182)
+
+**Interfaces:**
+- Consumes: `needs.create-tag.outputs.version` (existing workflow output), artifact names from Task 6.
+
+- [ ] **Step 1: Add the `build-binaries` job**
+
+After the `publish` job, add:
+
+```yaml
+  build-binaries:
+    name: Build Release Binaries
+    needs: create-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      # Mirrors the Dockerfile's frontend stage: the SPA build lands in
+      # web/dist, where web/embed.go embeds it into the Go binaries below.
+      - name: Build SPA
+        env:
+          ECONUMO_VERSION: ${{ needs.create-tag.outputs.version }}
+        run: |
+          npm install -g pnpm@11
+          cd web
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        env:
+          VERSION: ${{ needs.create-tag.outputs.version }}
+        run: |
+          mkdir -p release-out
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
+              go build -trimpath \
+              -ldflags "-s -w -X github.com/econumo/econumo/internal/version.Version=${VERSION}" \
+              -o "release-out/econumo-linux-${arch}" ./cmd/econumo
+          done
+          cd release-out && sha256sum econumo-linux-amd64 econumo-linux-arm64 > SHA256SUMS
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: release-out/
+          if-no-files-found: error
+```
+
+- [ ] **Step 2: Attach the binaries to the GitHub release**
+
+In `create-github-release`: change `needs: [create-tag, publish]` to `needs: [create-tag, publish, build-binaries]`, and immediately after the `npx changelogithub` step (the release must exist before upload) add:
+
+```yaml
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binaries
+          path: release-out
+
+      - name: Attach binaries to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.create-tag.outputs.version }}
+        run: |
+          gh release upload "$TAG" \
+            release-out/econumo-linux-amd64 \
+            release-out/econumo-linux-arm64 \
+            release-out/SHA256SUMS \
+            --clobber
+```
+
+Also update the workflow's header comment: the first line "Publishes the Go backend image to ghcr.io/econumo/econumo ONLY." becomes "Publishes the Go backend image to ghcr.io/econumo/econumo and attaches single-file linux binaries (SPA embedded) to the GitHub release."
+
+- [ ] **Step 3: Validate the YAML and commit**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/publish-release.yml'))" && echo OK`
+Expected: `OK` (full behavioral verification happens on the next real release — the job mirrors `make release-binaries`, which Task 6 verified end-to-end).
+
+```bash
+git add .github/workflows/publish-release.yml
+git commit -m "ci: build and attach linux release binaries to the GitHub release"
+```
+
+---
+
+### Task 8: systemd unit + docs (README, .env.example, CLAUDE.md)
+
+**Files:**
+- Create: `deployment/systemd/econumo.service`
+- Modify: `README.md` (new section between "Configuration" and "Localization", ~line 79)
+- Modify: `.env.example` (SPA overrides area, ~line 30)
+- Modify: `CLAUDE.md` (Project Overview artifact sentence; `ECONUMO_WEB_DIST` bullet; Deployment section)
+
+**Interfaces:**
+- Consumes: artifact names + `SHA256SUMS` (Task 6/7), `version` subcommand (Task 1), selection rule (Task 4).
+
+- [ ] **Step 1: Write the unit file**
+
+Create `deployment/systemd/econumo.service`:
+
+```ini
+# Reference unit for running the single-file Econumo binary without Docker.
+# Assumes: binary at /opt/econumo/econumo, env at /etc/econumo/env (modeled on
+# .env.example; at minimum DATABASE_URL and PORT), a dedicated system user
+# `econumo`, and SQLite data under /var/lib/econumo. See the README section
+# "Run without Docker (single binary)" for the setup walkthrough.
+
+[Unit]
+Description=Econumo personal finance server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=econumo
+Group=econumo
+WorkingDirectory=/var/lib/econumo
+EnvironmentFile=/etc/econumo/env
+ExecStart=/opt/econumo/econumo serve
+Restart=on-failure
+RestartSec=5
+
+# Hardening: the process only ever writes its database directory.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadWritePaths=/var/lib/econumo
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 2: Add the README section**
+
+In `README.md`, after the "Configuration" section (the `user:create` docker-exec example) and before "### Localization", insert:
+
+~~~markdown
+### Run without Docker (single binary)
+
+Every release also ships self-contained Linux binaries — the web UI is
+embedded, so one file is the whole app. Grab the binary for your
+architecture plus `SHA256SUMS` from the
+[latest release](https://github.com/econumo/econumo/releases/latest) and
+verify it:
+
+```console
+$ curl -LO https://github.com/econumo/econumo/releases/latest/download/econumo-linux-amd64
+$ curl -LO https://github.com/econumo/econumo/releases/latest/download/SHA256SUMS
+$ sha256sum --check --ignore-missing SHA256SUMS
+```
+
+A reference systemd unit lives in
+[`deployment/systemd/econumo.service`](deployment/systemd/econumo.service):
+
+```console
+$ sudo useradd --system --home-dir /var/lib/econumo --shell /usr/sbin/nologin econumo
+$ sudo mkdir -p /opt/econumo /var/lib/econumo /etc/econumo
+$ sudo chown econumo:econumo /var/lib/econumo
+$ sudo install -m 0755 econumo-linux-amd64 /opt/econumo/econumo
+$ sudoedit /etc/econumo/env
+$ sudo cp deployment/systemd/econumo.service /etc/systemd/system/
+$ sudo systemctl daemon-reload && sudo systemctl enable --now econumo
+```
+
+A minimal `/etc/econumo/env` (all other settings from
+[`.env.example`](.env.example) work here too):
+
+```
+DATABASE_URL=sqlite:///var/lib/econumo/db.sqlite
+PORT=8181
+```
+
+**Upgrades:** replace `/opt/econumo/econumo` with the new release binary and
+`sudo systemctl restart econumo` — database migrations run on boot, exactly
+as in the Docker image. `/opt/econumo/econumo version` prints the installed
+version.
+
+**Management commands** need the same environment as the service:
+
+```console
+$ sudo -u econumo sh -c 'set -a; . /etc/econumo/env; exec /opt/econumo/econumo user:create "Name" user@example.com password'
+```
+
+**Back up** `/var/lib/econumo` (the SQLite database is the only state).
+~~~
+
+- [ ] **Step 3: Document the override in .env.example**
+
+In `.env.example`, in the optional web-UI overrides area (after the `API_URL` block, ~line 30 — read the file to place it cleanly), add:
+
+```bash
+# Serve the web UI from a directory on disk instead of the SPA embedded in
+# the binary (dev override / separately-built frontend). Unset = embedded.
+# ECONUMO_WEB_DIST=web/dist
+```
+
+- [ ] **Step 4: Update CLAUDE.md**
+
+Three targeted edits:
+
+a) Project Overview: change "The production artifact is a single self-contained Go binary in a distroless image" sentence to also say "(SPA embedded via `go:embed` — `web/embed.go`); releases additionally attach standalone `econumo-linux-{amd64,arm64}` binaries + `SHA256SUMS` for Docker-free hosting."
+
+b) Replace the `ECONUMO_WEB_DIST` config bullet with:
+
+```markdown
+- `ECONUMO_WEB_DIST` — disk path to a built SPA, overriding the build embedded
+  in the binary (`web/embed.go`). Unset (default) = serve the embedded SPA,
+  falling back to `web/dist` on disk when no build is embedded (source
+  checkout). The binary logs the chosen source at boot (`spa_source`).
+```
+
+c) Deployment section: add a bullet after the image description:
+
+```markdown
+- Docker-free: each release attaches single-file linux binaries (SPA embedded)
+  + `SHA256SUMS`; reference systemd unit in `deployment/systemd/econumo.service`,
+  walkthrough in the README ("Run without Docker"). `make release-binaries`
+  builds the same artifacts locally.
+```
+
+- [ ] **Step 5: Validate + commit**
+
+Run: `make go-test` (guards nothing new here, but confirms the tree is green)
+Manually verify the systemd unit parses: `systemd-analyze verify deployment/systemd/econumo.service 2>&1 | grep -v "Unit is bound" || true` (on a systemd host; warnings about the missing econumo user/binary are expected and fine — only syntax errors matter).
+
+```bash
+git add deployment/systemd/econumo.service README.md .env.example CLAUDE.md
+git commit -m "docs: systemd unit + run-without-docker walkthrough for the single binary"
+```
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] `make go-test` — full smoke tier green.
+- [ ] `make test` — full tier (engine comparison + frontend suite) green.
+- [ ] `make release-binaries VERSION=v0.0.0-rc && cd release-out && sha256sum -c SHA256SUMS` — artifacts reproducible.
+- [ ] Boot `econumo-linux-amd64` from an empty scratch dir (no `.env`, no `web/dist`): SPA loads, `/health` OK, `version` prints the stamp, boot log says `spa_source=embedded`.
+- [ ] `docker build` the image and confirm the SPA serves with no `/app/web` in the image (`docker run --rm --entrypoint /app/econumo <img> version` works; SPA + `/econumo-config.js` merge verified per Task 5 Step 3).
+- [ ] `git status` clean after a `make web-bundle` (the `.gitkeep` round-trip).
+- [ ] The real workflow run is verified at the next release (publish-release skill).

--- a/docs/superpowers/specs/2026-07-22-single-binary-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-22-single-binary-deployment-design.md
@@ -1,0 +1,121 @@
+# Single-binary release artifacts + bare-metal deployment
+
+**Date:** 2026-07-22
+**Status:** Approved
+
+## Goal
+
+Offer a Docker-free distribution channel: every GitHub release ships
+self-contained Linux binaries (SPA embedded) that a self-hoster can run on a
+single server — binary + SQLite database on one host — under systemd. The
+Docker image remains the primary channel and converges on the same embedded-SPA
+code path.
+
+## Decisions (settled with the user)
+
+- **Audience:** official release artifacts attached to every GitHub release,
+  not a personal-server-only path.
+- **Packaging:** true single file via `go:embed` of the built SPA — no tarball,
+  no build-tag split. `ECONUMO_WEB_DIST` stays as a disk override.
+- **Platforms:** `linux/amd64` + `linux/arm64` only (matches the image's arch
+  matrix). No macOS/Windows, no deb/rpm, no install script, no auto-update.
+- **Deploy story:** a reference systemd unit shipped in `deployment/` plus a
+  documented walkthrough.
+
+## 1. SPA embedding
+
+- New `web/embed.go` (`package web`, module path
+  `github.com/econumo/econumo/web`) with `//go:embed all:dist` exposing the
+  built SPA as an `embed.FS`. `go:embed` cannot reach outside a package
+  directory, and `web/dist` is exactly where `pnpm build` already writes —
+  no copy step, no drift.
+- Commit a placeholder `web/dist/.gitkeep` (everything else in `dist/` stays
+  gitignored) so `go build ./...` / `go test ./...` / CI smoke never require a
+  frontend build. The `all:` prefix embeds dot-files, so the pattern always
+  matches. An embed containing no `index.html` means "no SPA embedded".
+- `internal/web/spa` refactors from `Handler(dir string, overrides …)` to
+  serving from an `fs.FS` (`http.FileServerFS`, `fs.Stat`/`fs.ReadFile`).
+  Frozen semantics are unchanged: history-mode fallback to `index.html`,
+  honest 404 for missing asset-like paths and reserved (`/api`, `/_`) paths,
+  cache-control headers, and the `econumo-config.js` `Object.assign` merge of
+  server-owned keys.
+- Runtime source selection (in `config`/`server` wiring):
+  1. `ECONUMO_WEB_DIST` explicitly set → serve that disk directory
+     (dev override, separately-hosted SPA — current behavior).
+  2. Else, embedded dist contains `index.html` → serve the embedded FS.
+  3. Else → the current `web/dist` disk default (source checkout with a built
+     SPA but a stale binary).
+- Dockerfile: the gobuild stage gains
+  `COPY --from=frontend /build/web/dist ./web/dist` before `go build`; the
+  runtime stage drops the `/app/web` COPY and the `ECONUMO_WEB_DIST` env. The
+  image and the release binary now exercise one code path.
+
+## 2. Binary version identity
+
+- New `internal/version` package: `var Version = "dev"`, set by
+  `-ldflags "-X github.com/econumo/econumo/internal/version.Version=vX.Y.Z"`
+  in the release job and the Docker build.
+- Surfaced in a `version` subcommand (the binary is subcommand-driven; no
+  flag form) and as a field on the serve boot log line. It complements (does not replace) the SPA's
+  Vite-inlined `ECONUMO_VERSION` label; the workflow sets both from the same
+  input.
+
+## 3. Release artifacts (workflow changes)
+
+- `.github/workflows/publish-release.yml` gains a `build-binaries` job
+  (`needs: create-tag`, checkout of the tagged ref):
+  1. Build the SPA once with `ECONUMO_VERSION=<version>` (`pnpm install
+     --frozen-lockfile && pnpm run build`, with `locales/` present as in the
+     Dockerfile — a repo checkout already has it in place).
+  2. For `GOARCH` in `amd64`, `arm64`:
+     `CGO_ENABLED=0 GOOS=linux go build -trimpath
+     -ldflags "-s -w -X …/internal/version.Version=<version>"`
+     → `econumo-linux-amd64`, `econumo-linux-arm64`.
+  3. `sha256sum econumo-linux-* > SHA256SUMS`; upload the three files as a
+     workflow artifact.
+- `create-github-release` adds `build-binaries` to its `needs`, downloads the
+  artifact, and after changelogithub creates the release runs
+  `gh release upload "$TAG" econumo-linux-amd64 econumo-linux-arm64 SHA256SUMS`.
+- A local `make release-binaries` target mirrors the cross-compile (SPA build +
+  both arches + checksums, version from a `VERSION` variable defaulting to
+  `dev`) so the artifact shape is verifiable without a workflow run.
+
+## 4. Deployment: systemd unit + docs
+
+- `deployment/systemd/econumo.service` — reference unit:
+  - dedicated `econumo` system user/group; binary at `/opt/econumo/econumo`;
+    `ExecStart=/opt/econumo/econumo serve`.
+  - `EnvironmentFile=/etc/econumo/env` (contents modeled on `.env.example`;
+    at minimum `DATABASE_URL=sqlite:///var/lib/econumo/db.sqlite` and a
+    non-privileged `PORT`).
+  - SQLite data in `/var/lib/econumo`.
+  - Hardening: `NoNewPrivileges=yes`, `ProtectSystem=strict`,
+    `ProtectHome=yes`, `ReadWritePaths=/var/lib/econumo`,
+    `PrivateTmp=yes`; `Restart=on-failure`.
+- Docs: a "Run without Docker (single binary)" section in the README (or a
+  `docs/` page the README links): download the arch binary from the release,
+  verify against `SHA256SUMS`, create user + dirs, write `/etc/econumo/env`,
+  install the unit, `systemctl enable --now econumo`, check
+  `/opt/econumo/econumo healthcheck` / `/health`. Upgrades: replace the
+  binary, restart — migrations run on boot, exactly as in the image. CLI
+  management commands run as `sudo -u econumo /opt/econumo/econumo user:create …`.
+
+## 5. Testing
+
+- `spa_test.go` moves to `fs.FS` fixtures (`fstest.MapFS`); all existing
+  behavioral assertions carry over.
+- New test: a placeholder-only embed (no `index.html`) is treated as absent —
+  selection falls through to the disk path.
+- New test: version wiring (`internal/version` default + subcommand output).
+- apiparity / mcpparity / goldens: untouched — no route, envelope, or wire
+  change.
+- CI smoke (`make go-test`) stays frontend-free via the `.gitkeep`
+  placeholder.
+- Artifact verification (manual, pre-first-release): `make release-binaries`,
+  boot `econumo-linux-amd64` on a scratch SQLite `.env`, log in, confirm the
+  SPA loads from the embed and `version` reports the ldflags value.
+
+## Out of scope
+
+Install script, macOS/Windows binaries, OS packages (deb/rpm), auto-update,
+PostgreSQL setup guidance beyond what `.env.example` already covers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,8 @@ type Config struct {
 	OpenExchangeRatesToken string
 
 	// SPA
-	SPADir string // path to web/dist (served directly by the Go binary)
+	SPADir    string // disk path to a built SPA (dev default web/dist)
+	SPADirSet bool   // ECONUMO_WEB_DIST was set: the disk dir overrides the embedded SPA
 
 	// Optional SPA config overrides merged into the served econumo-config.js.
 	// Empty/nil = leave the dist file's value (the server does not enforce
@@ -96,6 +97,7 @@ func Load() (Config, error) {
 		LogLevel:               getEnv("ECONUMO_LOG_LEVEL", "info"),
 		OpenExchangeRatesToken: os.Getenv("OPEN_EXCHANGE_RATES_TOKEN"),
 		SPADir:                 getEnv("ECONUMO_WEB_DIST", "web/dist"),
+		SPADirSet:              os.Getenv("ECONUMO_WEB_DIST") != "",
 	}
 
 	if c.DatabaseURL == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,15 +61,16 @@ type Config struct {
 	// Integrations
 	OpenExchangeRatesToken string
 
-	// SPA
-	SPADir    string // disk path to a built SPA (dev default web/dist)
-	SPADirSet bool   // ECONUMO_WEB_DIST was set: the disk dir overrides the embedded SPA
-
-	// Optional SPA config overrides merged into the served econumo-config.js.
-	// Empty/nil = leave the dist file's value (the server does not enforce
-	// these; they only reach the frontend).
-	APIURL         string // ECONUMO_API_URL
-	AllowCustomAPI *bool  // ECONUMO_ALLOW_CUSTOM_API
+	// SPA config overrides merged into the served econumo-config.js (the SPA
+	// itself is always embedded in the binary; only these config values reach
+	// the frontend from the environment). Each key mirrors a window.econumoConfig
+	// key under the ECONUMO_<KEY> name; an empty string / nil pointer leaves the
+	// embedded default in place (the backend value wins only when present).
+	APIURL          string // ECONUMO_API_URL
+	AllowCustomAPI  *bool  // ECONUMO_ALLOW_CUSTOM_API
+	LiltagConfigURL string // ECONUMO_LILTAG_CONFIG_URL: URL the SPA loads liltag config from (empty = embedded liltag-config.json)
+	LiltagCacheTTL  string // ECONUMO_LILTAG_CACHE_TTL: liltag config cache TTL in seconds (empty = embedded default)
+	Version         string // ECONUMO_VERSION: overrides the UI version label (empty = the binary's build version)
 }
 
 // isLoopbackHost reports whether a URL hostname is loopback ("localhost" or a
@@ -96,8 +97,9 @@ func Load() (Config, error) {
 		CORSAllowedOrigins:     getStringList("ECONUMO_CORS_ALLOW_ORIGIN", nil),
 		LogLevel:               getEnv("ECONUMO_LOG_LEVEL", "info"),
 		OpenExchangeRatesToken: os.Getenv("OPEN_EXCHANGE_RATES_TOKEN"),
-		SPADir:                 getEnv("ECONUMO_WEB_DIST", "web/dist"),
-		SPADirSet:              os.Getenv("ECONUMO_WEB_DIST") != "",
+		LiltagConfigURL:        os.Getenv("ECONUMO_LILTAG_CONFIG_URL"),
+		LiltagCacheTTL:         os.Getenv("ECONUMO_LILTAG_CACHE_TTL"),
+		Version:                os.Getenv("ECONUMO_VERSION"),
 	}
 
 	if c.DatabaseURL == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -304,6 +304,29 @@ func TestLoad_SPAOverrides(t *testing.T) {
 	}
 }
 
+func TestSPADirExplicit(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/econumo-test.sqlite")
+
+	// Unset (and set-empty, matching getEnv semantics) = the default, not explicit.
+	t.Setenv("ECONUMO_WEB_DIST", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SPADirSet || cfg.SPADir != "web/dist" {
+		t.Fatalf("unset: SPADir = %q, SPADirSet = %v; want web/dist, false", cfg.SPADir, cfg.SPADirSet)
+	}
+
+	t.Setenv("ECONUMO_WEB_DIST", "/srv/spa")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.SPADirSet || cfg.SPADir != "/srv/spa" {
+		t.Fatalf("set: SPADir = %q, SPADirSet = %v; want /srv/spa, true", cfg.SPADir, cfg.SPADirSet)
+	}
+}
+
 func TestLoad_AdminRequiresBothOrNeither(t *testing.T) {
 	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
 	t.Setenv("ECONUMO_ADMIN_PORT", "9090")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -304,26 +304,28 @@ func TestLoad_SPAOverrides(t *testing.T) {
 	}
 }
 
-func TestSPADirExplicit(t *testing.T) {
+func TestLoad_LiltagAndVersionOverrides(t *testing.T) {
 	t.Setenv("DATABASE_URL", "sqlite:///tmp/econumo-test.sqlite")
 
-	// Unset (and set-empty, matching getEnv semantics) = the default, not explicit.
-	t.Setenv("ECONUMO_WEB_DIST", "")
+	// Unset = empty, so the embedded econumo-config.js defaults stay in place.
 	cfg, err := Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.SPADirSet || cfg.SPADir != "web/dist" {
-		t.Fatalf("unset: SPADir = %q, SPADirSet = %v; want web/dist, false", cfg.SPADir, cfg.SPADirSet)
+	if cfg.LiltagConfigURL != "" || cfg.LiltagCacheTTL != "" || cfg.Version != "" {
+		t.Fatalf("unset: liltag/version overrides should be empty, got url=%q ttl=%q version=%q",
+			cfg.LiltagConfigURL, cfg.LiltagCacheTTL, cfg.Version)
 	}
 
-	t.Setenv("ECONUMO_WEB_DIST", "/srv/spa")
+	t.Setenv("ECONUMO_LILTAG_CONFIG_URL", "https://cdn.example/liltag.json")
+	t.Setenv("ECONUMO_LILTAG_CACHE_TTL", "3600")
+	t.Setenv("ECONUMO_VERSION", "demo-42")
 	cfg, err = Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !cfg.SPADirSet || cfg.SPADir != "/srv/spa" {
-		t.Fatalf("set: SPADir = %q, SPADirSet = %v; want /srv/spa, true", cfg.SPADir, cfg.SPADirSet)
+	if cfg.LiltagConfigURL != "https://cdn.example/liltag.json" || cfg.LiltagCacheTTL != "3600" || cfg.Version != "demo-42" {
+		t.Fatalf("set: got url=%q ttl=%q version=%q", cfg.LiltagConfigURL, cfg.LiltagCacheTTL, cfg.Version)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,6 +61,7 @@ import (
 	handleruser "github.com/econumo/econumo/internal/user/api"
 	usermcp "github.com/econumo/econumo/internal/user/mcp"
 	userrepo "github.com/econumo/econumo/internal/user/repo"
+	"github.com/econumo/econumo/internal/version"
 	"github.com/econumo/econumo/internal/web/apidoc"
 	webmcp "github.com/econumo/econumo/internal/web/mcp"
 	"github.com/econumo/econumo/internal/web/middleware"
@@ -281,7 +282,14 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 		timezoneFallback(userSvc),
 	)(webmcp.NewHandler(mcpRegister))
 
-	spaFS, _ := web.SelectFS(cfg.SPADir, cfg.SPADirSet)
+	// The SPA is always embedded in the binary. The served econumo-config.js
+	// reports the running binary's version, overridable via ECONUMO_VERSION
+	// (handy for demo/staging environments).
+	spaFS, _ := web.DistFS()
+	spaVersion := cfg.Version
+	if spaVersion == "" {
+		spaVersion = version.Version
+	}
 	return router.New(router.Deps{
 		Cfg:                cfg,
 		DB:                 pinger{db},
@@ -289,6 +297,7 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 		SupportedLanguages: i18n.Supported,
 		MCP:                mcpHandler,
 		SPA:                spaFS,
+		SPAVersion:         spaVersion,
 	}), adminHandler
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,6 +65,7 @@ import (
 	webmcp "github.com/econumo/econumo/internal/web/mcp"
 	"github.com/econumo/econumo/internal/web/middleware"
 	"github.com/econumo/econumo/internal/web/router"
+	"github.com/econumo/econumo/web"
 )
 
 // Seams are BuildAPI's injectable sources of nondeterminism. The zero value
@@ -280,12 +281,14 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 		timezoneFallback(userSvc),
 	)(webmcp.NewHandler(mcpRegister))
 
+	spaFS, _ := web.SelectFS(cfg.SPADir, cfg.SPADirSet)
 	return router.New(router.Deps{
 		Cfg:                cfg,
 		DB:                 pinger{db},
 		RegisterAPI:        registerAPI,
 		SupportedLanguages: i18n.Supported,
 		MCP:                mcpHandler,
+		SPA:                spaFS,
 	}), adminHandler
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+// Package version carries the build-stamped binary version. Release builds
+// overwrite the default at link time:
+//
+//	go build -ldflags "-X github.com/econumo/econumo/internal/version.Version=v1.2.3"
+package version
+
+// Version is "dev" unless stamped by -ldflags at build time.
+var Version = "dev"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,9 @@
+package version
+
+import "testing"
+
+func TestDefaultIsDev(t *testing.T) {
+	if Version != "dev" {
+		t.Fatalf("Version = %q, want %q (the unstamped default)", Version, "dev")
+	}
+}

--- a/internal/web/router/router.go
+++ b/internal/web/router/router.go
@@ -22,6 +22,7 @@
 package router
 
 import (
+	"io/fs"
 	"net/http"
 	"os"
 
@@ -80,6 +81,11 @@ type Deps struct {
 	// MCP is the fully-wrapped MCP endpoint handler (auth + timezone fallback
 	// applied by the composition root). Nil = endpoint not mounted.
 	MCP http.Handler
+
+	// SPA is the filesystem the SPA catch-all serves — the embedded build or
+	// a disk directory, selected by the composition root (web.SelectFS).
+	// Nil falls back to Cfg.SPADir on disk.
+	SPA fs.FS
 }
 
 // New builds the root http.Handler from deps.
@@ -149,7 +155,11 @@ func New(deps Deps) http.Handler {
 	if deps.Cfg.AllowCustomAPI != nil {
 		overrides["ALLOW_CUSTOM_API"] = *deps.Cfg.AllowCustomAPI
 	}
-	root.Handle("/", spa.Handler(os.DirFS(deps.Cfg.SPADir), overrides))
+	spaFS := deps.SPA
+	if spaFS == nil {
+		spaFS = os.DirFS(deps.Cfg.SPADir)
+	}
+	root.Handle("/", spa.Handler(spaFS, overrides))
 
 	// Browser-hardening headers wrap the WHOLE tree — including the SPA catch-all,
 	// which the per-subtree global chain deliberately skips — so the served HTML

--- a/internal/web/router/router.go
+++ b/internal/web/router/router.go
@@ -23,6 +23,7 @@ package router
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/econumo/econumo/internal/config"
 	"github.com/econumo/econumo/internal/web/middleware"
@@ -148,7 +149,7 @@ func New(deps Deps) http.Handler {
 	if deps.Cfg.AllowCustomAPI != nil {
 		overrides["ALLOW_CUSTOM_API"] = *deps.Cfg.AllowCustomAPI
 	}
-	root.Handle("/", spa.Handler(deps.Cfg.SPADir, overrides))
+	root.Handle("/", spa.Handler(os.DirFS(deps.Cfg.SPADir), overrides))
 
 	// Browser-hardening headers wrap the WHOLE tree — including the SPA catch-all,
 	// which the per-subtree global chain deliberately skips — so the served HTML

--- a/internal/web/router/router.go
+++ b/internal/web/router/router.go
@@ -24,11 +24,11 @@ package router
 import (
 	"io/fs"
 	"net/http"
-	"os"
 
 	"github.com/econumo/econumo/internal/config"
 	"github.com/econumo/econumo/internal/web/middleware"
 	"github.com/econumo/econumo/internal/web/spa"
+	"github.com/econumo/econumo/web"
 )
 
 // RegisterAPI is the seam through which resource modules attach their routes.
@@ -61,7 +61,7 @@ func Compose(fns ...RegisterAPI) RegisterAPI {
 // this foundational stage so the router is mountable before later phases wire
 // the database and API modules.
 type Deps struct {
-	// Cfg supplies the CORS allowlist and the SPA directory.
+	// Cfg supplies the CORS allowlist and the SPA config-override values.
 	Cfg config.Config
 
 	// DB is used by the health-check. May be nil (reports database: true).
@@ -82,10 +82,15 @@ type Deps struct {
 	// applied by the composition root). Nil = endpoint not mounted.
 	MCP http.Handler
 
-	// SPA is the filesystem the SPA catch-all serves — the embedded build or
-	// a disk directory, selected by the composition root (web.SelectFS).
-	// Nil falls back to Cfg.SPADir on disk.
+	// SPA is the filesystem the SPA catch-all serves. In production it is the
+	// SPA embedded in the binary (web.DistFS); it is a seam for tests to inject
+	// a fixture FS. Nil falls back to the embedded build.
 	SPA fs.FS
+
+	// SPAVersion is the version string merged into the served econumo-config.js
+	// as VERSION (the binary version, or the ECONUMO_VERSION override), resolved
+	// by the composition root. Empty is tolerated (the embedded default remains).
+	SPAVersion string
 }
 
 // New builds the root http.Handler from deps.
@@ -134,20 +139,25 @@ func New(deps Deps) http.Handler {
 	// SPA catch-all. Not wrapped in the API global chain (static assets do not
 	// need request-id/cors/timezone); spa.Handler refuses /api and /_ paths so
 	// it never shadows the server-side groups.
-	// Server-owned SPA config keys, merged into the served econumo-config.js so
-	// the .env values reach the frontend (the dist file's static values are the
-	// fallback for separately-hosted SPAs). ANALYTICS and ALLOW_REGISTRATION are
-	// always server truth (the server enforces/owns them); the rest merge only
-	// when explicitly configured, so a file-configured deployment is never
-	// clobbered by a default.
+	// The env-driven config keys are merged into the served econumo-config.js so
+	// .env values reach the frontend. One rule: the backend value overwrites the
+	// embedded default whenever it is present. Flags and VERSION are always
+	// present (a bool is never blank; VERSION defaults to the binary version), so
+	// they always come from the backend; text/URL values are merged only when
+	// non-empty, leaving the embedded default in place otherwise.
 	overrides := map[string]any{
 		"ANALYTICS":          deps.Cfg.Analytics,
 		"ALLOW_REGISTRATION": deps.Cfg.AllowRegistration,
-		// Always server truth, including when empty: the backend is what decides
-		// whether create-billing-link works, so an empty value here must be able
-		// to switch the SPA's billing UI off rather than leave a stale dist value
-		// pointing at a portal the server will not mint links for.
+		// Present even when empty: the backend decides whether create-billing-link
+		// works, so an empty value must switch the SPA's billing UI off rather than
+		// leave a stale default pointing at a portal the server will not mint for.
 		"BILLING_URL": deps.Cfg.BillingURL,
+	}
+	// The running binary's version (or the ECONUMO_VERSION override), resolved by
+	// the composition root; always non-empty in production, so the UI label
+	// always matches the served binary.
+	if deps.SPAVersion != "" {
+		overrides["VERSION"] = deps.SPAVersion
 	}
 	if deps.Cfg.APIURL != "" {
 		overrides["API_URL"] = deps.Cfg.APIURL
@@ -155,9 +165,17 @@ func New(deps Deps) http.Handler {
 	if deps.Cfg.AllowCustomAPI != nil {
 		overrides["ALLOW_CUSTOM_API"] = *deps.Cfg.AllowCustomAPI
 	}
+	if deps.Cfg.LiltagConfigURL != "" {
+		overrides["LILTAG_CONFIG_URL"] = deps.Cfg.LiltagConfigURL
+	}
+	if deps.Cfg.LiltagCacheTTL != "" {
+		overrides["LILTAG_CACHE_TTL"] = deps.Cfg.LiltagCacheTTL
+	}
+	// The SPA is always embedded in the binary; deps.SPA is the injection seam
+	// for tests. A nil value falls back to the embedded FS.
 	spaFS := deps.SPA
 	if spaFS == nil {
-		spaFS = os.DirFS(deps.Cfg.SPADir)
+		spaFS, _ = web.DistFS()
 	}
 	root.Handle("/", spa.Handler(spaFS, overrides))
 

--- a/internal/web/router/router_test.go
+++ b/internal/web/router/router_test.go
@@ -27,7 +27,8 @@ func newServer(t *testing.T, reg router.RegisterAPI) *httptest.Server {
 		t.Fatalf("write favicon: %v", err)
 	}
 	h := router.New(router.Deps{
-		Cfg:         config.Config{CORSAllowedOrigins: []string{"*"}, SPADir: dir},
+		Cfg:         config.Config{CORSAllowedOrigins: []string{"*"}},
+		SPA:         os.DirFS(dir),
 		RegisterAPI: reg,
 	})
 	srv := httptest.NewServer(h)
@@ -171,7 +172,8 @@ func TestHealthCheck_DBDown_ReportsFalse(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "index.html"), []byte("x"), 0o644)
 	h := router.New(router.Deps{
-		Cfg: config.Config{SPADir: dir},
+		Cfg: config.Config{},
+		SPA: os.DirFS(dir),
 		DB:  stubPinger{err: context.DeadlineExceeded},
 	})
 	srv := httptest.NewServer(h)
@@ -202,13 +204,15 @@ func TestRuntimeConfigOverrides(t *testing.T) {
 		t.Fatal(err)
 	}
 	allowCustom := false
-	h := router.New(router.Deps{Cfg: config.Config{
-		SPADir:         dir,
-		Analytics:      true,
-		APIURL:         "https://api.example.test",
-		AllowCustomAPI: &allowCustom,
-		BillingURL:     "https://pay.example.test/cloud/",
-	}})
+	h := router.New(router.Deps{
+		SPA: os.DirFS(dir),
+		Cfg: config.Config{
+			Analytics:      true,
+			APIURL:         "https://api.example.test",
+			AllowCustomAPI: &allowCustom,
+			BillingURL:     "https://pay.example.test/cloud/",
+		},
+	})
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 
@@ -231,7 +235,7 @@ func TestRuntimeConfigOverrides_EmptyBillingURLIsMerged(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={};"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	h := router.New(router.Deps{Cfg: config.Config{SPADir: dir}})
+	h := router.New(router.Deps{SPA: os.DirFS(dir)})
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 
@@ -247,19 +251,52 @@ func TestRuntimeConfigOverrides_UnsetKeysNotMerged(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={};"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	h := router.New(router.Deps{Cfg: config.Config{SPADir: dir, Analytics: true}})
+	h := router.New(router.Deps{SPA: os.DirFS(dir), Cfg: config.Config{Analytics: true}})
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 
 	resp := get(t, srv, http.MethodGet, "/econumo-config.js")
 	defer resp.Body.Close()
 	body := readBody(t, resp)
-	for _, absent := range []string{"API_URL", "ALLOW_CUSTOM_API"} {
+	for _, absent := range []string{"API_URL", "ALLOW_CUSTOM_API", "LILTAG_CONFIG_URL", "LILTAG_CACHE_TTL", "VERSION"} {
 		if strings.Contains(body, absent) {
 			t.Fatalf("unset key %q must not be merged:\n%s", absent, body)
 		}
 	}
 	if !strings.Contains(body, `"ANALYTICS":true`) {
 		t.Fatalf("ANALYTICS missing:\n%s", body)
+	}
+}
+
+// The liltag config URL and cache TTL are merged only when set, so a hosted
+// instance can point the SPA at a remote liltag config; VERSION carries the
+// running binary's version (or the ECONUMO_VERSION override).
+func TestRuntimeConfigOverrides_LiltagAndVersion(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={};"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := router.New(router.Deps{
+		SPA:        os.DirFS(dir),
+		SPAVersion: "v9.9.9",
+		Cfg: config.Config{
+			LiltagConfigURL: "https://cdn.example/liltag.json",
+			LiltagCacheTTL:  "3600",
+		},
+	})
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	resp := get(t, srv, http.MethodGet, "/econumo-config.js")
+	defer resp.Body.Close()
+	body := readBody(t, resp)
+	for _, want := range []string{
+		`"LILTAG_CONFIG_URL":"https://cdn.example/liltag.json"`,
+		`"LILTAG_CACHE_TTL":"3600"`,
+		`"VERSION":"v9.9.9"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("config body missing %q:\n%s", want, body)
+		}
 	}
 }

--- a/internal/web/spa/spa.go
+++ b/internal/web/spa/spa.go
@@ -1,29 +1,29 @@
-// Package spa serves the built single-page application from a directory on
-// disk (web/dist) with SPA history-mode fallback: any request
-// that does not map to an existing file and is not an API or internal route is
-// served index.html so the client-side router can take over.
+// Package spa serves the built single-page application from an fs.FS (the
+// SPA embedded in the binary, or a directory on disk) with SPA history-mode
+// fallback: any request that does not map to an existing file and is not an
+// API or internal route is served index.html so the client-side router can
+// take over.
 package spa
 
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/http"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 )
 
 // indexFile is the SPA entrypoint served for client-routed paths.
 const indexFile = "index.html"
 
-// Handler returns an http.Handler that serves static files from dir, falling
+// Handler returns an http.Handler that serves static files from fsys, falling
 // back to index.html for unknown paths (SPA history mode). Requests under /api
 // or /_ are never rewritten to index.html (they should be handled by the API /
 // internal routes; if they reach here they 404 honestly rather than masquerade
 // as the SPA shell).
-func Handler(dir string, overrides map[string]any) http.Handler {
-	fs := http.FileServer(http.Dir(dir))
+func Handler(fsys fs.FS, overrides map[string]any) http.Handler {
+	fileServer := http.FileServerFS(fsys)
 
 	// The runtime config is the one templated response: the dist file plus a
 	// merge of the server-owned keys, so the instance's environment genuinely
@@ -55,23 +55,26 @@ func Handler(dir string, overrides map[string]any) http.Handler {
 		}
 
 		if cleaned == "/econumo-config.js" && configSuffix != nil {
-			serveRuntimeConfig(w, r, dir, configSuffix)
+			serveRuntimeConfig(w, r, fsys, configSuffix)
 			return
 		}
 
-		// Map the cleaned URL path onto a filesystem path within dir. path.Clean
-		// already collapsed any ".." against the leading "/", but resolvePath
-		// re-asserts containment so the file lookup can never escape dir even if
-		// the cleaning above is later weakened.
-		fsPath, ok := resolvePath(dir, cleaned)
-		if !ok {
+		// Map the cleaned URL path onto an fs.FS name. path.Clean already
+		// collapsed any ".." against the leading "/", but fs.ValidPath
+		// re-asserts containment (rooted, no ".."), so the lookup can never
+		// escape fsys even if the cleaning above is later weakened.
+		name := strings.TrimPrefix(cleaned, "/")
+		if name == "" {
+			name = "."
+		}
+		if !fs.ValidPath(name) {
 			http.NotFound(w, r)
 			return
 		}
 
-		if fileExists(fsPath) {
+		if fileExists(fsys, name) {
 			setCacheControl(w, cleaned)
-			fs.ServeHTTP(w, r)
+			fileServer.ServeHTTP(w, r)
 			return
 		}
 
@@ -91,12 +94,12 @@ func Handler(dir string, overrides map[string]any) http.Handler {
 
 		// SPA fallback: serve index.html for client-side routes.
 		setCacheControl(w, "/"+indexFile)
-		http.ServeFile(w, r, filepath.Join(dir, indexFile))
+		http.ServeFileFS(w, r, fsys, indexFile)
 	})
 }
 
-func serveRuntimeConfig(w http.ResponseWriter, r *http.Request, dir string, configSuffix []byte) {
-	content, err := os.ReadFile(filepath.Join(dir, "econumo-config.js"))
+func serveRuntimeConfig(w http.ResponseWriter, r *http.Request, fsys fs.FS, configSuffix []byte) {
+	content, err := fs.ReadFile(fsys, "econumo-config.js")
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -130,25 +133,11 @@ func isReservedPath(p string) bool {
 		p == "/_" || strings.HasPrefix(p, "/_/")
 }
 
-// resolvePath maps a cleaned, slash-rooted URL path onto a filesystem path and
-// reports whether the result is genuinely contained in dir. Containment is
-// checked with filepath.Rel rather than a string prefix, so a sibling directory
-// sharing dir's name prefix (dist vs dist-other) cannot pass.
-func resolvePath(dir, cleaned string) (string, bool) {
-	rel := strings.TrimPrefix(cleaned, "/")
-	candidate := filepath.Join(dir, filepath.FromSlash(rel))
-	inside, err := filepath.Rel(dir, candidate)
-	if err != nil || inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) {
-		return "", false
-	}
-	return candidate, true
-}
-
 // fileExists reports whether name is an existing regular file (not a
 // directory). Directories fall through to the SPA fallback so that e.g.
 // "/accounts" does not accidentally serve a directory listing.
-func fileExists(name string) bool {
-	info, err := os.Stat(name)
+func fileExists(fsys fs.FS, name string) bool {
+	info, err := fs.Stat(fsys, name)
 	if err != nil {
 		return false
 	}

--- a/internal/web/spa/spa_test.go
+++ b/internal/web/spa/spa_test.go
@@ -3,30 +3,20 @@ package spa
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 )
 
-// newSPADir writes a minimal built-SPA layout (index.html + one real asset) to a
-// temp dir and returns it.
-func newSPADir(t *testing.T) string {
+// newSPAFS builds a minimal built-SPA layout (index.html + one real asset)
+// as an in-memory fs.FS.
+func newSPAFS(t *testing.T) fstest.MapFS {
 	t.Helper()
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<!doctype html><title>spa</title>"), 0o644); err != nil {
-		t.Fatal(err)
+	return fstest.MapFS{
+		"index.html":                {Data: []byte("<!doctype html><title>spa</title>")},
+		"assets/econumo.abc123.svg": {Data: []byte("<svg/>")},
+		"econumo-config.js":         {Data: []byte("window.econumoConfig={}")},
 	}
-	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "assets", "econumo.abc123.svg"), []byte("<svg/>"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "econumo-config.js"), []byte("window.econumoConfig={}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	return dir
 }
 
 func get(t *testing.T, h http.Handler, path string) (int, string) {
@@ -37,7 +27,7 @@ func get(t *testing.T, h http.Handler, path string) (int, string) {
 }
 
 func TestSPA_Serving(t *testing.T) {
-	h := Handler(newSPADir(t), nil)
+	h := Handler(newSPAFS(t), nil)
 
 	cases := []struct {
 		name     string
@@ -76,7 +66,7 @@ func TestSPA_Serving(t *testing.T) {
 // old hashed bundles) long after a deploy. The shell and other non-fingerprinted
 // files must force revalidation; Vite-fingerprinted /assets/ files are immutable.
 func TestSPA_CacheHeaders(t *testing.T) {
-	h := Handler(newSPADir(t), nil)
+	h := Handler(newSPAFS(t), nil)
 
 	cases := []struct {
 		name string
@@ -102,7 +92,7 @@ func TestSPA_CacheHeaders(t *testing.T) {
 }
 
 func TestSPA_RuntimeConfigOverride(t *testing.T) {
-	h := Handler(newSPADir(t), map[string]any{"ANALYTICS": false, "ALLOW_REGISTRATION": true})
+	h := Handler(newSPAFS(t), map[string]any{"ANALYTICS": false, "ALLOW_REGISTRATION": true})
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/econumo-config.js", nil))
 	if rec.Code != http.StatusOK {
@@ -126,7 +116,7 @@ func TestSPA_RuntimeConfigOverride(t *testing.T) {
 }
 
 func TestSPA_RuntimeConfigNoOverrides(t *testing.T) {
-	h := Handler(newSPADir(t), nil)
+	h := Handler(newSPAFS(t), nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/econumo-config.js", nil))
 	if rec.Code != http.StatusOK {
@@ -138,7 +128,7 @@ func TestSPA_RuntimeConfigNoOverrides(t *testing.T) {
 }
 
 func TestSPA_RuntimeConfigMissingFile(t *testing.T) {
-	h := Handler(t.TempDir(), map[string]any{"ANALYTICS": true})
+	h := Handler(fstest.MapFS{}, map[string]any{"ANALYTICS": true})
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/econumo-config.js", nil))
 	if rec.Code != http.StatusNotFound {
@@ -146,38 +136,18 @@ func TestSPA_RuntimeConfigMissingFile(t *testing.T) {
 	}
 }
 
-// resolvePath is the containment boundary for static-file lookups: nothing it
-// approves may fall outside dir, however the URL path is spelled.
-func TestResolvePath_StaysInsideDir(t *testing.T) {
-	dir := t.TempDir()
-
-	for _, cleaned := range []string{"/", "/index.html", "/assets/app.js", "/a/b/c.png"} {
-		got, ok := resolvePath(dir, cleaned)
-		if !ok {
-			t.Errorf("resolvePath(%q) rejected a legitimate path", cleaned)
-			continue
+// fs.ValidPath is the containment boundary now: path.Clean collapses ".."
+// against the leading "/", and any name that still is not a valid rooted fs
+// path is refused before lookup. Nothing may escape fsys, however the URL
+// path is spelled.
+func TestSPA_TraversalAttempts(t *testing.T) {
+	h := Handler(newSPAFS(t), nil)
+	for _, p := range []string{"/../etc/passwd", "/..", "/a/../../etc/passwd", "/%2e%2e/etc/passwd"} {
+		code, body := get(t, h, p)
+		// Legal outcomes: 404, or the SPA shell for an extensionless clean
+		// result — never file content from outside the fixture FS.
+		if code == http.StatusOK && !strings.Contains(body, "<title>spa</title>") {
+			t.Errorf("%s: served unexpected content: %q", p, body)
 		}
-		if rel, err := filepath.Rel(dir, got); err != nil || strings.HasPrefix(rel, "..") {
-			t.Errorf("resolvePath(%q) = %q, which escapes %q", cleaned, got, dir)
-		}
-	}
-
-	// Paths that resolve outside dir must be refused outright.
-	for _, cleaned := range []string{"/..", "/../etc/passwd", "/../../root/.ssh/id_rsa"} {
-		if got, ok := resolvePath(dir, cleaned); ok {
-			t.Errorf("resolvePath(%q) = %q, want rejection", cleaned, got)
-		}
-	}
-}
-
-// A sibling directory sharing dir's name prefix must not read as "inside" it.
-func TestResolvePath_RejectsPrefixSibling(t *testing.T) {
-	base := t.TempDir()
-	dir := filepath.Join(base, "dist")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if got, ok := resolvePath(dir, "/../dist-evil/secret.txt"); ok {
-		t.Errorf("resolvePath escaped into a prefix sibling: %q", got)
 	}
 }

--- a/internal/web/spa/spa_test.go
+++ b/internal/web/spa/spa_test.go
@@ -1,6 +1,7 @@
 package spa
 
 import (
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -136,10 +137,13 @@ func TestSPA_RuntimeConfigMissingFile(t *testing.T) {
 	}
 }
 
-// fs.ValidPath is the containment boundary now: path.Clean collapses ".."
-// against the leading "/", and any name that still is not a valid rooted fs
-// path is refused before lookup. Nothing may escape fsys, however the URL
-// path is spelled.
+// Traversal attempts must never leak content from outside the served FS. In
+// a normal HTTP request path.Clean collapses any ".." against the leading
+// "/", so these payloads are refused before reaching the handler's
+// fs.ValidPath backstop (they 4xx). This asserts the observable invariant:
+// no payload yields file content other than the SPA shell. TestValidPathGate
+// below covers the fs.ValidPath backstop line directly, standing in for the
+// removed resolvePath unit tests.
 func TestSPA_TraversalAttempts(t *testing.T) {
 	h := Handler(newSPAFS(t), nil)
 	for _, p := range []string{"/../etc/passwd", "/..", "/a/../../etc/passwd", "/%2e%2e/etc/passwd"} {
@@ -148,6 +152,26 @@ func TestSPA_TraversalAttempts(t *testing.T) {
 		// result — never file content from outside the fixture FS.
 		if code == http.StatusOK && !strings.Contains(body, "<title>spa</title>") {
 			t.Errorf("%s: served unexpected content: %q", p, body)
+		}
+	}
+}
+
+// TestValidPathGate covers the fs.ValidPath containment backstop directly:
+// the handler maps a cleaned URL path onto an fs name and refuses it unless
+// fs.ValidPath accepts it, so any name carrying a "." or ".." element — the
+// forms an escape would take — must be rejected. Reached via HTTP only if
+// path.Clean is ever weakened, so it is asserted here in isolation.
+func TestValidPathGate(t *testing.T) {
+	rejected := []string{"..", "../etc/passwd", "../../root/.ssh/id_rsa", "a/../../etc/passwd", "./x", "/etc/passwd"}
+	for _, name := range rejected {
+		if fs.ValidPath(name) {
+			t.Errorf("fs.ValidPath(%q) = true, want false (escape/non-rooted name must be refused)", name)
+		}
+	}
+	accepted := []string{"index.html", "assets/app.js", "econumo-config.js"}
+	for _, name := range accepted {
+		if !fs.ValidPath(name) {
+			t.Errorf("fs.ValidPath(%q) = false, want true (legitimate asset name)", name)
 		}
 	}
 }

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -8,7 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/*
+!dist/.gitkeep
 dist-ssr
 *.local
 

--- a/web/embed.go
+++ b/web/embed.go
@@ -7,7 +7,6 @@ package web
 import (
 	"embed"
 	"io/fs"
-	"os"
 )
 
 //go:embed all:dist
@@ -22,18 +21,4 @@ func DistFS() (fs.FS, bool) {
 	}
 	_, err = fs.Stat(sub, "index.html")
 	return sub, err == nil
-}
-
-// SelectFS picks the filesystem the SPA is served from: an explicitly
-// configured directory always wins (dev override, separately-hosted SPA);
-// otherwise the embedded build when present; otherwise the disk default —
-// a source checkout with a built SPA but a placeholder-only binary. The
-// returned label names the source for the boot log.
-func SelectFS(dir string, explicit bool) (fs.FS, string) {
-	if !explicit {
-		if sub, ok := DistFS(); ok {
-			return sub, "embedded"
-		}
-	}
-	return os.DirFS(dir), dir
 }

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,39 @@
+// Package web embeds the built SPA (dist/, the pnpm build output) so a
+// release binary is fully self-contained. A source checkout without a
+// frontend build embeds only the committed placeholder, which DistFS
+// reports as "no build".
+package web
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+)
+
+//go:embed all:dist
+var dist embed.FS
+
+// DistFS returns the embedded SPA rooted at dist/ and whether a real build
+// is present (a placeholder-only embed has no index.html).
+func DistFS() (fs.FS, bool) {
+	sub, err := fs.Sub(dist, "dist")
+	if err != nil {
+		return nil, false
+	}
+	_, err = fs.Stat(sub, "index.html")
+	return sub, err == nil
+}
+
+// SelectFS picks the filesystem the SPA is served from: an explicitly
+// configured directory always wins (dev override, separately-hosted SPA);
+// otherwise the embedded build when present; otherwise the disk default —
+// a source checkout with a built SPA but a placeholder-only binary. The
+// returned label names the source for the boot log.
+func SelectFS(dir string, explicit bool) (fs.FS, string) {
+	if !explicit {
+		if sub, ok := DistFS(); ok {
+			return sub, "embedded"
+		}
+	}
+	return os.DirFS(dir), dir
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// The committed placeholder (.gitkeep) must not read as a real SPA build —
+// otherwise a source-checkout binary would serve an empty shell instead of
+// falling back to the disk dist.
+func TestDistFS_PlaceholderIsNotABuild(t *testing.T) {
+	sub, ok := DistFS()
+	if sub == nil {
+		t.Fatal("DistFS returned a nil fs")
+	}
+	if _, err := fs.Stat(sub, "index.html"); err == nil {
+		// A dev machine with a built SPA embeds the real thing; the placeholder
+		// assertion only applies to a frontend-free checkout (CI smoke).
+		if !ok {
+			t.Fatal("index.html embedded but DistFS reported no build")
+		}
+		t.Skip("real SPA build present in web/dist")
+	}
+	if ok {
+		t.Fatal("DistFS reported a real build for a placeholder-only embed")
+	}
+}
+
+func TestSelectFS(t *testing.T) {
+	// An explicitly configured directory always wins, embed or not.
+	if _, label := SelectFS("/some/dir", true); label != "/some/dir" {
+		t.Fatalf("explicit dir: label = %q, want /some/dir", label)
+	}
+	// Without an explicit dir the outcome depends on whether a build is
+	// embedded (dev machines may have one); label and DistFS must agree.
+	fsys, label := SelectFS("web/dist", false)
+	if fsys == nil {
+		t.Fatal("SelectFS returned a nil fs")
+	}
+	if _, ok := DistFS(); ok && label != "embedded" {
+		t.Fatalf("embedded build present but label = %q", label)
+	} else if !ok && label != "web/dist" {
+		t.Fatalf("no embedded build but label = %q, want web/dist", label)
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 // The committed placeholder (.gitkeep) must not read as a real SPA build —
-// otherwise a source-checkout binary would serve an empty shell instead of
-// falling back to the disk dist.
+// otherwise a source-checkout binary would report an embedded build and serve
+// an empty shell.
 func TestDistFS_PlaceholderIsNotABuild(t *testing.T) {
 	sub, ok := DistFS()
 	if sub == nil {
@@ -23,23 +23,5 @@ func TestDistFS_PlaceholderIsNotABuild(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("DistFS reported a real build for a placeholder-only embed")
-	}
-}
-
-func TestSelectFS(t *testing.T) {
-	// An explicitly configured directory always wins, embed or not.
-	if _, label := SelectFS("/some/dir", true); label != "/some/dir" {
-		t.Fatalf("explicit dir: label = %q, want /some/dir", label)
-	}
-	// Without an explicit dir the outcome depends on whether a build is
-	// embedded (dev machines may have one); label and DistFS must agree.
-	fsys, label := SelectFS("web/dist", false)
-	if fsys == nil {
-		t.Fatal("SelectFS returned a nil fs")
-	}
-	if _, ok := DistFS(); ok && label != "embedded" {
-		t.Fatalf("embedded build present but label = %q", label)
-	} else if !ok && label != "web/dist" {
-		t.Fatalf("no embedded build but label = %q, want web/dist", label)
 	}
 }


### PR DESCRIPTION
## Summary
Ships Econumo as self-contained Linux release binaries with the web UI **embedded via `go:embed`**, plus a bare-metal (systemd) deployment path, and converges the Docker image onto the same embedded-SPA code path. The binary is unconditionally self-contained — there is no disk-serving mode; instance-specific frontend values are driven through `ECONUMO_*` env vars.

Supersedes #138 (its spec + plan docs are the first commits here).

## What changed
- **`internal/version`** + `econumo version` subcommand; version stamped via ldflags `github.com/econumo/econumo/internal/version.Version`, surfaced in the boot log.
- **`web` embed package** — `//go:embed all:dist` exposes `DistFS()`; committed `web/dist/.gitkeep` + `web/public/.gitkeep` keep Go builds frontend-free and survive `pnpm build` (verified round-trip).
- **`internal/web/spa` → `fs.FS`** — behavior-preserving refactor; `fs.ValidPath` replaces `resolvePath` as the containment boundary. Frozen SPA wire semantics unchanged (apiparity goldens untouched).
- **Always embedded** — the SPA is served unconditionally from the embedded FS. There is **no** `ECONUMO_WEB_DIST` / disk-serving mode.
- **Env-driven `econumo-config.js`** — every `window.econumoConfig` key is overridable through `ECONUMO_<KEY>` and merged into the served config. One rule: the backend value overwrites the embedded default **when present** (flags always; text/URL keys only when non-empty). New knobs:
  - `ECONUMO_LILTAG_CONFIG_URL` — load the liltag tag config from a remote URL instead of the bundled `liltag-config.json`.
  - `ECONUMO_LILTAG_CACHE_TTL` — liltag config cache TTL.
  - `ECONUMO_VERSION` — UI version label; defaults to the binary's `internal/version.Version`, overridable for demo/staging environments.
- **Dockerfile** embeds the SPA + stamps the version, drops `/app/web` and the `ECONUMO_WEB_DIST` env.
- **`make release-binaries`** and a release-workflow `build-binaries` job that cross-compiles `econumo-linux-{amd64,arm64}` + `SHA256SUMS` and attaches them to the GitHub release.
- **Deployment** — reference `deployment/systemd/econumo.service`; the run-without-docker walkthrough lives in `docs/run-without-docker.md` (linked from the README); `.env.example` and CLAUDE.md updated.

## Testing
- `make go-test` green — coverage 80.6% (min 78%), archtest + apiparity/mcpparity goldens clean.
- Config merge verified end-to-end against a real build: a `v1.2.3`-stamped binary with `ECONUMO_ANALYTICS=false`, `ECONUMO_LILTAG_CONFIG_URL`, and `ECONUMO_LILTAG_CACHE_TTL=3600` set served an `econumo-config.js` merging exactly those values plus `"VERSION":"v1.2.3"`; the `version` subcommand agreed.
- Docker image built and served the embedded SPA (stamped version) end-to-end; `make release-binaries` artifacts verified (`sha256sum -c`) and the amd64 binary booted from a scratch dir with no disk `web/dist`.
- Recommend `make test` (engine-compare + frontend) before merge, and letting the first real release exercise the workflow job.

Design: `docs/superpowers/specs/2026-07-22-single-binary-deployment-design.md` · Plan: `docs/superpowers/plans/2026-07-22-single-binary-deployment.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)