### PR TITLE
refactor(user): retire the identifier column (lower(email) is the key)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ DTOs those use cases operate on live in the shared `internal/model` package
 │   │   ├── storage/migrations/ ... SQL migrations per engine ({sqlite,pgsql}); run on boot
 │   │   ├── operation/ ............ shared row-based idempotency guard (operation_requests_ids) for
 │   │   │                          client-supplied operation ids on create endpoints
-│   │   ├── auth/ ................ password hashing + AES email encryption + user-identifier hashing
+│   │   ├── auth/ ................ password hashing + AES email encryption
 │   │   ├── clock/ ................ time source abstraction
 │   │   └── mailer/ .............. transactional email; transport from MAILER_DSN (console stdout | Resend API)
 │   ├── web/ ..................... HTTP-edge infrastructure shared by every feature (the Go server edge —
@@ -324,11 +324,11 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   no token-related configuration. Persist the `/app/var` volume (the db) to keep data and
   logins valid. Leftover `ECONUMO_JWT_*` variables from older builds are ignored.
 - `ECONUMO_DATA_SALT` — **Deprecated and IGNORED by the API/repositories**, which always run
-  salt-free (plaintext emails, `md5(lower(email))` identifiers). It is consumed by exactly one
+  salt-free (plaintext emails, `lower(email)` as the lookup key). It is consumed by exactly one
   code path, the `data:remove-salt` migration (below), which reads it to decrypt existing data.
   Set it to your old salt, run that command, then unset it. Until you migrate, a still-salted
-  database has unreadable emails / mismatched identifiers, so those users cannot log in (the
-  intended push to migrate); `serve` logs a WARN at boot while it is set.
+  database has unreadable emails, so those users cannot log in (the intended push to migrate);
+  `serve` logs a WARN at boot while it is set.
 - `ECONUMO_ALLOW_REGISTRATION` — enable/disable the register endpoint.
 - `ECONUMO_TRIAL` — access granted to a newly registered user: `none` (default, no
   access grant) or `end-of-next-month` (full access until the first of the month
@@ -483,10 +483,14 @@ data:remove-salt
 ```
 
 `data:remove-salt` is a one-off migration that decrypts every user's email
-back to plaintext and re-derives the identifier as `md5(lower(email))` (no salt),
-so `ECONUMO_DATA_SALT` can be removed. Run it **while the old salt is still set**
-(it needs it to decrypt), then unset `ECONUMO_DATA_SALT` and restart. It refuses
-to run with an empty salt, and is idempotent (already-plaintext rows are skipped).
+back to plaintext, so `ECONUMO_DATA_SALT` can be removed. `lower(email)` is the
+unique lookup key (unique expression index `users_email_lower_uniq`), so a
+still-salted instance MUST run this command after upgrading, before that index
+is relied on — otherwise emails stay encrypted and those users can't log in
+(they are already login-broken pre-migration, so this is not a regression).
+Run it **while the old salt is still set** (it needs it to decrypt), then
+unset `ECONUMO_DATA_SALT` and restart. It refuses to run with an empty salt,
+and is idempotent (already-plaintext rows are skipped).
 Back up the DB first — the decryption is one-way in practice.
 
 In the distroless image these run via the binary directly, e.g.
@@ -565,9 +569,9 @@ data unreadable. Most are also asserted by the test suite.
 
 ### Auth crypto (`internal/infra/auth/`)
 - **Password hash**: versioned by `users.algorithm`. `sha512` (legacy, all pre-existing rows): sha512, 500 iterations, base64 (88 chars), salt merged as `password{salt}`; `digest = sha512(salted)` then 499 rounds of `sha512(digest || salted)`; verify rejects len≠88 or a `$`, constant-time. `argon2id` (every new hash: registration and all password changes): PHC string `$argon2id$v=19$m=19456,t=2,p=1$…$…` (OWASP params), salt embedded in the hash — the `salt` column persists for sha512 rows. Verification dispatches on the column; unknown values fail closed.
-- **User identifier**: `hex(md5(lower(email)))` — 32-char hex; the primary user lookup key. (`EncodeService` still supports a salted form `hex(md5(lower(email) || salt))`, but only the `data:remove-salt` migration uses it — see below.)
+- **User lookup key**: `lower(email)` — enforced unique by the expression index `users_email_lower_uniq`; repo lookups are `GetByEmail`/`ExistsByEmail` (`WHERE lower(email) = lower(?)`). The legacy `identifier` column is retained (dropping a NOT NULL UNIQUE column would force a SQLite table rebuild) but retired: it now holds the row's own `id` as a unique non-null placeholder, no longer derived from email. `EncodeService.Hash` (the md5 identifier derivation) was removed — nothing computes it anymore.
 - **Email encryption**: emails are stored as plaintext. `EncodeService` still implements AES-128-CBC (key = raw salt, 16 bytes; layout `base64(iv[16] || hmac_sha256[32] || ciphertext)`, PKCS#7, random IV, HMAC verified constant-time before decrypt), but the API constructs it with an empty salt, so Encode/Decode are passthrough. The salted path runs only inside `data:remove-salt`.
-- **Salt-free everywhere**: the API and all CLI user commands construct `EncodeService` with `""` and ignore `ECONUMO_DATA_SALT` entirely (`server.BuildAPI`, `cli` container). The salt reaches code through one path only: `data:remove-salt` passes it into `MigrateRemoveDataSalt(ctx, salt)`, which builds a temporary salted encoder to decrypt legacy data and re-derive identifiers as `md5(lower(email))`.
+- **Salt-free everywhere**: the API and all CLI user commands construct `EncodeService` with `""` and ignore `ECONUMO_DATA_SALT` entirely (`server.BuildAPI`, `cli` container). The salt reaches code through one path only: `data:remove-salt` passes it into `MigrateRemoveDataSalt(ctx, salt)`, which builds a temporary salted encoder to decrypt legacy email data to plaintext (the repo writes the row `id` into `identifier` automatically, so no re-derivation is needed).
 
 ### Access tokens (`internal/user/token.go`)
 - Format: `eco_ses_` (session) / `eco_pat_` (personal) + `base64.RawURLEncoding` of 32

--- a/docs/migration-v0-to-v1.md
+++ b/docs/migration-v0-to-v1.md
@@ -123,10 +123,13 @@ The Symfony variables are gone; start from the new
   default — prints to stdout) or `resend://<api_key>?from=…&reply_to=…`. A
   leftover v0.x value will **fail at boot**, so clear it or set the new form.
 - **`ECONUMO_DATA_SALT`** is deprecated, and v1.x runs **salt-free** — it no
-  longer decrypts salted data. If your v0.x instance never set it (or set it
-  empty), do nothing. **If it was set, you must migrate the data once**, or those
-  users can't log in (their emails are unreadable and identifiers no longer match).
-  Back up your database first, then:
+  longer decrypts salted data. Users are looked up by `lower(email)`, which
+  only works once emails are plaintext. If your v0.x instance never set it (or
+  set it empty), do nothing. **If it was set, you must migrate the data once**,
+  or those users can't log in (their emails are unreadable, so they can't be
+  matched against the plaintext `lower(email)` lookup) — this is not a new
+  regression, they're already unable to log in until you migrate. Back up
+  your database first, then:
 
     1. In `.env`, set `ECONUMO_DATA_SALT` to your **old** salt (so the migration
        can decrypt), and start v1.x: `docker compose up -d`.
@@ -137,8 +140,8 @@ The Symfony variables are gone; start from the new
         $ docker compose exec econumo /app/econumo data:remove-salt
         ```
 
-       It decrypts every email to plaintext, re-derives identifiers without the
-       salt, refuses to run on an empty salt, and is idempotent (safe to re-run).
+       It decrypts every email to plaintext, refuses to run on an empty salt,
+       and is idempotent (safe to re-run).
     3. Remove/comment `ECONUMO_DATA_SALT` in `.env` and restart:
        `docker compose up -d`. The boot-time `ECONUMO_DATA_SALT is set` warning
        clearing confirms you're done.

--- a/docs/superpowers/plans/2026-07-22-retire-user-identifier.md
+++ b/docs/superpowers/plans/2026-07-22-retire-user-identifier.md
@@ -233,8 +233,10 @@ In `internal/user/login.go`, replace lines 24-25:
 with:
 
 ```go
-	u, err := s.repo.GetByEmail(ctx, strings.TrimSpace(req.Username))
+	u, err := s.repo.GetByEmail(ctx, req.Username)
 ```
+
+(Pass `req.Username` UNTRIMMED — the original lookup was `Hash(ToLower(req.Username))` with no trim; `GetByEmail`'s query lowercases, so this reproduces the exact prior matching behavior. Do not add `TrimSpace` here.)
 
 - [ ] **Step 2: Switch `userByEmail` (admin lookups)**
 

--- a/docs/superpowers/plans/2026-07-22-retire-user-identifier.md
+++ b/docs/superpowers/plans/2026-07-22-retire-user-identifier.md
@@ -1,0 +1,551 @@
+# Retire the `users.identifier` column — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `lower(email)` the unique + lookup key for users, stop deriving `identifier` from email, and remove `User.Identifier` from the domain — keeping the physical column in place (populated with the row `id`) so no SQLite table rebuild is needed.
+
+**Architecture:** Three functional phases plus docs. (1) Add email-based repo lookups additively so the build stays green. (2) Switch every service lookup/existence check from the md5 identifier to email. (3) Retire `identifier`: a migration adds a `lower(email)` unique index and backfills `identifier = id`; the model drops the field; the repo writes `id` into the column and stops reading it; `EncodeService.Hash` and the old identifier queries are removed. Each phase compiles and passes tests on its own.
+
+**Tech Stack:** Go (hexagonal, per-feature packages), sqlc v1.30 (per-engine codegen: `gen/sqlite`, `gen/pgsql`), SQLite (`modernc.org/sqlite`) + PostgreSQL (`pgx`), `internal/test/dbtest` + `enginecompare`.
+
+## Global Constraints
+
+- **Wire contract is frozen and must not change.** `identifier` is never serialized; login/register/reset/verify behavior stays byte-identical. `apiparity` and `mcpparity` goldens MUST NOT change — if a golden diff appears, something regressed. Never hand-edit a golden.
+- **Two engines, byte-identical.** Every schema/query change lands in BOTH `sqlite` and `pgsql` variants. `make test-repo-pgsql` and the `enginecompare` suite must pass.
+- **sqlc is the source of truth for SQL.** After editing any `query/{sqlite,pgsql}/*.sql` or migration, regenerate with `sqlc generate` (from `internal/infra/storage/sqlc/`, or `go generate ./internal/infra/storage/sqlc/...`). A query referencing a dropped column fails generation.
+- **sqlc ASCII-only in `.sql`.** No em dashes / non-ASCII in query or migration files (v1.30 sqlite codegen mangles byte offsets).
+- **Coverage gate:** `make go-test` enforces `GO_COVER_MIN` (default 78).
+- **Comments:** only the *why* for non-obvious/frozen-contract rationale; no restating-the-name godoc, no references to the former PHP implementation.
+- **Validated fact:** sqlc generates `func (q *Queries) GetUserByEmail(ctx, lower string) (GetUserByEmailRow, error)` (sqlite) and `(bool, error)` for `ExistsUserByEmail`; the generated positional param is named `lower` (from the `lower(?)` expression) — harmless, called positionally.
+
+---
+
+### Task 1: Add email-based repo lookups (additive)
+
+Add `GetUserByEmail` / `ExistsUserByEmail` alongside the existing identifier queries and repo methods. Nothing is removed yet, so the build and all existing tests stay green. New integration tests prove the case-insensitive lookup.
+
+**Files:**
+- Modify: `internal/infra/storage/sqlc/query/sqlite/users.sql`
+- Modify: `internal/infra/storage/sqlc/query/pgsql/users.sql`
+- Regenerate: `internal/infra/storage/sqlc/gen/{sqlite,pgsql}/users.sql.go`, `querier.go`
+- Modify: `internal/user/repository.go:15-55` (Repository interface)
+- Modify: `internal/user/repo/repo.go:50-62` (querier interface), `:123-136` (methods)
+- Modify: `internal/user/repo/sqlite.go`, `internal/user/repo/pgsql.go` (adapters)
+- Test: `internal/user/repo/repo_integration_test.go`
+
+**Interfaces:**
+- Produces: `Repository.GetByEmail(ctx, email string) (*model.User, error)` and `Repository.ExistsByEmail(ctx, email string) (bool, error)` — case-insensitive on `email`; `GetByEmail` returns `*errs.NotFoundError` when absent. Task 2 consumes these.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add to `internal/user/repo/repo_integration_test.go` (mirrors the existing `TestUserRepo_GetByIdentifier` right above; `newTestUser` args are `(id, ident, email, name, avatar, hash, salt, active, created, updated, options)`):
+
+```go
+func TestUserRepo_GetByEmail(t *testing.T) {
+	repo, _, db := newRepos(t)
+	ctx := context.Background()
+	u := newTestUser(vo.MustParseId(userA), identA, "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Lookup is case-insensitive.
+	got, err := repo.GetByEmail(ctx, "alice@example.test")
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if got.ID.String() != userA {
+		t.Errorf("want %s, got %s", userA, got.ID)
+	}
+	_, err = repo.GetByEmail(ctx, "missing@example.test")
+	var nf *errs.NotFoundError
+	if !errors.As(err, &nf) {
+		t.Fatalf("want NotFound for missing email, got %v", err)
+	}
+}
+
+func TestUserRepo_ExistsByEmail(t *testing.T) {
+	repo, _, db := newRepos(t)
+	ctx := context.Background()
+	u := newTestUser(vo.MustParseId(userA), identA, "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	exists, err := repo.ExistsByEmail(ctx, "alice@example.test")
+	if err != nil || !exists {
+		t.Errorf("ExistsByEmail(alice) = %v, %v; want true", exists, err)
+	}
+	exists, err = repo.ExistsByEmail(ctx, "nope@example.test")
+	if err != nil || exists {
+		t.Errorf("ExistsByEmail(nope) = %v, %v; want false", exists, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (compile error)**
+
+Run: `go test ./internal/user/repo/ -run 'TestUserRepo_(GetByEmail|ExistsByEmail)'`
+Expected: FAIL — `repo.GetByEmail`/`repo.ExistsByEmail` undefined.
+
+- [ ] **Step 3: Add the sqlc queries (both engines)**
+
+Append to `internal/infra/storage/sqlc/query/sqlite/users.sql`:
+
+```sql
+-- name: GetUserByEmail :one
+SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+FROM users
+WHERE lower(email) = lower(?);
+
+-- name: ExistsUserByEmail :one
+SELECT EXISTS(SELECT 1 FROM users WHERE lower(email) = lower(?));
+```
+
+Append to `internal/infra/storage/sqlc/query/pgsql/users.sql`:
+
+```sql
+-- name: GetUserByEmail :one
+SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+FROM users
+WHERE lower(email) = lower($1);
+
+-- name: ExistsUserByEmail :one
+SELECT EXISTS(SELECT 1 FROM users WHERE lower(email) = lower($1));
+```
+
+- [ ] **Step 4: Regenerate sqlc**
+
+Run: `cd internal/infra/storage/sqlc && sqlc generate && cd -`
+Expected: exit 0; new `GetUserByEmail`/`ExistsUserByEmail` in `gen/sqlite/users.sql.go` and `gen/pgsql/users.sql.go`.
+
+- [ ] **Step 5: Add querier methods + adapters**
+
+In `internal/user/repo/repo.go`, add to the `querier` interface (after the `ExistsUserByIdentifier` line):
+
+```go
+	GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error)
+	ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error)
+```
+
+In `internal/user/repo/sqlite.go`, add:
+
+```go
+func (sqliteQuerier) GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error) {
+	row, err := sqlitegen.New(db).GetUserByEmail(ctx, email)
+	return userRow(row), err
+}
+
+func (sqliteQuerier) ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error) {
+	n, err := sqlitegen.New(db).ExistsUserByEmail(ctx, email)
+	return n != 0, err
+}
+```
+
+In `internal/user/repo/pgsql.go`, add:
+
+```go
+func (pgsqlQuerier) GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error) {
+	u, err := pgsqlgen.New(db).GetUserByEmail(ctx, email)
+	return userRow(u), err
+}
+
+func (pgsqlQuerier) ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error) {
+	return pgsqlgen.New(db).ExistsUserByEmail(ctx, email)
+}
+```
+
+- [ ] **Step 6: Add the Repo methods**
+
+In `internal/user/repo/repo.go`, after `ExistsByIdentifier` (`:136`):
+
+```go
+func (r *Repo) GetByEmail(ctx context.Context, email string) (*model.User, error) {
+	row, err := r.q.GetUserByEmail(ctx, r.db(ctx), email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errs.NewNotFound("User not found")
+		}
+		return nil, err
+	}
+	return r.hydrate(ctx, row)
+}
+
+func (r *Repo) ExistsByEmail(ctx context.Context, email string) (bool, error) {
+	return r.q.ExistsUserByEmail(ctx, r.db(ctx), email)
+}
+```
+
+- [ ] **Step 7: Add the methods to the Repository port**
+
+In `internal/user/repository.go`, inside `type Repository interface`, after `ExistsByIdentifier` (`:28`):
+
+```go
+	// GetByEmail loads a user (with options) by email, case-insensitively.
+	// Missing -> *errs.NotFoundError.
+	GetByEmail(ctx context.Context, email string) (*model.User, error)
+
+	// ExistsByEmail reports whether a user with that email exists
+	// (case-insensitive). Used by registration/change-email dup-checks.
+	ExistsByEmail(ctx context.Context, email string) (bool, error)
+```
+
+- [ ] **Step 8: Run the new tests (sqlite)**
+
+Run: `go test ./internal/user/repo/ -run 'TestUserRepo_(GetByEmail|ExistsByEmail)'`
+Expected: PASS.
+
+- [ ] **Step 9: Full smoke build + vet**
+
+Run: `go build ./... && go vet ./internal/user/...`
+Expected: exit 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/infra/storage/sqlc internal/user/repo internal/user/repository.go
+git commit -m "feat(user): add email-based repo lookups alongside identifier"
+```
+
+---
+
+### Task 2: Switch service lookups from identifier to email
+
+Repoint every service **lookup / existence check** at the email methods. Leave the `identifier`/`newIdentifier` locals that still feed `NewUser` / `UpdateEmail` in place (those signatures change in Task 3). Behavior is identical, so the existing suite is the test.
+
+**Files:**
+- Modify: `internal/user/login.go:24-25`
+- Modify: `internal/user/register.go:49-58`
+- Modify: `internal/user/admin.go:39-47` (change-email dup-check), `:158-161` (`userByEmail`)
+- Modify: `internal/user/password.go:88`, `:127`
+- Modify: `internal/user/verify_email.go:47`, `:131`
+
+**Interfaces:**
+- Consumes: `Repository.GetByEmail` / `ExistsByEmail` (Task 1).
+
+- [ ] **Step 1: Switch the login lookup**
+
+In `internal/user/login.go`, replace lines 24-25:
+
+```go
+	identifier := s.encode.Hash(strings.ToLower(req.Username))
+	u, err := s.repo.GetByIdentifier(ctx, identifier)
+```
+
+with:
+
+```go
+	u, err := s.repo.GetByEmail(ctx, strings.TrimSpace(req.Username))
+```
+
+- [ ] **Step 2: Switch `userByEmail` (admin lookups)**
+
+In `internal/user/admin.go`, replace the body of `userByEmail` (`:158-161`):
+
+```go
+func (s *Service) userByEmail(ctx context.Context, email string) (*model.User, error) {
+	return s.repo.GetByEmail(ctx, strings.TrimSpace(email))
+}
+```
+
+(Update the doc comment above it to say "resolves a user from a plaintext email (case-insensitive)"; drop the md5-identifier wording.)
+
+- [ ] **Step 3: Switch the register dup-check**
+
+In `internal/user/register.go` `createUser`, change the existence check (`:52`) from `ExistsByIdentifier(ctx, identifier)` to:
+
+```go
+	exists, err := s.repo.ExistsByEmail(ctx, loweredEmail)
+```
+
+Leave `loweredEmail` and `identifier := s.encode.Hash(loweredEmail)` (`:49-50`) as-is — `identifier` is still passed to `NewUser` at `:75` until Task 3.
+
+- [ ] **Step 4: Switch the change-email dup-check**
+
+In `internal/user/admin.go` `AdminChangeEmail`, the original guard compared `newIdentifier != u.Identifier` to skip the dup-check when the email is unchanged. `u.Identifier` is going away, so compare the emails directly (`u.Email` is ciphertext — decode it via the salt-free passthrough encoder). Replace the guarded block (`:37-47`) with:
+
+```go
+	currentEmail, derr := s.encode.Decode(u.Email)
+	if derr != nil {
+		return derr
+	}
+	loweredNew := strings.ToLower(strings.TrimSpace(newEmail))
+	newIdentifier := s.encode.Hash(loweredNew)
+	if loweredNew != strings.ToLower(currentEmail) {
+		exists, eerr := s.repo.ExistsByEmail(ctx, loweredNew)
+		if eerr != nil {
+			return eerr
+		}
+		if exists {
+			return &errs.ValidationError{Msg: "User already exists", MsgCode: errs.CodeUserAlreadyExists}
+		}
+	}
+```
+
+`newIdentifier` is still computed here because it feeds the `UpdateEmail(newIdentifier, ...)` call at `:55`, which keeps its current signature until Task 3. Leave the `encryptedEmail`/`UpdateEmail` lines (`:49-56`) unchanged in this task.
+
+- [ ] **Step 5: Switch the password-flow lookups**
+
+In `internal/user/password.go`, replace `s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))` at BOTH `:88` (RemindPassword) and `:127` (ResetPassword) with:
+
+```go
+	u, err := s.repo.GetByEmail(ctx, lowered)
+```
+
+(`lowered` is already `strings.ToLower(strings.TrimSpace(req.Username))` at both sites.)
+
+- [ ] **Step 6: Switch the verify-email lookups**
+
+In `internal/user/verify_email.go`, replace `s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))` at `:47` (ConfirmEmail) and `:131` (ResendVerificationCode / issue path) with:
+
+```go
+	u, err := s.repo.GetByEmail(ctx, lowered)
+```
+
+- [ ] **Step 7: Build + vet**
+
+Run: `go build ./... && go vet ./internal/user/...`
+Expected: exit 0. (If `strings` becomes unused in `login.go`, keep it — `TrimSpace` still uses it.)
+
+- [ ] **Step 8: Run the user + parity suites**
+
+Run: `go test ./internal/user/... ./internal/test/apiparity/... ./internal/test/mcpparity/...`
+Expected: PASS, and NO golden changes (behavior identical).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/user
+git commit -m "refactor(user): resolve users by email instead of md5 identifier"
+```
+
+---
+
+### Task 3: Retire the identifier column
+
+Add the migration (`lower(email)` unique index + `identifier = id` backfill), drop `User.Identifier`, make the repo write `id` into the column and stop reading it, remove `EncodeService.Hash` and the now-dead identifier queries, and update every identifier-asserting test. One atomic, behavior-preserving change.
+
+**Files:**
+- Create: `internal/infra/storage/migrations/sqlite/20260722000000.sql`
+- Create: `internal/infra/storage/migrations/pgsql/20260722000000.sql`
+- Modify: `internal/model/user.go:100-137` (field, `NewUser`), `:219-225` (`UpdateEmail`)
+- Modify: `internal/user/register.go:49-75`, `internal/user/admin.go:37-56`, `internal/user/migrate.go:44-72`
+- Modify: `internal/infra/storage/sqlc/query/{sqlite,pgsql}/users.sql` (remove identifier queries; drop `identifier` from the two SELECT column lists)
+- Regenerate: `gen/{sqlite,pgsql}`
+- Modify: `internal/user/repo/repo.go` (querier, `GetByIdentifier`/`ExistsByIdentifier` removal, `Save`, `userRow`, `hydrate`), `sqlite.go`, `pgsql.go`, `internal/user/repository.go`
+- Modify: `internal/infra/auth/encode.go` (remove `Hash`), `internal/infra/auth/crypto_golden_test.go` (drop Hash vectors)
+- Modify tests: `internal/test/fixture/entities.go:59`, `internal/user/repo/repo_integration_test.go` (`newTestUser`, remove `TestUserRepo_GetByIdentifier`/`ExistsByIdentifier`), `internal/user/migrate_test.go`, `internal/user/admin_integration_test.go`, `internal/user/trial_integration_test.go`, `internal/user/avatar_update_integration_test.go`, `internal/user/verify_email_test.go`, `internal/model/user_test.go`, `internal/model/user_activate_test.go`, `internal/infra/storage/migrations/email_verified_backfill_test.go`
+
+**Interfaces:**
+- Produces: `model.NewUser(id vo.Id, encryptedEmail, name, avatar, passwordHash, salt string, now time.Time) *User` (no `identifier`); `(*User).UpdateEmail(encryptedEmail string, now time.Time)` (no `identifier`). `Repository` no longer has `GetByIdentifier`/`ExistsByIdentifier`. `EncodeService` no longer has `Hash`.
+
+- [ ] **Step 1: Write the migration (both engines)**
+
+Create `internal/infra/storage/migrations/sqlite/20260722000000.sql`:
+
+```sql
+-- The email-derived md5 identifier is retired: lower(email) is now the unique
+-- key (index below), and the identifier column is kept only to satisfy its
+-- pre-existing NOT NULL UNIQUE constraint without a SQLite table rebuild. Each
+-- row's own id is a ready-made unique, non-null placeholder.
+CREATE UNIQUE INDEX users_email_lower_uniq ON users (lower(email));
+UPDATE users SET identifier = id;
+```
+
+Create `internal/infra/storage/migrations/pgsql/20260722000000.sql` with the identical two statements (same comment, same SQL — `lower(email)` and `identifier = id` are valid Postgres).
+
+- [ ] **Step 2: Write/adjust the failing model test**
+
+In `internal/model/user_test.go`, update the `NewUser`/`UpdateEmail` call sites to the new signatures and assert email-only behavior. Representative (adapt to the existing test names in the file):
+
+```go
+func TestUser_UpdateEmail(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	u := model.NewUser(vo.MustParseId("00000000-0000-7000-8000-000000000001"),
+		"old@example.test", "Alice", "face:blue", "hash", "salt", now)
+	later := now.Add(time.Hour)
+	u.UpdateEmail("new@example.test", later)
+	if u.Email != "new@example.test" {
+		t.Errorf("email = %q, want new@example.test", u.Email)
+	}
+	if !u.UpdatedAt.Equal(later) {
+		t.Errorf("UpdatedAt not bumped")
+	}
+}
+```
+
+Remove any assertions on `u.Identifier` in `user_test.go` and `user_activate_test.go`.
+
+- [ ] **Step 3: Run it to verify it fails (compile error)**
+
+Run: `go test ./internal/model/ -run TestUser_UpdateEmail`
+Expected: FAIL — too many arguments to `model.NewUser` / `UpdateEmail`.
+
+- [ ] **Step 4: Change the model**
+
+In `internal/model/user.go`: delete the `Identifier` field (`:102`); update the `User` doc comment (`:95-99`) to drop "or hashed (…Identifier)". Change `NewUser` (`:121-137`):
+
+```go
+// NewUser constructs a freshly-registered user. The caller (the service) has
+// already encrypted the email, picked the avatar, and hashed the password.
+// Options are seeded separately via SeedDefaultOptions.
+func NewUser(id vo.Id, encryptedEmail, name, avatar, passwordHash, salt string, now time.Time) *User {
+	return &User{
+		ID:            id,
+		Email:         encryptedEmail,
+		Name:          name,
+		Avatar:        avatar,
+		Password:      passwordHash,
+		Salt:          salt,
+		Algorithm:     AlgorithmArgon2id,
+		IsActive:      true,
+		EmailVerified: true,
+		AccessLevel:   AccessLevelFull,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+```
+
+Change `UpdateEmail` (`:219-225`):
+
+```go
+// UpdateEmail replaces the encrypted email. The identifier column is derived
+// from the row id at persistence time, so it needs no update here.
+func (u *User) UpdateEmail(encryptedEmail string, now time.Time) {
+	u.Email = encryptedEmail
+	u.UpdatedAt = now
+}
+```
+
+- [ ] **Step 5: Update the service call sites**
+
+`internal/user/register.go` `createUser`: delete `identifier := s.encode.Hash(loweredEmail)` (`:50`); keep `loweredEmail` (still used by `ExistsByEmail`). Change the `NewUser` call (`:75`) to:
+
+```go
+	u := model.NewUser(s.repo.NextIdentity(), encryptedEmail, name, avatar, passwordHash, salt, now)
+```
+
+`internal/user/admin.go` `AdminChangeEmail`: delete `newIdentifier := s.encode.Hash(loweredNew)`; change the commit (`:54-57`) to:
+
+```go
+	return s.tx.WithTx(ctx, func(ctx context.Context) error {
+		u.UpdateEmail(encryptedEmail, s.clock.Now())
+		return s.repo.Save(ctx, u)
+	})
+```
+
+`internal/user/migrate.go` `MigrateRemoveDataSalt`: delete the `saltFree` encoder (`:47`) and the `newIdent` derivation (`:62`); simplify the loop body (`:55-72`) to:
+
+```go
+			plain, derr := salted.Decode(u.Email)
+			if derr != nil {
+				skipped++
+				continue
+			}
+			if plain == u.Email {
+				skipped++
+				continue
+			}
+			u.UpdateEmail(plain, s.clock.Now())
+			if serr := s.repo.Save(ctx, u); serr != nil {
+				return serr
+			}
+			migrated++
+```
+
+Update the `MigrateRemoveDataSalt` doc comment to drop the identifier-re-derivation paragraph (it now only decrypts email to plaintext; the repo writes `id` into the identifier column).
+
+- [ ] **Step 6: Update the repo (write id, stop reading identifier)**
+
+`internal/user/repo/repo.go`:
+- In `Save` (`:166-181`), change `Identifier: u.Identifier,` to `Identifier: u.ID.String(),`.
+- Delete `GetByIdentifier` (`:123-132`) and `ExistsByIdentifier` (`:134-136`).
+- In the `querier` interface, delete the `GetUserByIdentifier` and `ExistsUserByIdentifier` lines.
+- In `userRow` (`:26-42`), delete the `Identifier string` field.
+- In `hydrate` (`:241`), delete `Identifier: row.Identifier,` from the `&model.User{...}` literal.
+
+`internal/user/repo/sqlite.go` and `pgsql.go`: delete the `GetUserByIdentifier` and `ExistsUserByIdentifier` adapter methods.
+
+`internal/user/repository.go`: delete the `GetByIdentifier` and `ExistsByIdentifier` interface methods (`:22-28`).
+
+- [ ] **Step 7: Update the sqlc queries + regenerate**
+
+In `internal/infra/storage/sqlc/query/sqlite/users.sql` and `.../pgsql/users.sql`:
+- Delete the `GetUserByIdentifier` and `ExistsUserByIdentifier` query blocks.
+- Remove `identifier, ` from the SELECT column list of BOTH `GetUserByID` and `GetUserByEmail` (so their generated row types match the trimmed `userRow`). Leave `InsertUser` / `UpsertUser` unchanged (they still write the `identifier` column; the repo supplies `id`).
+
+Run: `cd internal/infra/storage/sqlc && sqlc generate && cd -`
+Expected: exit 0; `gen/*/users.sql.go` no longer has `GetUserByIdentifier`; `GetUserByIDRow` / `GetUserByEmailRow` no longer have an `Identifier` field.
+
+- [ ] **Step 8: Remove `EncodeService.Hash`**
+
+In `internal/infra/auth/encode.go`, delete the `Hash` method (`:56-59`). In `internal/infra/auth/crypto_golden_test.go`, delete the `Hash` golden vectors (the `identifier_hash` fixture field at `:25` and the `svc.Hash` assertion at `:71`); if the fixture struct field becomes unused, remove it.
+
+- [ ] **Step 9: Update the remaining tests + fixtures**
+
+- `internal/test/fixture/entities.go:59`: delete the line computing/assigning `Identifier` (the repo now writes `id`); if the fixture builds `model.User` via `NewUser`, drop the identifier argument.
+- `internal/user/repo/repo_integration_test.go`: change `newTestUser` to drop the `ident` parameter (and remove `Identifier:` from the `model.User` it builds); update all `newTestUser(...)` call sites to drop the `identA` argument; DELETE `TestUserRepo_GetByIdentifier` and `TestUserRepo_ExistsByIdentifier` (superseded by the Task 1 email tests); remove the now-unused `identA` const if nothing else references it.
+- `internal/user/migrate_test.go`: stop asserting `u.Identifier`; assert the email was decrypted to plaintext and that a subsequent `GetByEmail` finds the row.
+- `internal/user/admin_integration_test.go`, `trial_integration_test.go`, `avatar_update_integration_test.go`, `verify_email_test.go`: replace every `GetByIdentifier(enc.Hash(x))` lookup with `GetByEmail(x)`; drop `enc.Hash`/identifier usages.
+- `internal/infra/storage/migrations/email_verified_backfill_test.go:44,63`: the raw `INSERT INTO users (...)` still lists `identifier` (the column exists) — set its value to the row's `id` instead of an md5 (any unique non-null value works).
+
+- [ ] **Step 10: Build, vet, and run the full Go smoke suite**
+
+Run: `make go-test`
+Expected: PASS — build + vet + gofmt + apiparity/mcpparity goldens UNCHANGED + i18n guards + coverage gate. If a golden diff appears, STOP and investigate (behavior must be identical).
+
+- [ ] **Step 11: Run the PostgreSQL + engine-comparison suites**
+
+Run: `make test-repo-pgsql` then `go test -tags enginecompare ./internal/test/enginecompare/...`
+Expected: PASS (the `lower(email)` index + lookups behave identically on both engines). If Postgres isn't provisioned, `make test` auto-provisions it.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal
+git commit -m "refactor(user): retire the identifier column (lower(email) is the key)"
+```
+
+---
+
+### Task 4: Documentation
+
+Update the prose that describes the identifier so it matches reality (email is the key; the column is a retired `= id` placeholder), and add the upgrade note.
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `internal/infra/storage/sqlc/sqlc.yaml` (header comment mentioning the `Identifier` VO mapping)
+- Modify: `internal/server/server.go:114`, `internal/config/config.go:24` (explanatory comments)
+- Modify: `docs/run-without-docker.md` OR the README upgrade section (whichever documents `data:remove-salt`) — add the prerequisite note
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+In the "Wire & data contract" → "Auth crypto" section, change the "User identifier" bullet to state that `lower(email)` is now the unique + lookup key (unique expression index `users_email_lower_uniq`), and that the legacy `identifier` column is retained but retired (populated with the row `id`, no longer derived from email). In the "Salt-free everywhere" bullet and the `data:remove-salt` / `ECONUMO_DATA_SALT` description, drop the "re-derives the identifier" wording — `data:remove-salt` now only decrypts email to plaintext. Keep it ASCII-clean.
+
+- [ ] **Step 2: Update code comments**
+
+- `internal/infra/storage/sqlc/sqlc.yaml`: in the header comment, change "string <-> domain value objects (Id, Identifier)" to just "(Id)".
+- `internal/server/server.go:114` and `internal/config/config.go:24`: reword any comment that describes the md5 identifier as the lookup key to reference `lower(email)`; keep the `ECONUMO_DATA_SALT` decryption note.
+
+- [ ] **Step 3: Add the upgrade note**
+
+Wherever `data:remove-salt` is documented for operators, add: a still-salted instance must run `data:remove-salt` after upgrading so emails are plaintext before the `lower(email)` unique index is relied upon (salted instances are already login-broken until they migrate — no regression).
+
+- [ ] **Step 4: Verify docs build / no broken references**
+
+Run: `make go-lint`
+Expected: exit 0 (build + vet + gofmt + OpenAPI-docs-fresh check unaffected by prose).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md internal/infra/storage/sqlc/sqlc.yaml internal/server/server.go internal/config/config.go docs
+git commit -m "docs: describe lower(email) as the user key; identifier retired"
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not** attempt to drop the `identifier` column or its `UNIQUE` constraint — that would force a SQLite `users` table rebuild under `foreign_keys = ON`, which is the risk this design deliberately avoids.
+- The three functional tasks are ordered so the build + tests stay green after each. If you must reorder, keep Task 3 atomic: the model signature change, the sqlc SELECT trim, and `userRow`/`hydrate` must land together or the package won't compile.
+- Golden files (`apiparity`, `mcpparity`) must not change. A diff means a behavior regression — investigate, don't regenerate.

--- a/docs/superpowers/plans/2026-07-22-retire-user-identifier.md
+++ b/docs/superpowers/plans/2026-07-22-retire-user-identifier.md
@@ -302,6 +302,30 @@ In `internal/user/verify_email.go`, replace `s.repo.GetByIdentifier(ctx, s.encod
 	u, err := s.repo.GetByEmail(ctx, lowered)
 ```
 
+- [ ] **Step 6b: Make the legacy user test harnesses salt-free (production parity)**
+
+Three older integration harnesses build the Service + fixtures with a non-empty
+AES salt, so `users.email` is stored as ciphertext — a configuration production
+no longer uses (the API is salt-free, so `Encode` is passthrough / plaintext).
+`GetByEmail`/`ExistsByEmail` match on the plaintext `email` column, so these
+harnesses must be salt-free too (the newer tests already use
+`auth.NewEncodeService("")` — `authenticate_test.go:50`, `verify_email_test.go:55,80`).
+
+Change the encoder construction to `auth.NewEncodeService("")` and the paired
+fixture `WithCrypto(...)` calls to the salt-free form (empty salt, or drop
+`WithCrypto`) in:
+- `internal/user/admin_integration_test.go:30` (`newUserSvc`) and `:173`
+- `internal/user/trial_integration_test.go:27` (`newTrialSvc`)
+- `internal/user/api/harness_test.go:90` (`newHarness`/`newHarnessWithLimiter`) and `:167`
+
+Keep `migrate_test.go` salted — it tests `data:remove-salt`. `MigrateRemoveDataSalt`
+takes the salt as a PARAMETER and builds its own salted encoder internally (it
+does not use `s.encode`), so `newUserSvc` being salt-free is fine for the migration
+call. Keep `migrate_test.go`'s salted seeding (`fixture.New(t, db).WithCrypto(testSalt)`)
+and construct any salted encoder it needs for pre-migration assertions LOCALLY
+(`auth.NewEncodeService(testSalt)`) instead of via the harness. Keep the `testSalt`
+const (still used by `migrate_test.go`).
+
 - [ ] **Step 7: Build + vet**
 
 Run: `go build ./... && go vet ./internal/user/...`
@@ -309,8 +333,8 @@ Expected: exit 0. (If `strings` becomes unused in `login.go`, keep it — `TrimS
 
 - [ ] **Step 8: Run the user + parity suites**
 
-Run: `go test ./internal/user/... ./internal/test/apiparity/... ./internal/test/mcpparity/...`
-Expected: PASS, and NO golden changes (behavior identical).
+Run: `go test ./internal/user/... ./internal/user/api/... ./internal/test/apiparity/... ./internal/test/mcpparity/...`
+Expected: PASS (including the now-salt-free harnesses from Step 6b), and NO golden changes (behavior identical — `git status` shows no testdata/golden edits).
 
 - [ ] **Step 9: Commit**
 

--- a/docs/superpowers/specs/2026-07-22-remove-user-identifier-design.md
+++ b/docs/superpowers/specs/2026-07-22-remove-user-identifier-design.md
@@ -1,4 +1,4 @@
-# Remove the `users.identifier` column
+# Retire the `users.identifier` column
 
 **Date:** 2026-07-22
 **Status:** Approved (design)
@@ -18,70 +18,89 @@ deterministic `identifier` hash was the stand-in.
 The app now runs **salt-free with plaintext emails** (`ECONUMO_DATA_SALT` is
 deprecated/ignored; `data:remove-salt` decrypts existing data to plaintext). With
 plaintext emails, a unique index on `lower(email)` plus direct email lookups fully
-replace `identifier`. The column is redundant.
+replace `identifier`. The column's derivation is redundant.
 
 ## Goal
 
-Delete `users.identifier`. Make `lower(email)` the unique + lookup key. Keep the
-observable wire contract byte-identical.
+Make `lower(email)` the unique + lookup key. Stop deriving `identifier` from email
+anywhere in the code, and remove `User.Identifier` from the domain model.
 
-Non-goals: the change-email feature itself (separate spec), any change to email
-encryption/`Encode`/`Decode`, any change to how other tables reference `users.id`.
+**Keep the physical column** (populated with the row's own `id` as a unique,
+non-null placeholder). We do NOT drop it, because SQLite cannot drop a
+`NOT NULL UNIQUE` column without a full `users` table rebuild, and migrations here
+run in a single transaction under `foreign_keys = ON` (which can't be toggled
+mid-transaction) — a bespoke rebuild of the FK-heavy `users` parent is the one
+delicate, data-loss-capable step we choose to avoid. Retiring the column in place
+achieves the functional goal at near-zero migration risk on both engines.
+
+Keep the observable wire contract byte-identical.
+
+Non-goals: dropping the physical column; the change-email feature (separate spec);
+any change to email encryption / `Encode` / `Decode`; any change to how other
+tables reference `users.id`.
 
 ## Key facts (from codebase investigation)
 
-- `identifier` is **never on the wire**: no `json:"identifier"` tag exists in any
-  DTO/response; `model.User.Identifier` has no JSON tag. So REST/MCP goldens
-  (`apiparity`, `mcpparity`) must not change.
+- `identifier` is **never on the wire**: no `json:"identifier"` tag in any DTO;
+  `model.User.Identifier` has no JSON tag. REST/MCP goldens (`apiparity`,
+  `mcpparity`) must not change.
 - `identifier` is **not a foreign-key target**: every FK to users targets
-  `users(id)`. `identifier` is only a standalone `UNIQUE` column/index on `users`.
+  `users(id)`.
 - Only **two repo methods** read it: `GetByIdentifier`, `ExistsByIdentifier`
   (`internal/user/repo/repo.go:123,134`). All other use is the
-  `s.encode.Hash(lower(email))` derivation at the call sites below.
+  `s.encode.Hash(lower(email))` derivation (login, register, admin, password,
+  verify-email).
 - The stored `email` column holds ciphertext/plaintext of the **original-case**
-  (trimmed) email. Lowercasing happens today only at the `Hash` call sites, never
-  before storage. Therefore the replacement uniqueness must be an **expression
-  index on `lower(email)`**, not a plain unique index on the column.
-- Expression indexes are supported by both engines (SQLite ≥ 3.9, PostgreSQL).
+  (trimmed) email. Lowercasing happens today only at the `Hash` call sites.
+  Therefore the replacement uniqueness must be an **expression index on
+  `lower(email)`**, supported by both engines (SQLite ≥ 3.9, PostgreSQL).
+- The `identifier` column is `NOT NULL` and `UNIQUE` (both a table constraint,
+  baseline `20260101000000.sql:71`, and a named index `UNIQ_1483A5E9772E836A`,
+  `:435`). A repeated constant would violate the constraint; the placeholder must
+  stay unique → use each row's `id`.
+- Migrations run one-file-per-transaction with `foreign_keys = ON`
+  (`internal/infra/storage/migrate/migrate.go:178` `applyMigration`).
 
 ## Design
 
-### 1. Schema migration (new dated file, both engines)
+### 1. Schema migration (new dated file `20260722000000.sql`, both engines)
 
-Append-only — do **not** edit historical migrations (they have run in production;
-new installs replay old→new in order).
+Append-only. Two statements, identical intent on both engines:
 
-For `internal/infra/storage/migrations/{sqlite,pgsql}`:
+```sql
+CREATE UNIQUE INDEX users_email_lower_uniq ON users (lower(email));
+UPDATE users SET identifier = id;
+```
 
-1. `CREATE UNIQUE INDEX <name> ON users (lower(email));`
-2. Drop the identifier unique index (`UNIQ_1483A5E9772E836A`) / `UNIQUE (identifier)`
-   constraint and the `identifier` column.
-
-**Migration-ordering caveat (must be documented in the upgrade note / CLAUDE.md):**
-the `lower(email)` scheme requires *plaintext* emails. An instance still holding
-salted/encrypted emails is *already* login-broken by design (mismatched
-identifiers), so this is no regression — but such an instance must run
-`data:remove-salt` to log in after upgrading. The boot migration itself does not
-depend on the salt state (it does not read `identifier`).
+- The expression unique index makes `lower(email)` the enforced key.
+- The `UPDATE` retires the email-derived values (sets each to the row's own unique
+  id). The pre-existing `NOT NULL UNIQUE` constraint on `identifier` is left in
+  place; `id` satisfies both. No column drop, no table rebuild → safe on both
+  engines.
+- **Precondition (documented):** requires plaintext emails. A still-salted
+  instance is *already* login-broken by design; after `data:remove-salt` the
+  emails are plaintext and the `lower(email)` index/lookups work. If two existing
+  rows share a `lower(email)` (shouldn't happen — the old identifier uniqueness
+  prevented it), index creation fails loudly rather than silently.
 
 ### 2. Queries / repository (regenerate sqlc)
 
 `internal/infra/storage/sqlc/query/{sqlite,pgsql}/users.sql`:
 
-- `GetUserByIdentifier` → `GetUserByEmail` — `WHERE lower(email) = lower(?)`
-  (`$1` for pgsql).
-- `ExistsUserByIdentifier` → `ExistsUserByEmail` — same predicate.
-- Remove `identifier` from `CreateUser` and `SyncUser` (insert columns + upsert
-  `identifier = excluded.identifier` clause).
-- Regenerate `sqlc/gen/{sqlite,pgsql}` + `querier.go`.
+- Add `GetUserByEmail` / `ExistsUserByEmail` — `WHERE lower(email) = lower(?)`
+  (`lower($1)` for pgsql).
+- Remove `GetUserByIdentifier` / `ExistsUserByIdentifier`.
+- Drop `identifier` from the `GetUserByID` / `GetUserByEmail` SELECT column lists
+  (the column stays in the table; it is simply no longer read into the domain).
+- Keep `identifier` in `InsertUser` / `UpsertUser` (the column is still
+  `NOT NULL`); the repo supplies the row `id` as its value.
 
 `internal/user/repo/`:
 
 - `repo.go`: `GetByIdentifier`/`ExistsByIdentifier` → `GetByEmail(ctx, email)` /
-  `ExistsByEmail(ctx, email)`; drop `Identifier` from `Save` params and `toModel`
-  scan; drop the field from the row struct.
-- `sqlite.go` / `pgsql.go` adapters: rename to `GetUserByEmail` /
-  `ExistsUserByEmail`; interface in `repo.go` updated.
+  `ExistsByEmail(ctx, email)`. In `Save`, set the upsert param
+  `Identifier: u.ID.String()`. Drop `Identifier` from `userRow` and from
+  `hydrate`. Update the `querier` interface + `sqlite.go`/`pgsql.go` adapters.
 - `internal/user/repository.go`: interface method rename.
 
 ### 3. Service / model
@@ -94,78 +113,72 @@ depend on the salt state (it does not read `identifier`).
   `UpdateEmail(identifier, encryptedEmail, now)`).
 
 Service call sites — replace `s.encode.Hash(lower(email))` + `GetByIdentifier`
-with `GetByEmail(email)` (the query lowercases; pass the raw trimmed email):
+with `GetByEmail(email)` (the query lowercases; pass the trimmed email):
 
-- `internal/user/login.go:24-25` — primary auth lookup.
-- `internal/user/register.go:50-52` — dup-check via `ExistsByEmail`.
-- `internal/user/admin.go:159-160` — `userByEmail` helper.
-- `internal/user/admin.go:37-55` — `AdminChangeEmail`: drop the new-identifier
-  derivation; uniqueness via `ExistsByEmail(newEmail)`; `UpdateEmail(newEmail, now)`.
-- `internal/user/password.go:88,127` — reset/change flows.
-- `internal/user/verify_email.go:47,131` — verification lookups.
+- `internal/user/login.go:24-25`
+- `internal/user/register.go:49-52` — dup-check via `ExistsByEmail`
+- `internal/user/admin.go:158-160` — `userByEmail`
+- `internal/user/admin.go:37-55` — `AdminChangeEmail`: drop new-identifier
+  derivation; uniqueness via `ExistsByEmail(newEmail)`; `UpdateEmail(newEmail, now)`
+- `internal/user/password.go:88,127`
+- `internal/user/verify_email.go:47,131`
 
-**Storage casing:** keep storing the trimmed **original-case** email (preserves the
-`get-user-data` display value). The `lower(email)` expression index owns
-uniqueness, so stored case does not matter for correctness.
+**Storage casing:** keep storing trimmed **original-case** email; the
+`lower(email)` index owns uniqueness.
 
-**`EncodeService.Hash`:** becomes dead code (nothing references it after this
-change) — remove the method and its golden vectors in
-`internal/infra/auth/crypto_golden_test.go`. `Encode`/`Decode` remain (used by
-`data:remove-salt`).
+**`EncodeService.Hash`:** becomes dead code — remove the method and its golden
+vectors (`internal/infra/auth/crypto_golden_test.go`). `Encode`/`Decode` remain.
 
 ### 4. `data:remove-salt` migration (`internal/user/migrate.go`)
 
-Keep the CLI command. Update `MigrateRemoveDataSalt`:
-
-- Drop the `saltFree.Hash(...)` identifier re-derivation.
-- Still decrypt each `email` ciphertext → plaintext (via the salted encoder) and
-  persist with `UpdateEmail(plain, now)`.
-
-Its role — produce plaintext emails — is now precisely what the `lower(email)`
-index depends on.
+Keep the command. Drop the `saltFree.Hash(...)` identifier re-derivation; still
+decrypt each `email` ciphertext → plaintext and persist with
+`UpdateEmail(plain, now)`. The repo writes `id` into the `identifier` column
+automatically on save.
 
 ## Wire contract
 
 Unchanged. `identifier` was never serialized; login/register/reset/verify behavior
-is byte-identical. `apiparity` and `mcpparity` goldens must not change — if they
-do, something regressed.
+is byte-identical. `apiparity` and `mcpparity` goldens must not change.
 
 ## Testing
 
-- Update every identifier-asserting test to email-based lookups:
-  `internal/test/fixture/entities.go:59` (fixture builder),
-  `internal/user/migrate_test.go`, `internal/user/admin_integration_test.go`,
+- Update every identifier-asserting test to email-based lookups /
+  no-Identifier-field:
+  `internal/test/fixture/entities.go:59`, `internal/user/migrate_test.go`,
+  `internal/user/admin_integration_test.go`,
   `internal/user/trial_integration_test.go`,
   `internal/user/avatar_update_integration_test.go`,
   `internal/user/verify_email_test.go`,
   `internal/user/repo/repo_integration_test.go`
-  (`TestUserRepo_GetByIdentifier`/`ExistsByIdentifier` → email variants),
+  (`GetByIdentifier`/`ExistsByIdentifier` → email variants),
   `internal/model/user_test.go`, `internal/model/user_activate_test.go`,
   `internal/infra/auth/crypto_golden_test.go` (drop Hash vectors),
-  `internal/infra/storage/migrations/email_verified_backfill_test.go` (raw
-  `INSERT INTO users (... identifier ...)`).
+  `internal/infra/storage/migrations/email_verified_backfill_test.go`.
 - `make go-test` (smoke: build, vet, gofmt, sqlite unit/integration, apiparity +
   mcpparity goldens unchanged, i18n guards, coverage gate).
-- `make test-repo-pgsql` + the `enginecompare` suite — the expression index and
-  `lower(email)` lookups must behave identically on SQLite and PostgreSQL.
+- `make test-repo-pgsql` + the `enginecompare` suite — `lower(email)` lookups and
+  the expression index must behave identically on SQLite and PostgreSQL.
 
 ## Docs
 
 - CLAUDE.md: the "Wire & data contract" identifier notes, the `data:remove-salt`
-  description, and the "Salt-free everywhere" / user-identifier references.
-- Explanatory comments at `internal/server/server.go:114` and
-  `internal/config/config.go:24`.
-- Upgrade note documenting the `data:remove-salt` prerequisite for salted
-  instances.
+  description, the "Salt-free everywhere" / user-identifier references (note the
+  column is retained as a vestigial `= id` placeholder).
+- `internal/infra/storage/sqlc/sqlc.yaml` comment mentioning the Identifier VO
+  mapping; `internal/server/server.go:114`; `internal/config/config.go:24`.
+- Upgrade note: `data:remove-salt` prerequisite for salted instances.
 
-## Accepted edge
+## Accepted edges
 
-Non-ASCII email casing: Go's Unicode `strings.ToLower` (old identifier input) vs
-SQL `lower()` (ASCII in SQLite) can differ for non-ASCII local parts. Emails are
-ASCII in practice — accepted.
+- The `identifier` column is retained (vestigial, `= id`) rather than dropped, to
+  avoid a SQLite table rebuild. A future dedicated migration can drop it if ever
+  desired.
+- Non-ASCII email casing: Go's Unicode `strings.ToLower` (old identifier input) vs
+  SQL `lower()` (ASCII in SQLite) can differ for non-ASCII local parts. Emails are
+  ASCII in practice — accepted.
 
 ## Follow-on: change-email (separate spec)
 
-Once this ships, the change-email feature simplifies: its pending-change table
-needs no `new_identifier` column, and request/confirm uniqueness is a plain
-`ExistsByEmail` check.
+Once this ships, the change-email feature simplifies: request/confirm uniqueness
+is a plain `ExistsByEmail` check and no identifier derivation is involved.

--- a/docs/superpowers/specs/2026-07-22-remove-user-identifier-design.md
+++ b/docs/superpowers/specs/2026-07-22-remove-user-identifier-design.md
@@ -1,0 +1,171 @@
+# Remove the `users.identifier` column
+
+**Date:** 2026-07-22
+**Status:** Approved (design)
+**Follow-on:** enables the simplified "change email" feature (separate spec).
+
+## Problem
+
+The `users` table carries an `identifier` column — `hex(md5(lower(email)))` — that
+serves as the unique constraint and the primary lookup key for authentication
+(login, register dup-check, password reset, email verification, admin
+change-email).
+
+That column only exists because emails *used to* be AES-encrypted with a random
+IV, so the ciphertext was neither uniquely indexable nor directly searchable. The
+deterministic `identifier` hash was the stand-in.
+
+The app now runs **salt-free with plaintext emails** (`ECONUMO_DATA_SALT` is
+deprecated/ignored; `data:remove-salt` decrypts existing data to plaintext). With
+plaintext emails, a unique index on `lower(email)` plus direct email lookups fully
+replace `identifier`. The column is redundant.
+
+## Goal
+
+Delete `users.identifier`. Make `lower(email)` the unique + lookup key. Keep the
+observable wire contract byte-identical.
+
+Non-goals: the change-email feature itself (separate spec), any change to email
+encryption/`Encode`/`Decode`, any change to how other tables reference `users.id`.
+
+## Key facts (from codebase investigation)
+
+- `identifier` is **never on the wire**: no `json:"identifier"` tag exists in any
+  DTO/response; `model.User.Identifier` has no JSON tag. So REST/MCP goldens
+  (`apiparity`, `mcpparity`) must not change.
+- `identifier` is **not a foreign-key target**: every FK to users targets
+  `users(id)`. `identifier` is only a standalone `UNIQUE` column/index on `users`.
+- Only **two repo methods** read it: `GetByIdentifier`, `ExistsByIdentifier`
+  (`internal/user/repo/repo.go:123,134`). All other use is the
+  `s.encode.Hash(lower(email))` derivation at the call sites below.
+- The stored `email` column holds ciphertext/plaintext of the **original-case**
+  (trimmed) email. Lowercasing happens today only at the `Hash` call sites, never
+  before storage. Therefore the replacement uniqueness must be an **expression
+  index on `lower(email)`**, not a plain unique index on the column.
+- Expression indexes are supported by both engines (SQLite ≥ 3.9, PostgreSQL).
+
+## Design
+
+### 1. Schema migration (new dated file, both engines)
+
+Append-only — do **not** edit historical migrations (they have run in production;
+new installs replay old→new in order).
+
+For `internal/infra/storage/migrations/{sqlite,pgsql}`:
+
+1. `CREATE UNIQUE INDEX <name> ON users (lower(email));`
+2. Drop the identifier unique index (`UNIQ_1483A5E9772E836A`) / `UNIQUE (identifier)`
+   constraint and the `identifier` column.
+
+**Migration-ordering caveat (must be documented in the upgrade note / CLAUDE.md):**
+the `lower(email)` scheme requires *plaintext* emails. An instance still holding
+salted/encrypted emails is *already* login-broken by design (mismatched
+identifiers), so this is no regression — but such an instance must run
+`data:remove-salt` to log in after upgrading. The boot migration itself does not
+depend on the salt state (it does not read `identifier`).
+
+### 2. Queries / repository (regenerate sqlc)
+
+`internal/infra/storage/sqlc/query/{sqlite,pgsql}/users.sql`:
+
+- `GetUserByIdentifier` → `GetUserByEmail` — `WHERE lower(email) = lower(?)`
+  (`$1` for pgsql).
+- `ExistsUserByIdentifier` → `ExistsUserByEmail` — same predicate.
+- Remove `identifier` from `CreateUser` and `SyncUser` (insert columns + upsert
+  `identifier = excluded.identifier` clause).
+- Regenerate `sqlc/gen/{sqlite,pgsql}` + `querier.go`.
+
+`internal/user/repo/`:
+
+- `repo.go`: `GetByIdentifier`/`ExistsByIdentifier` → `GetByEmail(ctx, email)` /
+  `ExistsByEmail(ctx, email)`; drop `Identifier` from `Save` params and `toModel`
+  scan; drop the field from the row struct.
+- `sqlite.go` / `pgsql.go` adapters: rename to `GetUserByEmail` /
+  `ExistsUserByEmail`; interface in `repo.go` updated.
+- `internal/user/repository.go`: interface method rename.
+
+### 3. Service / model
+
+`internal/model/user.go`:
+
+- Remove the `Identifier` field.
+- `NewUser(...)` loses the `identifier` argument.
+- `UpdateEmail(email, now)` loses the `identifier` argument (was
+  `UpdateEmail(identifier, encryptedEmail, now)`).
+
+Service call sites — replace `s.encode.Hash(lower(email))` + `GetByIdentifier`
+with `GetByEmail(email)` (the query lowercases; pass the raw trimmed email):
+
+- `internal/user/login.go:24-25` — primary auth lookup.
+- `internal/user/register.go:50-52` — dup-check via `ExistsByEmail`.
+- `internal/user/admin.go:159-160` — `userByEmail` helper.
+- `internal/user/admin.go:37-55` — `AdminChangeEmail`: drop the new-identifier
+  derivation; uniqueness via `ExistsByEmail(newEmail)`; `UpdateEmail(newEmail, now)`.
+- `internal/user/password.go:88,127` — reset/change flows.
+- `internal/user/verify_email.go:47,131` — verification lookups.
+
+**Storage casing:** keep storing the trimmed **original-case** email (preserves the
+`get-user-data` display value). The `lower(email)` expression index owns
+uniqueness, so stored case does not matter for correctness.
+
+**`EncodeService.Hash`:** becomes dead code (nothing references it after this
+change) — remove the method and its golden vectors in
+`internal/infra/auth/crypto_golden_test.go`. `Encode`/`Decode` remain (used by
+`data:remove-salt`).
+
+### 4. `data:remove-salt` migration (`internal/user/migrate.go`)
+
+Keep the CLI command. Update `MigrateRemoveDataSalt`:
+
+- Drop the `saltFree.Hash(...)` identifier re-derivation.
+- Still decrypt each `email` ciphertext → plaintext (via the salted encoder) and
+  persist with `UpdateEmail(plain, now)`.
+
+Its role — produce plaintext emails — is now precisely what the `lower(email)`
+index depends on.
+
+## Wire contract
+
+Unchanged. `identifier` was never serialized; login/register/reset/verify behavior
+is byte-identical. `apiparity` and `mcpparity` goldens must not change — if they
+do, something regressed.
+
+## Testing
+
+- Update every identifier-asserting test to email-based lookups:
+  `internal/test/fixture/entities.go:59` (fixture builder),
+  `internal/user/migrate_test.go`, `internal/user/admin_integration_test.go`,
+  `internal/user/trial_integration_test.go`,
+  `internal/user/avatar_update_integration_test.go`,
+  `internal/user/verify_email_test.go`,
+  `internal/user/repo/repo_integration_test.go`
+  (`TestUserRepo_GetByIdentifier`/`ExistsByIdentifier` → email variants),
+  `internal/model/user_test.go`, `internal/model/user_activate_test.go`,
+  `internal/infra/auth/crypto_golden_test.go` (drop Hash vectors),
+  `internal/infra/storage/migrations/email_verified_backfill_test.go` (raw
+  `INSERT INTO users (... identifier ...)`).
+- `make go-test` (smoke: build, vet, gofmt, sqlite unit/integration, apiparity +
+  mcpparity goldens unchanged, i18n guards, coverage gate).
+- `make test-repo-pgsql` + the `enginecompare` suite — the expression index and
+  `lower(email)` lookups must behave identically on SQLite and PostgreSQL.
+
+## Docs
+
+- CLAUDE.md: the "Wire & data contract" identifier notes, the `data:remove-salt`
+  description, and the "Salt-free everywhere" / user-identifier references.
+- Explanatory comments at `internal/server/server.go:114` and
+  `internal/config/config.go:24`.
+- Upgrade note documenting the `data:remove-salt` prerequisite for salted
+  instances.
+
+## Accepted edge
+
+Non-ASCII email casing: Go's Unicode `strings.ToLower` (old identifier input) vs
+SQL `lower()` (ASCII in SQLite) can differ for non-ASCII local parts. Emails are
+ASCII in practice — accepted.
+
+## Follow-on: change-email (separate spec)
+
+Once this ships, the change-email feature simplifies: its pending-change table
+needs no `new_identifier` column, and request/confirm uniqueness is a plain
+`ExistsByEmail` check.

--- a/internal/infra/auth/crypto_golden_test.go
+++ b/internal/infra/auth/crypto_golden_test.go
@@ -18,11 +18,6 @@ type vectors struct {
 		Salt     string `json:"salt"`
 		Hash     string `json:"hash"`
 	} `json:"password_hasher"`
-	IdentifierHash []struct {
-		Value string `json:"value"`
-		Salt  string `json:"salt"`
-		Hash  string `json:"hash"`
-	} `json:"identifier_hash"`
 	Encode []struct {
 		Plaintext  string `json:"plaintext"`
 		Salt       string `json:"salt"`
@@ -60,16 +55,6 @@ func TestPasswordHasher_MatchesGoldenVectors(t *testing.T) {
 		}
 		if h.Verify(model.AlgorithmSHA512, tc.Hash, tc.Password+"x", tc.Salt) {
 			t.Errorf("Verify wrongly accepted bad password for %q", tc.Password)
-		}
-	}
-}
-
-func TestIdentifierHash_MatchesGoldenVectors(t *testing.T) {
-	v := loadVectors(t)
-	for _, tc := range v.IdentifierHash {
-		svc := NewEncodeService(tc.Salt)
-		if got := svc.Hash(tc.Value); got != tc.Hash {
-			t.Errorf("Hash(%q) got=%s want=%s", tc.Value, got, tc.Hash)
 		}
 	}
 }

--- a/internal/infra/auth/encode.go
+++ b/internal/infra/auth/encode.go
@@ -1,34 +1,31 @@
-// Package auth implements Econumo's crypto: the EncodeService (identifier
-// hashing + reversible email encryption) and the password hasher. These are
-// wire/data-compatible with existing accounts (see CLAUDE.md), locked
-// down by golden vectors in *_test.go.
+// Package auth implements Econumo's crypto: the EncodeService (reversible
+// email encryption) and the password hasher. These are wire/data-compatible
+// with existing accounts (see CLAUDE.md), locked down by golden vectors in
+// *_test.go.
 package auth
 
 import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"io"
 )
 
-// EncodeService hashes identifiers and reversibly encrypts emails.
+// EncodeService reversibly encrypts emails.
 //
 // AES-128-CBC takes a 16-byte key, but the raw ECONUMO_DATA_SALT may be any
 // length. To stay wire-compatible with already-stored emails, an over-long salt
 // is truncated to its first 16 bytes for the AES key and a short one is
-// zero-padded to 16, while the HMAC key and the md5 identifier deliberately use
-// the FULL salt. This asymmetry is part of the frozen data format: existing rows
-// were written this way, so deployments whose salt is not exactly 16 bytes must
-// keep decrypting.
+// zero-padded to 16, while the HMAC key deliberately uses the FULL salt. This
+// asymmetry is part of the frozen data format: existing rows were written this
+// way, so deployments whose salt is not exactly 16 bytes must keep decrypting.
 type EncodeService struct {
-	salt   []byte // full salt: HMAC key + md5 identifier salt
+	salt   []byte // full salt: the HMAC key
 	aesKey []byte // salt coerced to 16 bytes: the AES-128 key
 }
 
@@ -48,14 +45,6 @@ func coerceAESKey(salt []byte) []byte {
 	key := make([]byte, 16)
 	copy(key, salt) // copies min(16, len(salt)) bytes; remainder stays zero
 	return key
-}
-
-// Hash returns hex(md5(value + salt)) — the CHAR(32) user identifier.
-// Callers must lowercase the email before hashing; this method does not
-// lowercase.
-func (e *EncodeService) Hash(value string) string {
-	sum := md5.Sum(append([]byte(value), e.salt...))
-	return hex.EncodeToString(sum[:])
 }
 
 // Encode encrypts value with AES-128-CBC and returns

--- a/internal/infra/auth/testdata/vectors.json
+++ b/internal/infra/auth/testdata/vectors.json
@@ -21,23 +21,6 @@
             "hash": "PfEn1epTOxO3cR0oKGJ3g5Mbr0IbGOTIvHU7telWSpQ3D9lM8SfZpFOHMnHa0qyEVkHnmJedTWdrL+psOb15NQ=="
         }
     ],
-    "identifier_hash": [
-        {
-            "value": "john@example.com",
-            "salt": "0123456789abcdef",
-            "hash": "8ab901f184b70008d318983a58fcabc4"
-        },
-        {
-            "value": "john@example.com",
-            "salt": "0123456789abcdef",
-            "hash": "8ab901f184b70008d318983a58fcabc4"
-        },
-        {
-            "value": "тест@пример.рф",
-            "salt": "0123456789abcdef",
-            "hash": "bede302cbf0ba4144be2e7c2e3ccac15"
-        }
-    ],
     "encode": [
         {
             "plaintext": "john@example.com",

--- a/internal/infra/storage/migrations/email_verified_backfill_test.go
+++ b/internal/infra/storage/migrations/email_verified_backfill_test.go
@@ -41,7 +41,10 @@ func TestEmailVerifiedBackfillAndDefault(t *testing.T) {
 	if err := migrate.Run(ctx, db, before); err != nil {
 		t.Fatalf("pre-migrate: %v", err)
 	}
-	if _, err := db.ExecContext(ctx, `INSERT INTO users (id, identifier, email, name, avatar, password, salt, created_at, updated_at) VALUES ('u1','ident1','e','n','a','p','s','2020-01-01 00:00:00','2020-01-01 00:00:00')`); err != nil {
+	// identifier is set to the row's own id (any unique non-null value satisfies
+	// the column's legacy NOT NULL UNIQUE constraint); email must also be unique
+	// since a later migration in this run adds a unique index on lower(email).
+	if _, err := db.ExecContext(ctx, `INSERT INTO users (id, identifier, email, name, avatar, password, salt, created_at, updated_at) VALUES ('u1','u1','e1','n','a','p','s','2020-01-01 00:00:00','2020-01-01 00:00:00')`); err != nil {
 		t.Fatalf("seed legacy user: %v", err)
 	}
 
@@ -60,7 +63,7 @@ func TestEmailVerifiedBackfillAndDefault(t *testing.T) {
 	}
 
 	// A raw insert omitting email_verified must default to false (fail closed).
-	if _, err := db.ExecContext(ctx, `INSERT INTO users (id, identifier, email, name, avatar, password, salt, created_at, updated_at) VALUES ('u2','ident2','e','n','a','p','s','2026-01-01 00:00:00','2026-01-01 00:00:00')`); err != nil {
+	if _, err := db.ExecContext(ctx, `INSERT INTO users (id, identifier, email, name, avatar, password, salt, created_at, updated_at) VALUES ('u2','u2','e2','n','a','p','s','2026-01-01 00:00:00','2026-01-01 00:00:00')`); err != nil {
 		t.Fatalf("insert new user: %v", err)
 	}
 	var fresh bool

--- a/internal/infra/storage/migrations/pgsql/20260722000000.sql
+++ b/internal/infra/storage/migrations/pgsql/20260722000000.sql
@@ -1,0 +1,10 @@
+-- The email-derived md5 identifier is retired: lower(email) is now the unique
+-- key (index below), and the identifier column is kept only to satisfy its
+-- pre-existing NOT NULL UNIQUE constraint without a SQLite table rebuild. Each
+-- row's own id is a ready-made unique, non-null placeholder, but the column is
+-- still the legacy CHAR(32) sized for an md5 hex digest -- too narrow for a
+-- 36-char UUID string -- so it is widened first (sqlite's identifier column
+-- was already widened to unconstrained TEXT by an earlier baseline squash).
+ALTER TABLE users ALTER COLUMN identifier TYPE TEXT;
+CREATE UNIQUE INDEX users_email_lower_uniq ON users (lower(email));
+UPDATE users SET identifier = id;

--- a/internal/infra/storage/migrations/sqlite/20260722000000.sql
+++ b/internal/infra/storage/migrations/sqlite/20260722000000.sql
@@ -1,0 +1,6 @@
+-- The email-derived md5 identifier is retired: lower(email) is now the unique
+-- key (index below), and the identifier column is kept only to satisfy its
+-- pre-existing NOT NULL UNIQUE constraint without a SQLite table rebuild. Each
+-- row's own id is a ready-made unique, non-null placeholder.
+CREATE UNIQUE INDEX users_email_lower_uniq ON users (lower(email));
+UPDATE users SET identifier = id;

--- a/internal/infra/storage/sqlc/gen/pgsql/querier.go
+++ b/internal/infra/storage/sqlc/gen/pgsql/querier.go
@@ -42,6 +42,7 @@ type Querier interface {
 	// Password-reset request queries (users_password_requests). See the sqlite
 	// sibling for the flow; expiry is compared in the app layer, not SQL.
 	DeleteUserPasswordRequestsByUser(ctx context.Context, userID string) error
+	ExistsUserByEmail(ctx context.Context, lower string) (bool, error)
 	ExistsUserByIdentifier(ctx context.Context, identifier string) (bool, error)
 	// Joins users for access_level/access_until; see the sqlite sibling for why.
 	GetAccessTokenByHash(ctx context.Context, tokenHash string) (GetAccessTokenByHashRow, error)
@@ -112,6 +113,7 @@ type Querier interface {
 	// Write + read queries for the transaction module (PostgreSQL: $N placeholders).
 	// See the sqlite variant for documentation.
 	GetTransactionByID(ctx context.Context, id string) (GetTransactionByIDRow, error)
+	GetUserByEmail(ctx context.Context, lower string) (GetUserByEmailRow, error)
 	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
 	GetUserByIdentifier(ctx context.Context, identifier string) (GetUserByIdentifierRow, error)
 	GetUserEmailVerificationByUser(ctx context.Context, userID string) (UsersEmailVerification, error)

--- a/internal/infra/storage/sqlc/gen/pgsql/querier.go
+++ b/internal/infra/storage/sqlc/gen/pgsql/querier.go
@@ -43,7 +43,6 @@ type Querier interface {
 	// sibling for the flow; expiry is compared in the app layer, not SQL.
 	DeleteUserPasswordRequestsByUser(ctx context.Context, userID string) error
 	ExistsUserByEmail(ctx context.Context, lower string) (bool, error)
-	ExistsUserByIdentifier(ctx context.Context, identifier string) (bool, error)
 	// Joins users for access_level/access_until; see the sqlite sibling for why.
 	GetAccessTokenByHash(ctx context.Context, tokenHash string) (GetAccessTokenByHashRow, error)
 	GetAccessTokenByID(ctx context.Context, id string) (AccessToken, error)
@@ -115,7 +114,6 @@ type Querier interface {
 	GetTransactionByID(ctx context.Context, id string) (GetTransactionByIDRow, error)
 	GetUserByEmail(ctx context.Context, lower string) (GetUserByEmailRow, error)
 	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
-	GetUserByIdentifier(ctx context.Context, identifier string) (GetUserByIdentifierRow, error)
 	GetUserEmailVerificationByUser(ctx context.Context, userID string) (UsersEmailVerification, error)
 	GetUserLanguage(ctx context.Context, id string) (string, error)
 	// Tiebreak by id so the order is deterministic and identical across engines even

--- a/internal/infra/storage/sqlc/gen/pgsql/users.sql.go
+++ b/internal/infra/storage/sqlc/gen/pgsql/users.sql.go
@@ -10,6 +10,17 @@ import (
 	"time"
 )
 
+const existsUserByEmail = `-- name: ExistsUserByEmail :one
+SELECT EXISTS(SELECT 1 FROM users WHERE lower(email) = lower($1))
+`
+
+func (q *Queries) ExistsUserByEmail(ctx context.Context, lower string) (bool, error) {
+	row := q.db.QueryRowContext(ctx, existsUserByEmail, lower)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const existsUserByIdentifier = `-- name: ExistsUserByIdentifier :one
 SELECT EXISTS(SELECT 1 FROM users WHERE identifier = $1)
 `
@@ -19,6 +30,53 @@ func (q *Queries) ExistsUserByIdentifier(ctx context.Context, identifier string)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
+}
+
+const getUserByEmail = `-- name: GetUserByEmail :one
+SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+FROM users
+WHERE lower(email) = lower($1)
+`
+
+type GetUserByEmailRow struct {
+	ID            string
+	Identifier    string
+	Email         string
+	Name          string
+	Avatar        string
+	Password      string
+	Salt          string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	IsActive      bool
+	Algorithm     string
+	AccessLevel   string
+	AccessUntil   *time.Time
+	Timezone      string
+	EmailVerified bool
+}
+
+func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEmailRow, error) {
+	row := q.db.QueryRowContext(ctx, getUserByEmail, lower)
+	var i GetUserByEmailRow
+	err := row.Scan(
+		&i.ID,
+		&i.Identifier,
+		&i.Email,
+		&i.Name,
+		&i.Avatar,
+		&i.Password,
+		&i.Salt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.IsActive,
+		&i.Algorithm,
+		&i.AccessLevel,
+		&i.AccessUntil,
+		&i.Timezone,
+		&i.EmailVerified,
+	)
+	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one

--- a/internal/infra/storage/sqlc/gen/pgsql/users.sql.go
+++ b/internal/infra/storage/sqlc/gen/pgsql/users.sql.go
@@ -21,26 +21,14 @@ func (q *Queries) ExistsUserByEmail(ctx context.Context, lower string) (bool, er
 	return exists, err
 }
 
-const existsUserByIdentifier = `-- name: ExistsUserByIdentifier :one
-SELECT EXISTS(SELECT 1 FROM users WHERE identifier = $1)
-`
-
-func (q *Queries) ExistsUserByIdentifier(ctx context.Context, identifier string) (bool, error) {
-	row := q.db.QueryRowContext(ctx, existsUserByIdentifier, identifier)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
-}
-
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE lower(email) = lower($1)
 `
 
 type GetUserByEmailRow struct {
 	ID            string
-	Identifier    string
 	Email         string
 	Name          string
 	Avatar        string
@@ -61,7 +49,6 @@ func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEm
 	var i GetUserByEmailRow
 	err := row.Scan(
 		&i.ID,
-		&i.Identifier,
 		&i.Email,
 		&i.Name,
 		&i.Avatar,
@@ -80,14 +67,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEm
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE id = $1
 `
 
 type GetUserByIDRow struct {
 	ID            string
-	Identifier    string
 	Email         string
 	Name          string
 	Avatar        string
@@ -108,54 +94,6 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 	var i GetUserByIDRow
 	err := row.Scan(
 		&i.ID,
-		&i.Identifier,
-		&i.Email,
-		&i.Name,
-		&i.Avatar,
-		&i.Password,
-		&i.Salt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.IsActive,
-		&i.Algorithm,
-		&i.AccessLevel,
-		&i.AccessUntil,
-		&i.Timezone,
-		&i.EmailVerified,
-	)
-	return i, err
-}
-
-const getUserByIdentifier = `-- name: GetUserByIdentifier :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
-FROM users
-WHERE identifier = $1
-`
-
-type GetUserByIdentifierRow struct {
-	ID            string
-	Identifier    string
-	Email         string
-	Name          string
-	Avatar        string
-	Password      string
-	Salt          string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	IsActive      bool
-	Algorithm     string
-	AccessLevel   string
-	AccessUntil   *time.Time
-	Timezone      string
-	EmailVerified bool
-}
-
-func (q *Queries) GetUserByIdentifier(ctx context.Context, identifier string) (GetUserByIdentifierRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByIdentifier, identifier)
-	var i GetUserByIdentifierRow
-	err := row.Scan(
-		&i.ID,
-		&i.Identifier,
 		&i.Email,
 		&i.Name,
 		&i.Avatar,

--- a/internal/infra/storage/sqlc/gen/sqlite/querier.go
+++ b/internal/infra/storage/sqlc/gen/sqlite/querier.go
@@ -58,7 +58,6 @@ type Querier interface {
 	// engine date-format differences.
 	DeleteUserPasswordRequestsByUser(ctx context.Context, userID string) error
 	ExistsUserByEmail(ctx context.Context, lower string) (int64, error)
-	ExistsUserByIdentifier(ctx context.Context, identifier string) (int64, error)
 	// Joins users for access_level/access_until so per-request auth can report
 	// the caller's effective access level in the same round trip. This does NOT
 	// reuse the is_active shortcut (see GetAccessTokenByHash's Go caller): a
@@ -199,7 +198,6 @@ type Querier interface {
 	GetTransactionByID(ctx context.Context, id string) (Transaction, error)
 	GetUserByEmail(ctx context.Context, lower string) (GetUserByEmailRow, error)
 	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
-	GetUserByIdentifier(ctx context.Context, identifier string) (GetUserByIdentifierRow, error)
 	GetUserEmailVerificationByUser(ctx context.Context, userID string) (UsersEmailVerification, error)
 	GetUserLanguage(ctx context.Context, id string) (string, error)
 	// Tiebreak by id so the order is deterministic and identical across engines even

--- a/internal/infra/storage/sqlc/gen/sqlite/querier.go
+++ b/internal/infra/storage/sqlc/gen/sqlite/querier.go
@@ -57,6 +57,7 @@ type Querier interface {
 	// it. Expiry is compared in the app layer (Go time.Time), not in SQL, to avoid
 	// engine date-format differences.
 	DeleteUserPasswordRequestsByUser(ctx context.Context, userID string) error
+	ExistsUserByEmail(ctx context.Context, lower string) (int64, error)
 	ExistsUserByIdentifier(ctx context.Context, identifier string) (int64, error)
 	// Joins users for access_level/access_until so per-request auth can report
 	// the caller's effective access level in the same round trip. This does NOT
@@ -196,6 +197,7 @@ type Querier interface {
 	// category/payee/tag (non-transfers). Listing filters by account id sets the
 	// app layer computes (excluding deleted/hidden-folder accounts).
 	GetTransactionByID(ctx context.Context, id string) (Transaction, error)
+	GetUserByEmail(ctx context.Context, lower string) (GetUserByEmailRow, error)
 	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
 	GetUserByIdentifier(ctx context.Context, identifier string) (GetUserByIdentifierRow, error)
 	GetUserEmailVerificationByUser(ctx context.Context, userID string) (UsersEmailVerification, error)

--- a/internal/infra/storage/sqlc/gen/sqlite/users.sql.go
+++ b/internal/infra/storage/sqlc/gen/sqlite/users.sql.go
@@ -10,6 +10,17 @@ import (
 	"time"
 )
 
+const existsUserByEmail = `-- name: ExistsUserByEmail :one
+SELECT EXISTS(SELECT 1 FROM users WHERE lower(email) = lower(?))
+`
+
+func (q *Queries) ExistsUserByEmail(ctx context.Context, lower string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, existsUserByEmail, lower)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const existsUserByIdentifier = `-- name: ExistsUserByIdentifier :one
 SELECT EXISTS(SELECT 1 FROM users WHERE identifier = ?)
 `
@@ -19,6 +30,53 @@ func (q *Queries) ExistsUserByIdentifier(ctx context.Context, identifier string)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
+}
+
+const getUserByEmail = `-- name: GetUserByEmail :one
+SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+FROM users
+WHERE lower(email) = lower(?)
+`
+
+type GetUserByEmailRow struct {
+	ID            string
+	Identifier    string
+	Email         string
+	Name          string
+	Avatar        string
+	Password      string
+	Salt          string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	IsActive      bool
+	Algorithm     string
+	AccessLevel   string
+	AccessUntil   *time.Time
+	Timezone      string
+	EmailVerified bool
+}
+
+func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEmailRow, error) {
+	row := q.db.QueryRowContext(ctx, getUserByEmail, lower)
+	var i GetUserByEmailRow
+	err := row.Scan(
+		&i.ID,
+		&i.Identifier,
+		&i.Email,
+		&i.Name,
+		&i.Avatar,
+		&i.Password,
+		&i.Salt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.IsActive,
+		&i.Algorithm,
+		&i.AccessLevel,
+		&i.AccessUntil,
+		&i.Timezone,
+		&i.EmailVerified,
+	)
+	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one

--- a/internal/infra/storage/sqlc/gen/sqlite/users.sql.go
+++ b/internal/infra/storage/sqlc/gen/sqlite/users.sql.go
@@ -21,26 +21,14 @@ func (q *Queries) ExistsUserByEmail(ctx context.Context, lower string) (int64, e
 	return column_1, err
 }
 
-const existsUserByIdentifier = `-- name: ExistsUserByIdentifier :one
-SELECT EXISTS(SELECT 1 FROM users WHERE identifier = ?)
-`
-
-func (q *Queries) ExistsUserByIdentifier(ctx context.Context, identifier string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, existsUserByIdentifier, identifier)
-	var column_1 int64
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE lower(email) = lower(?)
 `
 
 type GetUserByEmailRow struct {
 	ID            string
-	Identifier    string
 	Email         string
 	Name          string
 	Avatar        string
@@ -61,7 +49,6 @@ func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEm
 	var i GetUserByEmailRow
 	err := row.Scan(
 		&i.ID,
-		&i.Identifier,
 		&i.Email,
 		&i.Name,
 		&i.Avatar,
@@ -80,14 +67,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEm
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE id = ?
 `
 
 type GetUserByIDRow struct {
 	ID            string
-	Identifier    string
 	Email         string
 	Name          string
 	Avatar        string
@@ -108,54 +94,6 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 	var i GetUserByIDRow
 	err := row.Scan(
 		&i.ID,
-		&i.Identifier,
-		&i.Email,
-		&i.Name,
-		&i.Avatar,
-		&i.Password,
-		&i.Salt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.IsActive,
-		&i.Algorithm,
-		&i.AccessLevel,
-		&i.AccessUntil,
-		&i.Timezone,
-		&i.EmailVerified,
-	)
-	return i, err
-}
-
-const getUserByIdentifier = `-- name: GetUserByIdentifier :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
-FROM users
-WHERE identifier = ?
-`
-
-type GetUserByIdentifierRow struct {
-	ID            string
-	Identifier    string
-	Email         string
-	Name          string
-	Avatar        string
-	Password      string
-	Salt          string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	IsActive      bool
-	Algorithm     string
-	AccessLevel   string
-	AccessUntil   *time.Time
-	Timezone      string
-	EmailVerified bool
-}
-
-func (q *Queries) GetUserByIdentifier(ctx context.Context, identifier string) (GetUserByIdentifierRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByIdentifier, identifier)
-	var i GetUserByIdentifierRow
-	err := row.Scan(
-		&i.ID,
-		&i.Identifier,
 		&i.Email,
 		&i.Name,
 		&i.Avatar,

--- a/internal/infra/storage/sqlc/query/pgsql/users.sql
+++ b/internal/infra/storage/sqlc/query/pgsql/users.sql
@@ -1,15 +1,7 @@
 -- name: GetUserByID :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE id = $1;
-
--- name: GetUserByIdentifier :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
-FROM users
-WHERE identifier = $1;
-
--- name: ExistsUserByIdentifier :one
-SELECT EXISTS(SELECT 1 FROM users WHERE identifier = $1);
 
 -- name: ListUserIDs :many
 SELECT id FROM users;
@@ -48,7 +40,7 @@ UPDATE users SET timezone = $1 WHERE id = $2;
 SELECT language FROM users WHERE id = $1;
 
 -- name: GetUserByEmail :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE lower(email) = lower($1);
 

--- a/internal/infra/storage/sqlc/query/pgsql/users.sql
+++ b/internal/infra/storage/sqlc/query/pgsql/users.sql
@@ -46,3 +46,11 @@ UPDATE users SET timezone = $1 WHERE id = $2;
 
 -- name: GetUserLanguage :one
 SELECT language FROM users WHERE id = $1;
+
+-- name: GetUserByEmail :one
+SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+FROM users
+WHERE lower(email) = lower($1);
+
+-- name: ExistsUserByEmail :one
+SELECT EXISTS(SELECT 1 FROM users WHERE lower(email) = lower($1));

--- a/internal/infra/storage/sqlc/query/sqlite/users.sql
+++ b/internal/infra/storage/sqlc/query/sqlite/users.sql
@@ -46,3 +46,11 @@ UPDATE users SET timezone = ? WHERE id = ?;
 
 -- name: GetUserLanguage :one
 SELECT language FROM users WHERE id = ?;
+
+-- name: GetUserByEmail :one
+SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+FROM users
+WHERE lower(email) = lower(?);
+
+-- name: ExistsUserByEmail :one
+SELECT EXISTS(SELECT 1 FROM users WHERE lower(email) = lower(?));

--- a/internal/infra/storage/sqlc/query/sqlite/users.sql
+++ b/internal/infra/storage/sqlc/query/sqlite/users.sql
@@ -1,15 +1,7 @@
 -- name: GetUserByID :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE id = ?;
-
--- name: GetUserByIdentifier :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
-FROM users
-WHERE identifier = ?;
-
--- name: ExistsUserByIdentifier :one
-SELECT EXISTS(SELECT 1 FROM users WHERE identifier = ?);
 
 -- name: ListUserIDs :many
 SELECT id FROM users;
@@ -48,7 +40,7 @@ UPDATE users SET timezone = ? WHERE id = ?;
 SELECT language FROM users WHERE id = ?;
 
 -- name: GetUserByEmail :one
-SELECT id, identifier, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
+SELECT id, email, name, avatar, password, salt, created_at, updated_at, is_active, algorithm, access_level, access_until, timezone, email_verified
 FROM users
 WHERE lower(email) = lower(?);
 

--- a/internal/infra/storage/sqlc/sqlc.yaml
+++ b/internal/infra/storage/sqlc/sqlc.yaml
@@ -13,7 +13,7 @@
 #
 # Type overrides keep the generated Go primitive-friendly: UUID / CHAR(36)
 # columns surface as plain string, and NUMERIC(19,8) money columns surface as
-# string. The repo layer adapts string <-> domain value objects (Id, Identifier)
+# string. The repo layer adapts string <-> domain value objects (Id)
 # and string <-> shopspring/decimal at scale 8, matching PHP bcmath exactly.
 version: "2"
 sql:

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -93,13 +93,12 @@ type Header struct {
 }
 
 // User is the user aggregate root. Strings that are encrypted at rest (Email)
-// or hashed (Password, Identifier) are stored opaquely here; the service layer
+// or hashed (Password) are stored opaquely here; the service layer
 // applies/reverses the crypto. The aggregate owns its Options. Fields are
 // exported for direct read access; all writes after construction go through the
 // mutators.
 type User struct {
 	ID            vo.Id
-	Identifier    string // md5(lower(email)+salt) — the auth lookup key
 	Email         string // AES-encrypted ciphertext (opaque here)
 	Name          string
 	Avatar        string
@@ -116,12 +115,11 @@ type User struct {
 }
 
 // NewUser constructs a freshly-registered user. The caller (the service) has
-// already computed identifier, encrypted email, avatar value, password hash and
-// salt. Options are seeded separately via SeedDefaultOptions.
-func NewUser(id vo.Id, identifier, encryptedEmail, name, avatar, passwordHash, salt string, now time.Time) *User {
+// already encrypted the email, picked the avatar, and hashed the password.
+// Options are seeded separately via SeedDefaultOptions.
+func NewUser(id vo.Id, encryptedEmail, name, avatar, passwordHash, salt string, now time.Time) *User {
 	return &User{
 		ID:            id,
-		Identifier:    identifier,
 		Email:         encryptedEmail,
 		Name:          name,
 		Avatar:        avatar,
@@ -216,10 +214,9 @@ func (u *User) UpdatePassword(passwordHash, algorithm string, now time.Time) {
 	u.UpdatedAt = now
 }
 
-// UpdateEmail replaces the encrypted email and identifier together, both
-// derived by the service.
-func (u *User) UpdateEmail(identifier, encryptedEmail string, now time.Time) {
-	u.Identifier = identifier
+// UpdateEmail replaces the encrypted email. The identifier column is derived
+// from the row id at persistence time, so it needs no update here.
+func (u *User) UpdateEmail(encryptedEmail string, now time.Time) {
 	u.Email = encryptedEmail
 	u.UpdatedAt = now
 }

--- a/internal/model/user_access_test.go
+++ b/internal/model/user_access_test.go
@@ -67,7 +67,7 @@ func TestSetAccessBumpsUpdatedAt(t *testing.T) {
 
 func TestNewUserDefaultsToFullAccess(t *testing.T) {
 	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
-	u := NewUser(vo.NewId(), "ident", "email", "Name", "face:sky", "hash", "salt", now)
+	u := NewUser(vo.NewId(), "email", "Name", "face:sky", "hash", "salt", now)
 	if u.AccessLevel != AccessLevelFull {
 		t.Fatalf("level: got %q want full", u.AccessLevel)
 	}

--- a/internal/model/user_activate_test.go
+++ b/internal/model/user_activate_test.go
@@ -15,7 +15,7 @@ func TestUserActivateDeactivate(t *testing.T) {
 	t2 := t0.Add(2 * time.Hour)
 	t3 := t0.Add(3 * time.Hour)
 
-	u := &User{ID: vo.NewId(), Identifier: "ident", Email: "enc-email", Name: "Name", Avatar: "avatar",
+	u := &User{ID: vo.NewId(), Email: "enc-email", Name: "Name", Avatar: "avatar",
 		Password: "pwhash", Salt: "salt", IsActive: true, CreatedAt: t0, UpdatedAt: t0}
 
 	// Already active: Activate is a no-op (updatedAt unchanged).

--- a/internal/model/user_test.go
+++ b/internal/model/user_test.go
@@ -39,7 +39,7 @@ func seqIDs(t *testing.T, uuids ...string) func() vo.Id {
 func newUser(t *testing.T) *User {
 	return NewUser(
 		mustID(t, "11111111-1111-1111-1111-111111111111"),
-		"identifier-md5", "encrypted-email", "Alice", "https://avatar/x",
+		"encrypted-email", "Alice", "https://avatar/x",
 		"password-hash", "salt-hex", tu0)
 }
 
@@ -57,9 +57,6 @@ func seeded(t *testing.T) *User {
 
 func TestNewUser_Getters(t *testing.T) {
 	u := newUser(t)
-	if u.Identifier != "identifier-md5" {
-		t.Errorf("Identifier()=%q", u.Identifier)
-	}
 	if u.Email != "encrypted-email" {
 		t.Errorf("Email()=%q", u.Email)
 	}
@@ -89,7 +86,7 @@ func TestNewUser_Getters(t *testing.T) {
 func TestUser_StructLiteral_RoundTrip(t *testing.T) {
 	id := mustID(t, "11111111-1111-1111-1111-111111111111")
 	opt := NewUserOption(mustID(t, "aaaaaaaa-0000-0000-0000-000000000001"), OptionBudget, strPtr("b-1"), tu0)
-	u := &User{ID: id, Identifier: "ident", Email: "email", Name: "Bob", Avatar: "avatar", Password: "pw",
+	u := &User{ID: id, Email: "email", Name: "Bob", Avatar: "avatar", Password: "pw",
 		Salt: "salt", IsActive: false, CreatedAt: tu0, UpdatedAt: tu1, Options: []UserOption{opt}}
 	if !u.ID.Equal(id) || u.Name != "Bob" || u.IsActive {
 		t.Fatal("scalar fields did not round-trip")
@@ -186,9 +183,9 @@ func TestUser_UpdatePassword(t *testing.T) {
 func TestUser_UpdateEmail(t *testing.T) {
 	u := newUser(t)
 	avatarBefore := u.Avatar
-	u.UpdateEmail("new-ident", "new-cipher", tu1)
-	if u.Identifier != "new-ident" || u.Email != "new-cipher" {
-		t.Fatalf("UpdateEmail fields: %q / %q", u.Identifier, u.Email)
+	u.UpdateEmail("new-cipher", tu1)
+	if u.Email != "new-cipher" {
+		t.Fatalf("UpdateEmail email: %q", u.Email)
 	}
 	if u.Avatar != avatarBefore {
 		t.Errorf("UpdateEmail must not change Avatar: got %q want %q", u.Avatar, avatarBefore)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -111,7 +111,7 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 	txm := backend.NewTxManager(db)
 
 	// The API ignores ECONUMO_DATA_SALT: it always runs salt-free (plaintext email,
-	// md5(lower(email)) identifier). The salt is consumed only by the data:remove-salt
+	// looked up by lower(email)). The salt is consumed only by the data:remove-salt
 	// migration, so a still-salted database must be migrated before its users can log in.
 	encodeSvc := auth.NewEncodeService("")
 	hasher := auth.NewPasswordHasher()

--- a/internal/test/fixture/entities.go
+++ b/internal/test/fixture/entities.go
@@ -16,9 +16,9 @@ func NewID() string { return vo.NewId().Value() }
 const USD = "dffc2a06-6f29-4704-8575-31709adee926"
 
 // User describes a user row. Zero fields take defaults: a fresh id, a derived
-// email/name, active=true. When the Builder has WithCrypto, identifier + email
-// are stored encrypted and the password is hashed (so login works); otherwise
-// literal placeholder values are stored (fine for tests that never authenticate).
+// email/name, active=true. When the Builder has WithCrypto, email is stored
+// encrypted and the password is hashed (so login works); otherwise literal
+// placeholder values are stored (fine for tests that never authenticate).
 type User struct {
 	ID       string
 	Email    string // default "user-<id8>@example.test"
@@ -54,19 +54,18 @@ func (b *Builder) User(u User) string {
 		u.Avatar = "diamond:sky"
 	}
 
-	identifier, email, password := u.Email, u.Email, u.Password
+	email, password := u.Email, u.Password
 	if b.encode != nil {
-		identifier = b.encode.Hash(lower(u.Email))
 		enc, err := b.encode.Encode(u.Email)
 		if err != nil {
 			b.t.Fatalf("fixture: encode email: %v", err)
 		}
 		email = enc
 		password = b.hasher.HashSHA512(u.Password, u.Salt)
-	} else {
-		// Keep identifier unique without crypto (the column is UNIQUE).
-		identifier = "ident-" + id[:8]
 	}
+	// The identifier column is retired but still NOT NULL UNIQUE; mirror the
+	// production repo and write the row's own id into it.
+	identifier := id
 
 	now := b.now()
 	active := "TRUE"
@@ -570,15 +569,4 @@ func nullable(s string) any {
 		return nil
 	}
 	return s
-}
-
-// lower lowercases ASCII without importing strings (kept tiny + allocation-light).
-func lower(s string) string {
-	b := []byte(s)
-	for i, c := range b {
-		if c >= 'A' && c <= 'Z' {
-			b[i] = c + 32
-		}
-	}
-	return string(b)
 }

--- a/internal/user/admin.go
+++ b/internal/user/admin.go
@@ -26,8 +26,8 @@ func (s *Service) AdminCreateUser(ctx context.Context, name, email, password str
 	return u.ID, nil
 }
 
-// AdminChangeEmail changes a user's email (identifier, ciphertext), looked up
-// by the current email. The avatar is left unchanged.
+// AdminChangeEmail changes a user's stored (encrypted) email, looked up by the
+// current email. The avatar is left unchanged.
 func (s *Service) AdminChangeEmail(ctx context.Context, oldEmail, newEmail string) error {
 	u, err := s.userByEmail(ctx, oldEmail)
 	if err != nil {
@@ -39,7 +39,6 @@ func (s *Service) AdminChangeEmail(ctx context.Context, oldEmail, newEmail strin
 		return derr
 	}
 	loweredNew := strings.ToLower(strings.TrimSpace(newEmail))
-	newIdentifier := s.encode.Hash(loweredNew)
 	if loweredNew != strings.ToLower(currentEmail) {
 		exists, eerr := s.repo.ExistsByEmail(ctx, loweredNew)
 		if eerr != nil {
@@ -56,7 +55,7 @@ func (s *Service) AdminChangeEmail(ctx context.Context, oldEmail, newEmail strin
 	}
 
 	return s.tx.WithTx(ctx, func(ctx context.Context) error {
-		u.UpdateEmail(newIdentifier, encryptedEmail, s.clock.Now())
+		u.UpdateEmail(encryptedEmail, s.clock.Now())
 		return s.repo.Save(ctx, u)
 	})
 }

--- a/internal/user/admin.go
+++ b/internal/user/admin.go
@@ -34,12 +34,16 @@ func (s *Service) AdminChangeEmail(ctx context.Context, oldEmail, newEmail strin
 		return err
 	}
 
+	currentEmail, derr := s.encode.Decode(u.Email)
+	if derr != nil {
+		return derr
+	}
 	loweredNew := strings.ToLower(strings.TrimSpace(newEmail))
 	newIdentifier := s.encode.Hash(loweredNew)
-	if newIdentifier != u.Identifier {
-		exists, err := s.repo.ExistsByIdentifier(ctx, newIdentifier)
-		if err != nil {
-			return err
+	if loweredNew != strings.ToLower(currentEmail) {
+		exists, eerr := s.repo.ExistsByEmail(ctx, loweredNew)
+		if eerr != nil {
+			return eerr
 		}
 		if exists {
 			return &errs.ValidationError{Msg: "User already exists", MsgCode: errs.CodeUserAlreadyExists}
@@ -152,12 +156,10 @@ func (s *Service) AdminShowUser(ctx context.Context, email string) (*model.User,
 	return u, u.EffectiveAccessLevel(s.clock.Now()), nil
 }
 
-// userByEmail resolves a user from a plaintext email via the md5 identifier
-// (the same lookup key registration computes). A miss returns the repo's
-// NotFound error.
+// userByEmail resolves a user from a plaintext email (case-insensitive). A
+// miss returns the repo's NotFound error.
 func (s *Service) userByEmail(ctx context.Context, email string) (*model.User, error) {
-	lowered := strings.ToLower(strings.TrimSpace(email))
-	return s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
+	return s.repo.GetByEmail(ctx, strings.TrimSpace(email))
 }
 
 // AdminUserByID loads a user by id with the email decrypted, for the admin

--- a/internal/user/admin_integration_test.go
+++ b/internal/user/admin_integration_test.go
@@ -20,14 +20,18 @@ import (
 	userrepo "github.com/econumo/econumo/internal/user/repo"
 )
 
-const testSalt = "0123456789abcdef" // AES-128 (16 bytes), like the seed devtool
+// testSalt is a legacy AES-128 (16 bytes) data salt, used only by
+// migrate_test.go to seed/decrypt genuinely encrypted rows for the
+// data:remove-salt migration test. Every other harness here is salt-free,
+// matching production (server.BuildAPI always builds EncodeService with "").
+const testSalt = "0123456789abcdef"
 
 // newUserSvc builds the user Service over a migrated SQLite DB exactly as
 // server.BuildAPI does (minus the unused JWT collaborator), plus the encode/hash
 // services tests assert against.
 func newUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.EncodeService, *auth.PasswordHasher) {
 	t.Helper()
-	enc := auth.NewEncodeService(testSalt)
+	enc := auth.NewEncodeService("")
 	hasher := auth.NewPasswordHasher()
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	tokens := userrepo.NewAccessTokenRepo(db.Engine, db.TX)
@@ -170,7 +174,7 @@ func TestAdminActivateDeactivate(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed two real (crypto) users at controlled creation times.
-	f := fixture.New(t, db).WithCrypto(testSalt)
+	f := fixture.New(t, db).WithCrypto("")
 	f.At(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
 	f.User(fixture.User{Email: "old@econumo.test"})
 	f.At(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))

--- a/internal/user/admin_integration_test.go
+++ b/internal/user/admin_integration_test.go
@@ -57,11 +57,11 @@ func TestAdminCreateUser(t *testing.T) {
 		t.Fatal("empty id")
 	}
 
-	// Lookup uses the lowercased-email identifier; the row must be there, active,
-	// with a verifiable password and a decryptable email.
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("synth@econumo.test"))
+	// Lookup is case-insensitive by email; the row must be there, active, with
+	// a verifiable password and a decryptable email.
+	u, err := repo.GetByEmail(ctx, "synth@econumo.test")
 	if err != nil {
-		t.Fatalf("GetByIdentifier: %v", err)
+		t.Fatalf("GetByEmail: %v", err)
 	}
 	if !u.IsActive {
 		t.Error("new user should be active")
@@ -98,13 +98,13 @@ func TestAdminChangeEmail(t *testing.T) {
 		t.Fatalf("AdminChangeEmail: %v", err)
 	}
 
-	// Old identifier gone, new identifier resolves with the new (decryptable) email.
-	if _, err := repo.GetByIdentifier(ctx, enc.Hash("old@econumo.test")); !isNotFound(err) {
-		t.Errorf("old identifier should be gone, got %v", err)
+	// Old email gone, new email resolves with the new (decryptable) email.
+	if _, err := repo.GetByEmail(ctx, "old@econumo.test"); !isNotFound(err) {
+		t.Errorf("old email should be gone, got %v", err)
 	}
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("new@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "new@econumo.test")
 	if err != nil {
-		t.Fatalf("new identifier lookup: %v", err)
+		t.Fatalf("new email lookup: %v", err)
 	}
 	if got, _ := enc.Decode(u.Email); got != "new@econumo.test" {
 		t.Errorf("decoded email = %q, want new@econumo.test", got)
@@ -126,7 +126,7 @@ func TestAdminChangeEmail(t *testing.T) {
 
 func TestAdminChangePassword(t *testing.T) {
 	db := dbtest.New(t)
-	svc, enc, hasher := newUserSvc(t, db)
+	svc, _, hasher := newUserSvc(t, db)
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	ctx := context.Background()
 
@@ -135,7 +135,7 @@ func TestAdminChangePassword(t *testing.T) {
 	}
 
 	// Force the account to the legacy scheme so the test proves the transition.
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("pw@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "pw@econumo.test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestAdminChangePassword(t *testing.T) {
 		t.Fatalf("AdminChangePassword: %v", err)
 	}
 
-	u, err = repo.GetByIdentifier(ctx, enc.Hash("pw@econumo.test"))
+	u, err = repo.GetByEmail(ctx, "pw@econumo.test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestAdminChangePassword(t *testing.T) {
 
 func TestAdminActivateDeactivate(t *testing.T) {
 	db := dbtest.New(t)
-	svc, enc, _ := newUserSvc(t, db)
+	svc, _, _ := newUserSvc(t, db)
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	ctx := context.Background()
 
@@ -184,10 +184,10 @@ func TestAdminActivateDeactivate(t *testing.T) {
 	if err := svc.AdminDeactivate(ctx, "old@econumo.test"); err != nil {
 		t.Fatalf("AdminDeactivate: %v", err)
 	}
-	if isActive(t, repo, enc, "old@econumo.test") {
+	if isActive(t, repo, "old@econumo.test") {
 		t.Error("old user should be deactivated")
 	}
-	if !isActive(t, repo, enc, "recent@econumo.test") {
+	if !isActive(t, repo, "recent@econumo.test") {
 		t.Error("recent user should remain active")
 	}
 
@@ -195,7 +195,7 @@ func TestAdminActivateDeactivate(t *testing.T) {
 	if err := svc.AdminDeactivate(ctx, "old@econumo.test"); err != nil {
 		t.Fatalf("second AdminDeactivate: %v", err)
 	}
-	if isActive(t, repo, enc, "old@econumo.test") {
+	if isActive(t, repo, "old@econumo.test") {
 		t.Error("old user should still be deactivated")
 	}
 
@@ -203,7 +203,7 @@ func TestAdminActivateDeactivate(t *testing.T) {
 	if err := svc.AdminActivate(ctx, "old@econumo.test"); err != nil {
 		t.Fatalf("AdminActivate: %v", err)
 	}
-	if !isActive(t, repo, enc, "old@econumo.test") {
+	if !isActive(t, repo, "old@econumo.test") {
 		t.Error("old user should be active again")
 	}
 
@@ -215,9 +215,9 @@ func TestAdminActivateDeactivate(t *testing.T) {
 	}
 }
 
-func isActive(t *testing.T, repo *userrepo.Repo, enc *auth.EncodeService, email string) bool {
+func isActive(t *testing.T, repo *userrepo.Repo, email string) bool {
 	t.Helper()
-	u, err := repo.GetByIdentifier(context.Background(), enc.Hash(strings.ToLower(email)))
+	u, err := repo.GetByEmail(context.Background(), email)
 	if err != nil {
 		t.Fatalf("lookup %s: %v", email, err)
 	}
@@ -236,16 +236,16 @@ func isNotFound(err error) bool {
 
 func TestAdminCreateUserAssignsPickedAvatar(t *testing.T) {
 	db := dbtest.New(t)
-	svc, enc, _ := newUserSvc(t, db)
+	svc, _, _ := newUserSvc(t, db)
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	ctx := context.Background()
 
 	if _, err := svc.AdminCreateUser(ctx, "Avatar Tester", "avatar@econumo.test", "secretpass"); err != nil {
 		t.Fatalf("AdminCreateUser: %v", err)
 	}
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("avatar@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "avatar@econumo.test")
 	if err != nil {
-		t.Fatalf("GetByIdentifier: %v", err)
+		t.Fatalf("GetByEmail: %v", err)
 	}
 	if u.Avatar != appuser.DefaultAvatar {
 		t.Fatalf("Avatar = %q, want the stub picker value %q", u.Avatar, appuser.DefaultAvatar)
@@ -327,7 +327,7 @@ func TestAdminSetAccess_UnknownEmail(t *testing.T) {
 
 func TestAdminChangeEmailKeepsAvatar(t *testing.T) {
 	db := dbtest.New(t)
-	svc, enc, _ := newUserSvc(t, db)
+	svc, _, _ := newUserSvc(t, db)
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	ctx := context.Background()
 
@@ -337,9 +337,9 @@ func TestAdminChangeEmailKeepsAvatar(t *testing.T) {
 	if err := svc.AdminChangeEmail(ctx, "keep@econumo.test", "kept@econumo.test"); err != nil {
 		t.Fatalf("AdminChangeEmail: %v", err)
 	}
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("kept@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "kept@econumo.test")
 	if err != nil {
-		t.Fatalf("GetByIdentifier: %v", err)
+		t.Fatalf("GetByEmail: %v", err)
 	}
 	if u.Avatar != appuser.DefaultAvatar {
 		t.Fatalf("Avatar = %q after email change, want unchanged %q", u.Avatar, appuser.DefaultAvatar)

--- a/internal/user/api/harness_test.go
+++ b/internal/user/api/harness_test.go
@@ -34,8 +34,6 @@ import (
 )
 
 const (
-	testDataSalt = "0123456789abcdef" // 16 bytes -> AES-128 requires exactly 16 key bytes
-
 	seedUserID   = "11111111-1111-1111-1111-111111111111"
 	seedEmail    = "user@example.test"
 	seedPassword = "secret-pw"
@@ -87,7 +85,7 @@ func newHarnessWithLimiter(t *testing.T, limiter appuser.AttemptLimiter) *harnes
 		t.Fatalf("migrate: %v", err)
 	}
 
-	encode := auth.NewEncodeService(testDataSalt)
+	encode := auth.NewEncodeService("") // salt-free, matching server.BuildAPI
 	hasher := auth.NewPasswordHasher()
 	// Use a near-now issuance time so tokens verify (the JWT verifier checks exp
 	// against the real wall clock). Truncated to the second to match the
@@ -164,7 +162,7 @@ func (m *recordingMailer) lastResetCode(t *testing.T) string {
 // existing option — can write to it.
 func seed(t *testing.T, tdb *dbtest.DB) {
 	t.Helper()
-	f := fixture.New(t, tdb).WithCrypto(testDataSalt)
+	f := fixture.New(t, tdb).WithCrypto("")
 	f.User(fixture.User{
 		ID:       seedUserID,
 		Email:    seedEmail,

--- a/internal/user/api/session_endpoints_test.go
+++ b/internal/user/api/session_endpoints_test.go
@@ -122,7 +122,7 @@ func TestRevokeSession_ForeignAndUnknown400(t *testing.T) {
 
 	// A second user with their own session.
 	otherUser := "99999999-9999-9999-9999-999999999999"
-	f := fixture.New(t, h.tdb).WithCrypto(testDataSalt)
+	f := fixture.New(t, h.tdb).WithCrypto("")
 	f.User(fixture.User{ID: otherUser, Email: "other-sess@example.test", Name: "Other"})
 	otherTok := h.issueTokenFor(t, otherUser)
 	foreign := h.sessionList(t, otherTok)[0].Id

--- a/internal/user/api/user_endpoints_test.go
+++ b/internal/user/api/user_endpoints_test.go
@@ -199,6 +199,39 @@ func TestRegisterUser_NoToken_CreatesUser(t *testing.T) {
 	}
 }
 
+// TestRegisterUser_TrimsEmailWhitespace_LoginWorks locks storage and lookup
+// normalization together: the user lookup key is lower(email) on the stored
+// column, so a padded email must be trimmed before being persisted, or a
+// later login/reset/verification with the clean email can never find the row
+// (lower() does not strip whitespace).
+func TestRegisterUser_TrimsEmailWhitespace_LoginWorks(t *testing.T) {
+	h := newHarness(t)
+
+	status, env := h.do(t, http.MethodPost, "/api/v1/user/register-user", "", map[string]string{
+		"email":    "  regtrim@example.test  ",
+		"password": "hunter2pw",
+		"name":     "Trim",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", status, env.raw)
+	}
+
+	res := mustUnmarshal[struct {
+		User currentUser `json:"user"`
+	}](t, env.Data)
+	if res.User.Email != "regtrim@example.test" {
+		t.Fatalf("user.email = %q, want trimmed %q", res.User.Email, "regtrim@example.test")
+	}
+
+	st2, env2 := h.do(t, http.MethodPost, "/api/v1/user/login-user", "", map[string]string{
+		"username": "regtrim@example.test",
+		"password": "hunter2pw",
+	})
+	if st2 != http.StatusOK {
+		t.Fatalf("login with clean email after padded registration: status = %d; body: %s", st2, env2.raw)
+	}
+}
+
 // TestRegisterUser_DoesNotAutoConnect locks the behaviour after removing
 // ECONUMO_CONNECT_USERS: a newly registered user is never auto-connected to any
 // existing user. The harness already seeds one user; after registering another,

--- a/internal/user/avatar_update_integration_test.go
+++ b/internal/user/avatar_update_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestUpdateAvatar(t *testing.T) {
 	db := dbtest.New(t)
-	svc, enc, _ := newUserSvc(t, db)
+	svc, _, _ := newUserSvc(t, db)
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	ctx := context.Background()
 
@@ -27,9 +27,9 @@ func TestUpdateAvatar(t *testing.T) {
 	if res.User.Avatar != "pets:teal" {
 		t.Fatalf("result avatar = %q, want pets:teal", res.User.Avatar)
 	}
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("upd@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "upd@econumo.test")
 	if err != nil {
-		t.Fatalf("GetByIdentifier: %v", err)
+		t.Fatalf("GetByEmail: %v", err)
 	}
 	if u.Avatar != "pets:teal" {
 		t.Fatalf("persisted avatar = %q, want pets:teal", u.Avatar)

--- a/internal/user/login.go
+++ b/internal/user/login.go
@@ -1,4 +1,4 @@
-// Login use case: authenticate by identifier and mint a session token.
+// Login use case: authenticate by email and mint a session token.
 package user
 
 import (
@@ -12,17 +12,16 @@ import (
 	"github.com/econumo/econumo/internal/shared/reqctx"
 )
 
-// Login authenticates by identifier (md5 of the lowercased username), verifies
-// the password against the stored hash+salt, mints a session token, and returns
-// the token + current user. A bad username or password yields an
-// UnauthorizedError (HTTP 401, "Invalid credentials.").
+// Login authenticates by email (case-insensitive), verifies the password
+// against the stored hash+salt, mints a session token, and returns the token +
+// current user. A bad username or password yields an UnauthorizedError (HTTP
+// 401, "Invalid credentials.").
 func (s *Service) Login(ctx context.Context, req model.LoginRequest, userAgent string, now time.Time) (*model.LoginResult, error) {
 	limitKey := strings.ToLower(strings.TrimSpace(req.Username))
 	if err := s.allowAttempt(RateScopeLogin, limitKey); err != nil {
 		return nil, err
 	}
-	identifier := s.encode.Hash(strings.ToLower(req.Username))
-	u, err := s.repo.GetByIdentifier(ctx, identifier)
+	u, err := s.repo.GetByEmail(ctx, req.Username)
 	if err != nil {
 		if _, ok := errs.AsNotFound(err); ok {
 			s.failAttempt(RateScopeLogin, limitKey)

--- a/internal/user/migrate.go
+++ b/internal/user/migrate.go
@@ -11,14 +11,11 @@ import (
 	"github.com/econumo/econumo/internal/infra/auth"
 )
 
-// MigrateRemoveDataSalt decrypts every user's email back to plaintext and
-// re-derives the identifier WITHOUT the data salt, so ECONUMO_DATA_SALT can be
-// unset afterwards. It rewrites both salt-dependent columns:
-//
-//   - email:      AES ciphertext -> plaintext (decrypted with the salt the data
-//     was written with, passed in by the caller).
-//   - identifier: hex(md5(lower(email)+salt)) -> hex(md5(lower(email))) — the
-//     exact value Login will compute (the API itself is already salt-free).
+// MigrateRemoveDataSalt decrypts every user's email back to plaintext (AES
+// ciphertext -> plaintext, decrypted with the salt the data was written with,
+// passed in by the caller) so ECONUMO_DATA_SALT can be unset afterwards. The
+// repo derives the identifier column from the row id at Save time, so this
+// migration no longer touches it.
 //
 // The salt arrives as a parameter rather than via s.encode: the service's own
 // encoder is salt-free (the API ignores ECONUMO_DATA_SALT), so this method builds
@@ -41,10 +38,7 @@ func (s *Service) MigrateRemoveDataSalt(ctx context.Context, salt string) (migra
 	if err != nil {
 		return 0, 0, err
 	}
-	// salted decrypts the stored emails; saltFree derives the post-removal
-	// identifier md5(lower(email)).
 	salted := auth.NewEncodeService(salt)
-	saltFree := auth.NewEncodeService("")
 
 	err = s.tx.WithTx(ctx, func(ctx context.Context) error {
 		for _, id := range ids {
@@ -59,13 +53,12 @@ func (s *Service) MigrateRemoveDataSalt(ctx context.Context, salt string) (migra
 				skipped++
 				continue
 			}
-			newIdent := saltFree.Hash(strings.ToLower(plain))
-			if plain == u.Email && newIdent == u.Identifier {
+			if plain == u.Email {
 				// Nothing to change (defensive: Decode normally errors first).
 				skipped++
 				continue
 			}
-			u.UpdateEmail(newIdent, plain, s.clock.Now())
+			u.UpdateEmail(plain, s.clock.Now())
 			if serr := s.repo.Save(ctx, u); serr != nil {
 				return serr
 			}

--- a/internal/user/migrate_test.go
+++ b/internal/user/migrate_test.go
@@ -36,11 +36,14 @@ func newSaltFreeUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.Pa
 
 func TestMigrateRemoveDataSalt(t *testing.T) {
 	db := dbtest.NewSQLite(t)
-	svc, enc, _ := newUserSvc(t, db) // service still holds the OLD salt (testSalt)
+	svc, _, _ := newUserSvc(t, db) // salt-free, like production; MigrateRemoveDataSalt takes the salt as a parameter
 	repo := userrepo.NewRepo("sqlite", db.TX)
 	ctx := context.Background()
 
-	// Seed encrypted users (real crypto with the SAME salt the service uses).
+	// Seed encrypted users (real crypto with a genuine salt), and a matching
+	// LOCAL encoder to compute the pre-migration salted identifier/ciphertext —
+	// the harness's own encoder is salt-free, so it can't derive these.
+	salted := auth.NewEncodeService(testSalt)
 	emails := []string{"Alice@Econumo.test", "bob@econumo.test"}
 	f := fixture.New(t, db).WithCrypto(testSalt)
 	for _, e := range emails {
@@ -50,7 +53,7 @@ func TestMigrateRemoveDataSalt(t *testing.T) {
 	// Sanity: emails are stored encrypted (not equal to plaintext) before migration.
 	saltFree := auth.NewEncodeService("")
 	for _, e := range emails {
-		u, err := repo.GetByIdentifier(ctx, enc.Hash(strings.ToLower(e)))
+		u, err := repo.GetByIdentifier(ctx, salted.Hash(strings.ToLower(e)))
 		if err != nil {
 			t.Fatalf("pre-migration lookup %s: %v", e, err)
 		}
@@ -80,7 +83,7 @@ func TestMigrateRemoveDataSalt(t *testing.T) {
 			t.Errorf("identifier for %s not the unsalted md5", e)
 		}
 		// The old (salted) identifier must no longer resolve.
-		if _, err := repo.GetByIdentifier(ctx, enc.Hash(strings.ToLower(e))); err == nil {
+		if _, err := repo.GetByIdentifier(ctx, salted.Hash(strings.ToLower(e))); err == nil {
 			t.Errorf("old salted identifier for %s still resolves", e)
 		}
 	}
@@ -99,7 +102,7 @@ func TestMigrateRemoveDataSalt(t *testing.T) {
 // salt-free service (ECONUMO_DATA_SALT unset) can log the user in.
 func TestMigrateThenLoginSaltFree(t *testing.T) {
 	db := dbtest.NewSQLite(t)
-	saltedSvc, _, _ := newUserSvc(t, db) // holds testSalt, used only to migrate
+	saltedSvc, _, _ := newUserSvc(t, db) // salt-free; MigrateRemoveDataSalt takes the salt as a parameter
 	ctx := context.Background()
 
 	const email = "Carol@Econumo.test"

--- a/internal/user/migrate_test.go
+++ b/internal/user/migrate_test.go
@@ -2,7 +2,6 @@ package user_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	currencyrepo "github.com/econumo/econumo/internal/currency/repo"
@@ -10,6 +9,7 @@ import (
 	"github.com/econumo/econumo/internal/infra/clock"
 	"github.com/econumo/econumo/internal/model"
 	"github.com/econumo/econumo/internal/server"
+	"github.com/econumo/econumo/internal/shared/vo"
 	"github.com/econumo/econumo/internal/test/dbtest"
 	"github.com/econumo/econumo/internal/test/fixture"
 	appuser "github.com/econumo/econumo/internal/user"
@@ -17,8 +17,8 @@ import (
 )
 
 // newSaltFreeUserSvc builds a user Service with an EMPTY data salt — the state
-// the deployment is in AFTER ECONUMO_DATA_SALT is removed. Login then computes
-// the identifier as md5(lower(email)) and treats the email column as plaintext.
+// the deployment is in AFTER ECONUMO_DATA_SALT is removed. Login then looks the
+// user up by email and treats the email column as plaintext.
 func newSaltFreeUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.PasswordHasher) {
 	t.Helper()
 	enc := auth.NewEncodeService("")
@@ -40,20 +40,20 @@ func TestMigrateRemoveDataSalt(t *testing.T) {
 	repo := userrepo.NewRepo("sqlite", db.TX)
 	ctx := context.Background()
 
-	// Seed encrypted users (real crypto with a genuine salt), and a matching
-	// LOCAL encoder to compute the pre-migration salted identifier/ciphertext —
-	// the harness's own encoder is salt-free, so it can't derive these.
-	salted := auth.NewEncodeService(testSalt)
+	// Seed encrypted users with a genuine salt (real crypto); the harness's own
+	// encoder is salt-free, so this exercises actual ciphertext. Ids are
+	// captured because the email column is ciphertext pre-migration, so
+	// GetByEmail cannot find the row until after the sweep.
 	emails := []string{"Alice@Econumo.test", "bob@econumo.test"}
 	f := fixture.New(t, db).WithCrypto(testSalt)
+	ids := make(map[string]string, len(emails)) // email -> id
 	for _, e := range emails {
-		f.User(fixture.User{Email: e})
+		ids[e] = f.User(fixture.User{Email: e})
 	}
 
 	// Sanity: emails are stored encrypted (not equal to plaintext) before migration.
-	saltFree := auth.NewEncodeService("")
 	for _, e := range emails {
-		u, err := repo.GetByIdentifier(ctx, salted.Hash(strings.ToLower(e)))
+		u, err := repo.GetByID(ctx, vo.MustParseId(ids[e]))
 		if err != nil {
 			t.Fatalf("pre-migration lookup %s: %v", e, err)
 		}
@@ -70,21 +70,22 @@ func TestMigrateRemoveDataSalt(t *testing.T) {
 		t.Fatalf("migrated=%d skipped=%d, want %d/0", migrated, skipped, len(emails))
 	}
 
-	// Each row is now plaintext, looked up by the UNSALTED identifier.
+	// Each row is now plaintext, and findable by GetByEmail (its post-migration
+	// lookup key).
 	for _, e := range emails {
-		u, err := repo.GetByIdentifier(ctx, saltFree.Hash(strings.ToLower(e)))
+		u, err := repo.GetByID(ctx, vo.MustParseId(ids[e]))
 		if err != nil {
-			t.Fatalf("post-migration lookup %s: %v", e, err)
+			t.Fatalf("post-migration lookup by id %s: %v", e, err)
 		}
 		if u.Email != e {
 			t.Errorf("email = %q, want plaintext %q (case preserved)", u.Email, e)
 		}
-		if u.Identifier != saltFree.Hash(strings.ToLower(e)) {
-			t.Errorf("identifier for %s not the unsalted md5", e)
+		byEmail, err := repo.GetByEmail(ctx, e)
+		if err != nil {
+			t.Fatalf("post-migration GetByEmail(%s): %v", e, err)
 		}
-		// The old (salted) identifier must no longer resolve.
-		if _, err := repo.GetByIdentifier(ctx, salted.Hash(strings.ToLower(e))); err == nil {
-			t.Errorf("old salted identifier for %s still resolves", e)
+		if byEmail.ID.String() != ids[e] {
+			t.Errorf("GetByEmail(%s) = %s, want %s", e, byEmail.ID, ids[e])
 		}
 	}
 

--- a/internal/user/password.go
+++ b/internal/user/password.go
@@ -85,7 +85,7 @@ func (s *Service) RemindPassword(ctx context.Context, req model.RemindPasswordRe
 	}
 	s.failAttempt(RateScopeRemind, lowered) // every remind sends an email, so every request counts
 
-	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
+	u, err := s.repo.GetByEmail(ctx, lowered)
 	if err != nil {
 		if isNotFound(err) {
 			return &model.RemindPasswordResult{}, nil // anti-enumeration
@@ -124,7 +124,7 @@ func (s *Service) ResetPassword(ctx context.Context, req model.ResetPasswordRequ
 	if err := s.allowAttempt(RateScopeReset, lowered); err != nil {
 		return nil, err
 	}
-	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
+	u, err := s.repo.GetByEmail(ctx, lowered)
 	if err != nil {
 		if isNotFound(err) {
 			s.failAttempt(RateScopeReset, lowered)

--- a/internal/user/register.go
+++ b/internal/user/register.go
@@ -49,7 +49,7 @@ func (s *Service) createUser(ctx context.Context, name, email, password string, 
 	loweredEmail := strings.ToLower(strings.TrimSpace(email))
 	identifier := s.encode.Hash(loweredEmail)
 
-	exists, err := s.repo.ExistsByIdentifier(ctx, identifier)
+	exists, err := s.repo.ExistsByEmail(ctx, loweredEmail)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/user/register.go
+++ b/internal/user/register.go
@@ -56,7 +56,7 @@ func (s *Service) createUser(ctx context.Context, name, email, password string, 
 		return nil, &errs.ValidationError{Msg: "User already exists", MsgCode: errs.CodeUserAlreadyExists}
 	}
 
-	encryptedEmail, eerr := s.encode.Encode(email)
+	encryptedEmail, eerr := s.encode.Encode(strings.TrimSpace(email))
 	if eerr != nil {
 		return nil, eerr
 	}

--- a/internal/user/register.go
+++ b/internal/user/register.go
@@ -47,7 +47,6 @@ func (s *Service) Register(ctx context.Context, req model.RegisterRequest) (*mod
 // lead to be time-boxed or a mailbox to confirm.
 func (s *Service) createUser(ctx context.Context, name, email, password string, selfService bool) (*model.User, error) {
 	loweredEmail := strings.ToLower(strings.TrimSpace(email))
-	identifier := s.encode.Hash(loweredEmail)
 
 	exists, err := s.repo.ExistsByEmail(ctx, loweredEmail)
 	if err != nil {
@@ -72,7 +71,7 @@ func (s *Service) createUser(ctx context.Context, name, email, password string, 
 	}
 	avatar := s.avatars.Pick()
 
-	u := model.NewUser(s.repo.NextIdentity(), identifier, encryptedEmail, name, avatar, passwordHash, salt, now)
+	u := model.NewUser(s.repo.NextIdentity(), encryptedEmail, name, avatar, passwordHash, salt, now)
 	u.SeedDefaultOptions(s.repo.NextIdentity, now)
 	if selfService && s.trial == "end-of-next-month" {
 		until := model.TrialEnd(now)

--- a/internal/user/repo/accesstoken_integration_test.go
+++ b/internal/user/repo/accesstoken_integration_test.go
@@ -17,7 +17,7 @@ func seedTokenUser(t *testing.T, db *dbtest.DB, id string) {
 	t.Helper()
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	u := newTestUser(
-		vo.MustParseId(id), identA, "enc-email", "Alice", "https://av/a",
+		vo.MustParseId(id), "enc-email", "Alice", "https://av/a",
 		"hash", "salt-a", true, fixedTime, fixedTime, nil,
 	)
 	if err := db.TX.WithTx(context.Background(), func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {

--- a/internal/user/repo/emailverification_integration_test.go
+++ b/internal/user/repo/emailverification_integration_test.go
@@ -19,7 +19,7 @@ func TestEmailVerificationRepoLifecycle(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Second)
 
-	u := model.NewUser(users.NextIdentity(), "ev-lifecycle", "cipher", "EV", "face:blue", "hash", "salt", now)
+	u := model.NewUser(users.NextIdentity(), "cipher", "EV", "face:blue", "hash", "salt", now)
 	if err := users.Save(ctx, u); err != nil {
 		t.Fatalf("save user: %v", err)
 	}

--- a/internal/user/repo/pgsql.go
+++ b/internal/user/repo/pgsql.go
@@ -16,15 +16,6 @@ func (pgsqlQuerier) GetUserByID(ctx context.Context, db backend.DBTX, id string)
 	return userRow(u), err
 }
 
-func (pgsqlQuerier) GetUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (userRow, error) {
-	u, err := pgsqlgen.New(db).GetUserByIdentifier(ctx, identifier)
-	return userRow(u), err
-}
-
-func (pgsqlQuerier) ExistsUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (bool, error) {
-	return pgsqlgen.New(db).ExistsUserByIdentifier(ctx, identifier)
-}
-
 func (pgsqlQuerier) GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error) {
 	u, err := pgsqlgen.New(db).GetUserByEmail(ctx, email)
 	return userRow(u), err

--- a/internal/user/repo/pgsql.go
+++ b/internal/user/repo/pgsql.go
@@ -25,6 +25,15 @@ func (pgsqlQuerier) ExistsUserByIdentifier(ctx context.Context, db backend.DBTX,
 	return pgsqlgen.New(db).ExistsUserByIdentifier(ctx, identifier)
 }
 
+func (pgsqlQuerier) GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error) {
+	u, err := pgsqlgen.New(db).GetUserByEmail(ctx, email)
+	return userRow(u), err
+}
+
+func (pgsqlQuerier) ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error) {
+	return pgsqlgen.New(db).ExistsUserByEmail(ctx, email)
+}
+
 func (pgsqlQuerier) ListUserIDs(ctx context.Context, db backend.DBTX) ([]string, error) {
 	return pgsqlgen.New(db).ListUserIDs(ctx)
 }

--- a/internal/user/repo/repo.go
+++ b/internal/user/repo/repo.go
@@ -25,7 +25,6 @@ import (
 type (
 	userRow struct {
 		ID            string
-		Identifier    string
 		Email         string
 		Name          string
 		Avatar        string
@@ -49,8 +48,6 @@ type (
 
 type querier interface {
 	GetUserByID(ctx context.Context, db backend.DBTX, id string) (userRow, error)
-	GetUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (userRow, error)
-	ExistsUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (bool, error)
 	GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error)
 	ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error)
 	ListUserIDs(ctx context.Context, db backend.DBTX) ([]string, error)
@@ -122,21 +119,6 @@ func (r *Repo) GetHeaderByID(ctx context.Context, id vo.Id) (model.Header, error
 	}, nil
 }
 
-func (r *Repo) GetByIdentifier(ctx context.Context, identifier string) (*model.User, error) {
-	row, err := r.q.GetUserByIdentifier(ctx, r.db(ctx), identifier)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errs.NewNotFound("User not found")
-		}
-		return nil, err
-	}
-	return r.hydrate(ctx, row)
-}
-
-func (r *Repo) ExistsByIdentifier(ctx context.Context, identifier string) (bool, error) {
-	return r.q.ExistsUserByIdentifier(ctx, r.db(ctx), identifier)
-}
-
 func (r *Repo) GetByEmail(ctx context.Context, email string) (*model.User, error) {
 	row, err := r.q.GetUserByEmail(ctx, r.db(ctx), email)
 	if err != nil {
@@ -182,7 +164,7 @@ func (r *Repo) Save(ctx context.Context, u *model.User) error {
 	db := r.db(ctx)
 	if err := r.q.UpsertUser(ctx, db, userParams{
 		ID:            u.ID.String(),
-		Identifier:    u.Identifier,
+		Identifier:    u.ID.String(),
 		Email:         u.Email,
 		Name:          u.Name,
 		Avatar:        u.Avatar,
@@ -255,7 +237,7 @@ func (r *Repo) hydrate(ctx context.Context, row userRow) (*model.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &model.User{ID: id, Identifier: row.Identifier, Email: row.Email, Name: row.Name,
+	return &model.User{ID: id, Email: row.Email, Name: row.Name,
 		Avatar: row.Avatar, Password: row.Password, Salt: row.Salt, Algorithm: row.Algorithm,
 		IsActive: row.IsActive, EmailVerified: row.EmailVerified, AccessLevel: model.AccessLevel(row.AccessLevel), AccessUntil: row.AccessUntil,
 		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt, Options: opts}, nil

--- a/internal/user/repo/repo.go
+++ b/internal/user/repo/repo.go
@@ -51,6 +51,8 @@ type querier interface {
 	GetUserByID(ctx context.Context, db backend.DBTX, id string) (userRow, error)
 	GetUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (userRow, error)
 	ExistsUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (bool, error)
+	GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error)
+	ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error)
 	ListUserIDs(ctx context.Context, db backend.DBTX) ([]string, error)
 	UpsertUser(ctx context.Context, db backend.DBTX, p userParams) error
 	GetUserOptions(ctx context.Context, db backend.DBTX, userID string) ([]optionRow, error)
@@ -133,6 +135,21 @@ func (r *Repo) GetByIdentifier(ctx context.Context, identifier string) (*model.U
 
 func (r *Repo) ExistsByIdentifier(ctx context.Context, identifier string) (bool, error) {
 	return r.q.ExistsUserByIdentifier(ctx, r.db(ctx), identifier)
+}
+
+func (r *Repo) GetByEmail(ctx context.Context, email string) (*model.User, error) {
+	row, err := r.q.GetUserByEmail(ctx, r.db(ctx), email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errs.NewNotFound("User not found")
+		}
+		return nil, err
+	}
+	return r.hydrate(ctx, row)
+}
+
+func (r *Repo) ExistsByEmail(ctx context.Context, email string) (bool, error) {
+	return r.q.ExistsUserByEmail(ctx, r.db(ctx), email)
 }
 
 func (r *Repo) ListIDs(ctx context.Context) ([]vo.Id, error) {

--- a/internal/user/repo/repo_integration_test.go
+++ b/internal/user/repo/repo_integration_test.go
@@ -150,6 +150,45 @@ func TestUserRepo_ExistsByIdentifier(t *testing.T) {
 	}
 }
 
+func TestUserRepo_GetByEmail(t *testing.T) {
+	repo, _, db := newRepos(t)
+	ctx := context.Background()
+	u := newTestUser(vo.MustParseId(userA), identA, "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Lookup is case-insensitive.
+	got, err := repo.GetByEmail(ctx, "alice@example.test")
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if got.ID.String() != userA {
+		t.Errorf("want %s, got %s", userA, got.ID)
+	}
+	_, err = repo.GetByEmail(ctx, "missing@example.test")
+	var nf *errs.NotFoundError
+	if !errors.As(err, &nf) {
+		t.Fatalf("want NotFound for missing email, got %v", err)
+	}
+}
+
+func TestUserRepo_ExistsByEmail(t *testing.T) {
+	repo, _, db := newRepos(t)
+	ctx := context.Background()
+	u := newTestUser(vo.MustParseId(userA), identA, "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	exists, err := repo.ExistsByEmail(ctx, "alice@example.test")
+	if err != nil || !exists {
+		t.Errorf("ExistsByEmail(alice) = %v, %v; want true", exists, err)
+	}
+	exists, err = repo.ExistsByEmail(ctx, "nope@example.test")
+	if err != nil || exists {
+		t.Errorf("ExistsByEmail(nope) = %v, %v; want false", exists, err)
+	}
+}
+
 func TestUserRepo_ListIDs(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()

--- a/internal/user/repo/repo_integration_test.go
+++ b/internal/user/repo/repo_integration_test.go
@@ -22,20 +22,15 @@ const (
 
 var fixedTime = time.Date(2024, 4, 1, 12, 0, 0, 0, time.UTC)
 
-// identA is a realistic 32-char identifier (production identifiers are
-// md5(lower(email)) = 32 hex chars); using exactly 32 avoids CHAR(32) padding
-// differences between sqlite and Postgres.
-const identA = "0123456789abcdef0123456789abcdef"
-
 func newRepos(t *testing.T) (*userrepo.Repo, *userrepo.ReadRepo, *dbtest.DB) {
 	t.Helper()
 	db := dbtest.New(t)
 	return userrepo.NewRepo(db.Engine, db.TX), userrepo.NewReadRepo(db.Engine, db.TX), db
 }
 
-func newTestUser(id vo.Id, identifier, email, name, avatar, password, salt string, isActive bool,
+func newTestUser(id vo.Id, email, name, avatar, password, salt string, isActive bool,
 	createdAt, updatedAt time.Time, opts []model.UserOption) *model.User {
-	return &model.User{ID: id, Identifier: identifier, Email: email, Name: name, Avatar: avatar,
+	return &model.User{ID: id, Email: email, Name: name, Avatar: avatar,
 		Password: password, Salt: salt, IsActive: isActive, AccessLevel: model.AccessLevelFull,
 		CreatedAt: createdAt, UpdatedAt: updatedAt, Options: opts}
 }
@@ -47,7 +42,7 @@ func TestUserRepo_SaveGetRoundTrip_WithOptions(t *testing.T) {
 	val := "USD"
 	opt := model.ReconstituteUserOption(vo.MustParseId(optID), "currency", &val, fixedTime, fixedTime)
 	u := newTestUser(
-		vo.MustParseId(userA), identA, "enc-email", "Alice", "https://av/a",
+		vo.MustParseId(userA), "enc-email", "Alice", "https://av/a",
 		"hash", "salt-a", true, fixedTime, fixedTime, []model.UserOption{opt},
 	)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
@@ -58,8 +53,8 @@ func TestUserRepo_SaveGetRoundTrip_WithOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
-	if got.Identifier != identA || got.Email != "enc-email" || got.Name != "Alice" {
-		t.Errorf("fields mismatch: %q %q %q", got.Identifier, got.Email, got.Name)
+	if got.Email != "enc-email" || got.Name != "Alice" {
+		t.Errorf("fields mismatch: %q %q", got.Email, got.Name)
 	}
 	if got.Avatar != "https://av/a" || got.Password != "hash" || got.Salt != "salt-a" || !got.IsActive {
 		t.Errorf("auth/avatar mismatch: %+v", got)
@@ -90,7 +85,7 @@ func TestUserRepo_GetHeaderByID(t *testing.T) {
 	ctx := context.Background()
 
 	u := newTestUser(
-		vo.MustParseId(userA), identA, "enc-email", "Alice", "https://av/a",
+		vo.MustParseId(userA), "enc-email", "Alice", "https://av/a",
 		"hash", "salt-a", true, fixedTime, fixedTime, nil,
 	)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
@@ -112,48 +107,10 @@ func TestUserRepo_GetHeaderByID(t *testing.T) {
 	}
 }
 
-func TestUserRepo_GetByIdentifier(t *testing.T) {
-	repo, _, db := newRepos(t)
-	ctx := context.Background()
-	u := newTestUser(vo.MustParseId(userA), identA, "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
-	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-	got, err := repo.GetByIdentifier(ctx, identA)
-	if err != nil {
-		t.Fatalf("GetByIdentifier: %v", err)
-	}
-	if got.ID.String() != userA {
-		t.Errorf("want %s, got %s", userA, got.ID)
-	}
-	_, err = repo.GetByIdentifier(ctx, "missing")
-	var nf *errs.NotFoundError
-	if !errors.As(err, &nf) {
-		t.Fatalf("want NotFound for missing identifier, got %v", err)
-	}
-}
-
-func TestUserRepo_ExistsByIdentifier(t *testing.T) {
-	repo, _, db := newRepos(t)
-	ctx := context.Background()
-	u := newTestUser(vo.MustParseId(userA), identA, "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
-	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-	exists, err := repo.ExistsByIdentifier(ctx, identA)
-	if err != nil || !exists {
-		t.Errorf("ExistsByIdentifier(ident-a) = %v, %v; want true", exists, err)
-	}
-	exists, err = repo.ExistsByIdentifier(ctx, "nope")
-	if err != nil || exists {
-		t.Errorf("ExistsByIdentifier(nope) = %v, %v; want false", exists, err)
-	}
-}
-
 func TestUserRepo_GetByEmail(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()
-	u := newTestUser(vo.MustParseId(userA), identA, "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	u := newTestUser(vo.MustParseId(userA), "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -175,7 +132,7 @@ func TestUserRepo_GetByEmail(t *testing.T) {
 func TestUserRepo_ExistsByEmail(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()
-	u := newTestUser(vo.MustParseId(userA), identA, "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	u := newTestUser(vo.MustParseId(userA), "Alice@Example.test", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -193,7 +150,8 @@ func TestUserRepo_ListIDs(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()
 	for _, id := range []string{userA, userB} {
-		u := newTestUser(vo.MustParseId(id), id[:32], "e", "U", "", "h", "s", true, fixedTime, fixedTime, nil)
+		// Email must be unique per row (lower(email) is now a unique index).
+		u := newTestUser(vo.MustParseId(id), id+"@example.test", "U", "", "h", "s", true, fixedTime, fixedTime, nil)
 		if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 			t.Fatalf("Save %s: %v", id, err)
 		}
@@ -212,7 +170,7 @@ func TestUserRepo_GetOptions(t *testing.T) {
 	ctx := context.Background()
 	val := "dark"
 	opt := model.ReconstituteUserOption(vo.MustParseId(optID), "theme", &val, fixedTime, fixedTime)
-	u := newTestUser(vo.MustParseId(userA), identA, "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, []model.UserOption{opt})
+	u := newTestUser(vo.MustParseId(userA), "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, []model.UserOption{opt})
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -230,7 +188,7 @@ func TestUserReadRepo_Views(t *testing.T) {
 	ctx := context.Background()
 	val := "light"
 	opt := model.ReconstituteUserOption(vo.MustParseId(optID), "theme", &val, fixedTime, fixedTime)
-	u := newTestUser(vo.MustParseId(userA), identA, "enc", "Alice", "https://av", "h", "s", true, fixedTime, fixedTime, []model.UserOption{opt})
+	u := newTestUser(vo.MustParseId(userA), "enc", "Alice", "https://av", "h", "s", true, fixedTime, fixedTime, []model.UserOption{opt})
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -274,7 +232,7 @@ func TestUserReadRepo_CurrencyIDByCode(t *testing.T) {
 func TestUserRepo_UpdateLanguage(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()
-	u := newTestUser(vo.MustParseId(userA), identA, "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	u := newTestUser(vo.MustParseId(userA), "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -299,7 +257,7 @@ func TestUserRepo_UpdateLanguage(t *testing.T) {
 func TestUserRepo_UpdateLanguage_DefaultsToEnglish(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()
-	u := newTestUser(vo.MustParseId(userA), identA, "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
+	u := newTestUser(vo.MustParseId(userA), "e", "Alice", "", "h", "s", true, fixedTime, fixedTime, nil)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -318,7 +276,7 @@ func TestUserRepo_AlgorithmRoundTrip(t *testing.T) {
 	ctx := context.Background()
 
 	u := newTestUser(
-		vo.MustParseId(userA), identA, "enc-email", "Alice", "https://av/a",
+		vo.MustParseId(userA), "enc-email", "Alice", "https://av/a",
 		"hash", "salt-a", true, fixedTime, fixedTime, nil,
 	)
 	u.Algorithm = model.AlgorithmArgon2id
@@ -355,7 +313,7 @@ func TestUserRepo_AccessRoundTrip(t *testing.T) {
 	ctx := context.Background()
 
 	until := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
-	u := newTestUser(vo.MustParseId(userA), identA, "enc-email", "Alice", "https://av/a",
+	u := newTestUser(vo.MustParseId(userA), "enc-email", "Alice", "https://av/a",
 		"hash", "salt-a", true, fixedTime, fixedTime, nil)
 	u.SetAccess(model.AccessLevelReadonly, &until, u.UpdatedAt)
 
@@ -379,7 +337,7 @@ func TestUserRepo_AccessDefaultsToFullWithNoExpiry(t *testing.T) {
 	repo, _, db := newRepos(t)
 	ctx := context.Background()
 
-	u := newTestUser(vo.MustParseId(userA), identA, "enc-email", "Alice", "https://av/a",
+	u := newTestUser(vo.MustParseId(userA), "enc-email", "Alice", "https://av/a",
 		"hash", "salt-a", true, fixedTime, fixedTime, nil)
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return repo.Save(ctx, u) }); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -418,7 +376,7 @@ func TestUserEmailVerifiedRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Second)
 
-	u := model.NewUser(r.NextIdentity(), "email-verified-rt", "cipher", "RT", "face:blue", "hash", "salt", now)
+	u := model.NewUser(r.NextIdentity(), "cipher", "RT", "face:blue", "hash", "salt", now)
 	if !u.EmailVerified {
 		t.Fatal("NewUser must default EmailVerified to true")
 	}
@@ -439,9 +397,9 @@ func TestUserEmailVerifiedRoundTrip(t *testing.T) {
 	if err := db.TX.WithTx(ctx, func(ctx context.Context) error { return r.Save(ctx, got) }); err != nil {
 		t.Fatalf("Save verified: %v", err)
 	}
-	again, err := r.GetByIdentifier(ctx, "email-verified-rt")
+	again, err := r.GetByID(ctx, u.ID)
 	if err != nil {
-		t.Fatalf("GetByIdentifier: %v", err)
+		t.Fatalf("GetByID: %v", err)
 	}
 	if !again.EmailVerified {
 		t.Error("MarkEmailVerified must persist")

--- a/internal/user/repo/sqlite.go
+++ b/internal/user/repo/sqlite.go
@@ -16,16 +16,6 @@ func (sqliteQuerier) GetUserByID(ctx context.Context, db backend.DBTX, id string
 	return userRow(row), err
 }
 
-func (sqliteQuerier) GetUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (userRow, error) {
-	row, err := sqlitegen.New(db).GetUserByIdentifier(ctx, identifier)
-	return userRow(row), err
-}
-
-func (sqliteQuerier) ExistsUserByIdentifier(ctx context.Context, db backend.DBTX, identifier string) (bool, error) {
-	n, err := sqlitegen.New(db).ExistsUserByIdentifier(ctx, identifier)
-	return n != 0, err
-}
-
 func (sqliteQuerier) GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error) {
 	row, err := sqlitegen.New(db).GetUserByEmail(ctx, email)
 	return userRow(row), err

--- a/internal/user/repo/sqlite.go
+++ b/internal/user/repo/sqlite.go
@@ -26,6 +26,16 @@ func (sqliteQuerier) ExistsUserByIdentifier(ctx context.Context, db backend.DBTX
 	return n != 0, err
 }
 
+func (sqliteQuerier) GetUserByEmail(ctx context.Context, db backend.DBTX, email string) (userRow, error) {
+	row, err := sqlitegen.New(db).GetUserByEmail(ctx, email)
+	return userRow(row), err
+}
+
+func (sqliteQuerier) ExistsUserByEmail(ctx context.Context, db backend.DBTX, email string) (bool, error) {
+	n, err := sqlitegen.New(db).ExistsUserByEmail(ctx, email)
+	return n != 0, err
+}
+
 func (sqliteQuerier) ListUserIDs(ctx context.Context, db backend.DBTX) ([]string, error) {
 	return sqlitegen.New(db).ListUserIDs(ctx)
 }

--- a/internal/user/repository.go
+++ b/internal/user/repository.go
@@ -27,6 +27,14 @@ type Repository interface {
 	// by registration to detect a duplicate without loading the row.
 	ExistsByIdentifier(ctx context.Context, identifier string) (bool, error)
 
+	// GetByEmail loads a user (with options) by email, case-insensitively.
+	// Missing -> *errs.NotFoundError.
+	GetByEmail(ctx context.Context, email string) (*model.User, error)
+
+	// ExistsByEmail reports whether a user with that email exists
+	// (case-insensitive). Used by registration/change-email dup-checks.
+	ExistsByEmail(ctx context.Context, email string) (bool, error)
+
 	// Save upserts the user row and its options.
 	Save(ctx context.Context, u *model.User) error
 

--- a/internal/user/repository.go
+++ b/internal/user/repository.go
@@ -19,14 +19,6 @@ type Repository interface {
 	// GetByID loads a user (with options) by id. Missing -> *errs.NotFoundError.
 	GetByID(ctx context.Context, id vo.Id) (*model.User, error)
 
-	// GetByIdentifier loads a user (with options) by the md5 identifier used for
-	// authentication. Missing -> *errs.NotFoundError.
-	GetByIdentifier(ctx context.Context, identifier string) (*model.User, error)
-
-	// ExistsByIdentifier reports whether a user with the identifier exists. Used
-	// by registration to detect a duplicate without loading the row.
-	ExistsByIdentifier(ctx context.Context, identifier string) (bool, error)
-
 	// GetByEmail loads a user (with options) by email, case-insensitively.
 	// Missing -> *errs.NotFoundError.
 	GetByEmail(ctx context.Context, email string) (*model.User, error)

--- a/internal/user/trial_integration_test.go
+++ b/internal/user/trial_integration_test.go
@@ -24,7 +24,7 @@ func (trialClock) Now() time.Time { return trialNow }
 
 func newTrialSvc(t *testing.T, db *dbtest.DB, trial string) (*appuser.Service, *userrepo.Repo, *auth.EncodeService) {
 	t.Helper()
-	enc := auth.NewEncodeService(testSalt)
+	enc := auth.NewEncodeService("")
 	hasher := auth.NewPasswordHasher()
 	repo := userrepo.NewRepo(db.Engine, db.TX)
 	tokens := userrepo.NewAccessTokenRepo(db.Engine, db.TX)

--- a/internal/user/trial_integration_test.go
+++ b/internal/user/trial_integration_test.go
@@ -38,7 +38,7 @@ func newTrialSvc(t *testing.T, db *dbtest.DB, trial string) (*appuser.Service, *
 
 func TestRegister_GrantsTrialWhenEnabled(t *testing.T) {
 	db := dbtest.New(t)
-	svc, repo, enc := newTrialSvc(t, db, "end-of-next-month")
+	svc, repo, _ := newTrialSvc(t, db, "end-of-next-month")
 	ctx := context.Background()
 
 	if _, err := svc.Register(ctx, model.RegisterRequest{
@@ -47,7 +47,7 @@ func TestRegister_GrantsTrialWhenEnabled(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("trial@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "trial@econumo.test")
 	if err != nil {
 		t.Fatalf("lookup: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestRegister_GrantsTrialWhenEnabled(t *testing.T) {
 
 func TestRegister_NoTrialByDefault(t *testing.T) {
 	db := dbtest.New(t)
-	svc, repo, enc := newTrialSvc(t, db, "none")
+	svc, repo, _ := newTrialSvc(t, db, "none")
 	ctx := context.Background()
 
 	if _, err := svc.Register(ctx, model.RegisterRequest{
@@ -74,7 +74,7 @@ func TestRegister_NoTrialByDefault(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("plain@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "plain@econumo.test")
 	if err != nil {
 		t.Fatalf("lookup: %v", err)
 	}
@@ -85,14 +85,14 @@ func TestRegister_NoTrialByDefault(t *testing.T) {
 
 func TestAdminCreateUser_NeverGrantsTrial(t *testing.T) {
 	db := dbtest.New(t)
-	svc, repo, enc := newTrialSvc(t, db, "end-of-next-month")
+	svc, repo, _ := newTrialSvc(t, db, "end-of-next-month")
 	ctx := context.Background()
 
 	if _, err := svc.AdminCreateUser(ctx, "Ops User", "ops@econumo.test", "secretpass"); err != nil {
 		t.Fatalf("AdminCreateUser: %v", err)
 	}
 
-	u, err := repo.GetByIdentifier(ctx, enc.Hash("ops@econumo.test"))
+	u, err := repo.GetByEmail(ctx, "ops@econumo.test")
 	if err != nil {
 		t.Fatalf("lookup: %v", err)
 	}

--- a/internal/user/verify_email.go
+++ b/internal/user/verify_email.go
@@ -44,7 +44,7 @@ func (s *Service) ConfirmEmail(ctx context.Context, req model.ConfirmEmailReques
 	}
 	invalid := &errs.ValidationError{Msg: "The confirmation code is not valid.", MsgCode: errs.CodeUserVerificationCodeInvalid}
 
-	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
+	u, err := s.repo.GetByEmail(ctx, lowered)
 	if err != nil {
 		if isNotFound(err) {
 			s.failAttempt(RateScopeConfirmEmail, lowered)
@@ -128,7 +128,7 @@ func (s *Service) ResendVerificationCode(ctx context.Context, req model.ResendVe
 	s.markSent(lowered)
 	fullGap := model.EmailVerificationResendGap
 
-	u, err := s.repo.GetByIdentifier(ctx, s.encode.Hash(lowered))
+	u, err := s.repo.GetByEmail(ctx, lowered)
 	if err != nil {
 		if isNotFound(err) {
 			return result, fullGap, nil // anti-enumeration

--- a/internal/user/verify_email_test.go
+++ b/internal/user/verify_email_test.go
@@ -370,7 +370,7 @@ func TestFlagOffKeepsLoginUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Flag off: users are born verified and login needs no code (and sends no email).
-	u, err := userrepo.NewRepo(db.Engine, db.TX).GetByIdentifier(ctx, auth.NewEncodeService("").Hash("legacy@econumo.test"))
+	u, err := userrepo.NewRepo(db.Engine, db.TX).GetByEmail(ctx, "legacy@econumo.test")
 	if err != nil {
 		t.Fatalf("load registered user: %v", err)
 	}


### PR DESCRIPTION
## Summary

Retires the `users.identifier` column (`hex(md5(lower(email)))`) as the user unique + auth lookup key. That column only existed because emails were once AES-encrypted with a random IV (so the ciphertext wasn't uniquely indexable). The app now runs **salt-free with plaintext emails**, so a unique index on `lower(email)` plus direct email lookups fully replace it.

**The column is retired in place, not dropped.** SQLite cannot drop a `NOT NULL UNIQUE` column without a full table rebuild (migrations run in one transaction under `foreign_keys = ON`), so instead the column is kept and repopulated with each row's own `id` — a unique, non-null placeholder no longer derived from email. This achieves the functional goal at near-zero migration risk on both engines.

## What changed

- **New key:** unique expression index `users_email_lower_uniq` on `lower(email)` (both engines). All user lookups go through `GetByEmail` / `ExistsByEmail` (`WHERE lower(email) = lower(?)`), replacing `GetByIdentifier` / `ExistsByIdentifier`.
- **Model:** `User.Identifier` removed; `NewUser` / `UpdateEmail` lose the identifier argument. The repo writes `id` into the `identifier` column on `Save`.
- **Crypto:** `EncodeService.Hash` (the md5 derivation) removed. `Encode`/`Decode` unchanged.
- **`data:remove-salt`:** no longer re-derives the identifier — it only decrypts each email to plaintext (the repo supplies `id`).
- **Migration:** `20260722000000.sql` adds the index and backfills `UPDATE users SET identifier = id`. On Postgres the column is also widened `CHAR(32)` → `TEXT` (a 36-char UUID doesn't fit the old md5 width — an in-place widening, not a rebuild).
- **Tests:** the legacy user integration harnesses are now salt-free (production parity); `migrate_test.go` keeps a local salted encoder since it tests `data:remove-salt`.
- **Docs:** CLAUDE.md, sqlc.yaml, server comments, and the v0→v1 migration note updated; upgrade note added (a still-salted instance must run `data:remove-salt` before the `lower(email)` index is relied upon — such instances are already login-broken until they migrate, so no new regression).

## Wire contract

Unchanged — `identifier` was never serialized. `apiparity` / `mcpparity` goldens are untouched.

## Testing

- `make go-test` (build, vet, gofmt, sqlite unit/integration, apiparity + mcpparity goldens unchanged, i18n guards) — **pass**, coverage 80.7% (min 78%).
- `make test-repo-pgsql` + `enginecompare` — **pass** (`lower(email)` index + lookups behave identically on SQLite and PostgreSQL).
- A whole-branch review caught one behavior regression — self-registration stored the email untrimmed while the new key is `lower(email)`, so a whitespace-padded registration email became a permanent ghost account. Fixed (register now trims before storing, matching the admin/CLI paths) with an end-to-end regression test.

## Notes

- The `identifier` column is retained (vestigial, `= id`); a future dedicated migration can physically drop it if ever desired.
- Design/plan: `docs/superpowers/specs/2026-07-22-remove-user-identifier-design.md`, `docs/superpowers/plans/2026-07-22-retire-user-identifier.md`.
- Groundwork for a follow-up **change-email** feature, which simplifies onto the email-only model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
