### PR TITLE
feat: mirror release binaries to private Cloudflare R2

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -236,9 +236,9 @@ jobs:
       # latest/ and dev/ only when their checkbox is set.
       - name: Mirror binaries to R2
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          ECONUMO_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          ECONUMO_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          ECONUMO_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           VERSION: ${{ needs.create-tag.outputs.version }}
           PUSH_LATEST: ${{ github.event.inputs.push_latest }}
           PUSH_DEV: ${{ github.event.inputs.push_dev }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -230,6 +230,23 @@ jobs:
           path: release-out/
           if-no-files-found: error
 
+      # Mirror the binaries to the private R2 bucket via the Makefile target
+      # (same upload logic as `make cdn-upload` locally). Channels gate exactly
+      # like the Docker image tags in create-tag: the version channel always,
+      # latest/ and dev/ only when their checkbox is set.
+      - name: Mirror binaries to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          VERSION: ${{ needs.create-tag.outputs.version }}
+          PUSH_LATEST: ${{ github.event.inputs.push_latest }}
+          PUSH_DEV: ${{ github.event.inputs.push_dev }}
+        run: |
+          make cdn-upload CHANNEL="$VERSION"
+          if [ "$PUSH_LATEST" = "true" ]; then make cdn-upload CHANNEL=latest; fi
+          if [ "$PUSH_DEV" = "true" ]; then make cdn-upload CHANNEL=dev; fi
+
   create-github-release:
     name: Create GitHub Release
     needs: [create-tag, publish, build-binaries]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,13 @@ upload the cross-compiled linux binaries (`econumo-linux-{amd64,arm64}` +
 fetched via the S3 API / signed URLs. In the release workflow the channels gate
 exactly like the image tags: the version channel always, `latest/` and `dev/`
 only when their checkbox is set. Endpoint + credentials come from the
-environment, never committed: `R2_ENDPOINT` (`https://<acct>.r2.cloudflarestorage.com`),
-`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — in CI the GitHub secrets
-`R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`. Local use needs the
+environment, never committed, and are `ECONUMO_`-prefixed so several projects'
+R2 targets can coexist in one shell: `ECONUMO_R2_ENDPOINT`
+(`https://<acct>.r2.cloudflarestorage.com`, required) plus optional
+`ECONUMO_R2_ACCESS_KEY_ID` / `ECONUMO_R2_SECRET_ACCESS_KEY` (mapped to `AWS_*`
+for the aws subprocess only; unset falls back to the `~/.aws` profile). In CI
+the GitHub secrets `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` are
+mapped to those `ECONUMO_R2_*` names in the step's `env:`. Local use needs the
 aws CLI installed.
 
 ### Branch naming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ make web-bundle    # cd web && pnpm build     (production SPA build -> web/dist)
 
 ```bash
 make publish-dev   # build + push the multi-arch `dev` image to ghcr.io/econumo/econumo:dev
+                   # AND mirror the `dev` binaries to the private R2 bucket
 ```
 
 Releases (`latest` + `vX.Y.Z`) are cut by the GitHub release workflow
@@ -70,6 +71,20 @@ commit as the base for future hotfixes; a hotfix dispatches from a new
 workflow then creates no branch. `latest` only moves for the highest version
 released so far. See `.claude/skills/publish-release` for the full process.
 Everything publishes to `ghcr.io/econumo/econumo` only.
+
+**R2 binary mirror.** Both `make publish-dev` and the release workflow also
+upload the cross-compiled linux binaries (`econumo-linux-{amd64,arm64}` +
+`SHA256SUMS`) to a **private** Cloudflare R2 bucket via `make cdn-upload`
+(aws S3 CLI). Keys are namespaced `s3://$(R2_BUCKET)/$(R2_PROJECT)/<channel>/`
+(defaults `econumo`/`econumo`; the bucket hosts several projects), channel ∈
+`dev` | `latest` | `vX.Y.Z`. The bucket has no public domain — objects are
+fetched via the S3 API / signed URLs. In the release workflow the channels gate
+exactly like the image tags: the version channel always, `latest/` and `dev/`
+only when their checkbox is set. Endpoint + credentials come from the
+environment, never committed: `R2_ENDPOINT` (`https://<acct>.r2.cloudflarestorage.com`),
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — in CI the GitHub secrets
+`R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`. Local use needs the
+aws CLI installed.
 
 ### Branch naming
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help web-install web-run web-test web-bundle web-lint go-build go-run go-test test-cover go-lint test test-engines test-repo-pgsql pg-ensure docker-up docker-down publish-dev publish-buildx-ensure swagger swagger-check release-binaries
+.PHONY: help web-install web-run web-test web-bundle web-lint go-build go-run go-test test-cover go-lint test test-engines test-repo-pgsql pg-ensure docker-up docker-down publish-dev publish-buildx-ensure swagger swagger-check release-binaries cdn-upload
 
 # Default target
 .DEFAULT_GOAL := help
@@ -21,12 +21,13 @@ help:
 	@echo ""
 	@echo "Releases:"
 	@echo "  make release-binaries - Cross-compile the downloadable release binaries (SPA embedded)"
+	@echo "  make cdn-upload CHANNEL=dev - Mirror release-out/ binaries to the private R2 bucket (needs R2_ENDPOINT + AWS creds)"
 	@echo ""
 	@echo "Suite & stack:"
 	@echo "  make test         - ALL tests: Go smoke + sqlite-vs-pgsql regression + frontend"
 	@echo "  make docker-up    - Start the stack (compose, builds from source)"
 	@echo "  make docker-down  - Stop the stack"
-	@echo "  make publish-dev  - Build + push the multi-arch 'dev' image to $(GHCR_IMAGE)"
+	@echo "  make publish-dev  - Build + push the multi-arch 'dev' image to $(GHCR_IMAGE) + mirror dev binaries to R2"
 
 # --- Frontend (web/) ---
 
@@ -247,8 +248,9 @@ publish-buildx-ensure:
 		docker buildx create --name $(BUILDX_BUILDER) --driver docker-container --bootstrap
 
 # Regenerates the OpenAPI docs (swagger) first so the image built from source
-# embeds the current spec.
-publish-dev: swagger publish-buildx-ensure
+# embeds the current spec. Also cross-compiles the release binaries and mirrors
+# the "dev" channel to the private R2 bucket (see cdn-upload).
+publish-dev: swagger publish-buildx-ensure release-binaries
 	@echo "Publishing $(GHCR_IMAGE):$(PUBLISH_TAG) ($(PUBLISH_PLATFORMS))..."
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
@@ -259,3 +261,41 @@ publish-dev: swagger publish-buildx-ensure
 		--tag $(GHCR_IMAGE):$(PUBLISH_TAG) \
 		--push \
 		.
+	@$(MAKE) cdn-upload CHANNEL=dev
+
+# --- Cloudflare R2 binary mirror -------------------------------------------
+
+# Mirror the built release binaries to the PRIVATE R2 bucket under
+# s3://$(R2_BUCKET)/$(R2_PROJECT)/$(CHANNEL)/. The bucket has no public domain;
+# objects are retrieved via the S3 API / signed URLs by credential holders.
+# The bucket + project namespace are hardcoded defaults (the bucket hosts
+# several projects); the endpoint and credentials come from the environment and
+# are never committed:
+#   R2_ENDPOINT            https://<account_id>.r2.cloudflarestorage.com (required)
+#   AWS_ACCESS_KEY_ID      R2 API-token access key id
+#   AWS_SECRET_ACCESS_KEY  R2 API-token secret
+# CHANNEL is required (dev | latest | vX.Y.Z). Usage:
+#   make cdn-upload CHANNEL=dev
+R2_BUCKET  ?= econumo
+R2_PROJECT ?= econumo
+CDN_SRC    ?= release-out
+
+# aws CLI v2 sends integrity headers R2 rejects; only send them when required.
+export AWS_REQUEST_CHECKSUM_CALCULATION = when_required
+
+cdn-upload:
+	@test -n "$(CHANNEL)" || { echo "cdn-upload: set CHANNEL (dev|latest|vX.Y.Z)"; exit 1; }
+	@test -n "$$R2_ENDPOINT" || { echo "cdn-upload: R2_ENDPOINT is required (https://<account_id>.r2.cloudflarestorage.com)"; exit 1; }
+	@case "$(CHANNEL)" in \
+		dev|latest) cache="no-cache" ;; \
+		*) cache="public, max-age=31536000, immutable" ;; \
+	esac; \
+	dest="s3://$(R2_BUCKET)/$(R2_PROJECT)/$(CHANNEL)"; \
+	for f in econumo-linux-amd64 econumo-linux-arm64 SHA256SUMS; do \
+		echo "Uploading $$f -> $$dest/$$f"; \
+		aws s3 cp "$(CDN_SRC)/$$f" "$$dest/$$f" \
+			--endpoint-url "$$R2_ENDPOINT" \
+			--content-type application/octet-stream \
+			--cache-control "$$cache" || exit 1; \
+	done; \
+	echo "Uploaded channel '$(CHANNEL)' to $$dest/"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 	@echo ""
 	@echo "Releases:"
 	@echo "  make release-binaries - Cross-compile the downloadable release binaries (SPA embedded)"
-	@echo "  make cdn-upload CHANNEL=dev - Mirror release-out/ binaries to the private R2 bucket (needs R2_ENDPOINT + AWS creds)"
+	@echo "  make cdn-upload CHANNEL=dev - Mirror release-out/ binaries to the private R2 bucket (needs ECONUMO_R2_ENDPOINT [+ ECONUMO_R2_* creds])"
 	@echo ""
 	@echo "Suite & stack:"
 	@echo "  make test         - ALL tests: Go smoke + sqlite-vs-pgsql regression + frontend"
@@ -270,11 +270,15 @@ publish-dev: swagger publish-buildx-ensure release-binaries
 # objects are retrieved via the S3 API / signed URLs by credential holders.
 # The bucket + project namespace are hardcoded defaults (the bucket hosts
 # several projects); the endpoint and credentials come from the environment and
-# are never committed:
-#   R2_ENDPOINT            https://<account_id>.r2.cloudflarestorage.com (required)
-#   AWS_ACCESS_KEY_ID      R2 API-token access key id
-#   AWS_SECRET_ACCESS_KEY  R2 API-token secret
-# CHANNEL is required (dev | latest | vX.Y.Z). Usage:
+# are never committed. The names are ECONUMO_-prefixed so several projects'
+# R2 endpoints/keys can coexist in one shell without colliding:
+#   ECONUMO_R2_ENDPOINT          https://<account_id>.r2.cloudflarestorage.com (required)
+#   ECONUMO_R2_ACCESS_KEY_ID     R2 API-token access key id (optional)
+#   ECONUMO_R2_SECRET_ACCESS_KEY R2 API-token secret        (optional)
+# The two credential vars are optional: when both are set they are mapped to
+# AWS_* for the aws subprocess only; when unset, aws falls back to its own
+# resolution (e.g. the ~/.aws default profile). CHANNEL is required
+# (dev | latest | vX.Y.Z). Usage:
 #   make cdn-upload CHANNEL=dev
 R2_BUCKET  ?= econumo
 R2_PROJECT ?= econumo
@@ -285,8 +289,11 @@ export AWS_REQUEST_CHECKSUM_CALCULATION = when_required
 
 cdn-upload:
 	@test -n "$(CHANNEL)" || { echo "cdn-upload: set CHANNEL (dev|latest|vX.Y.Z)"; exit 1; }
-	@test -n "$$R2_ENDPOINT" || { echo "cdn-upload: R2_ENDPOINT is required (https://<account_id>.r2.cloudflarestorage.com)"; exit 1; }
-	@case "$(CHANNEL)" in \
+	@test -n "$$ECONUMO_R2_ENDPOINT" || { echo "cdn-upload: ECONUMO_R2_ENDPOINT is required (https://<account_id>.r2.cloudflarestorage.com)"; exit 1; }
+	@if [ -n "$$ECONUMO_R2_ACCESS_KEY_ID" ] && [ -n "$$ECONUMO_R2_SECRET_ACCESS_KEY" ]; then \
+		export AWS_ACCESS_KEY_ID="$$ECONUMO_R2_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$ECONUMO_R2_SECRET_ACCESS_KEY"; \
+	fi; \
+	case "$(CHANNEL)" in \
 		dev|latest) cache="no-cache" ;; \
 		*) cache="public, max-age=31536000, immutable" ;; \
 	esac; \
@@ -294,7 +301,7 @@ cdn-upload:
 	for f in econumo-linux-amd64 econumo-linux-arm64 SHA256SUMS; do \
 		echo "Uploading $$f -> $$dest/$$f"; \
 		aws s3 cp "$(CDN_SRC)/$$f" "$$dest/$$f" \
-			--endpoint-url "$$R2_ENDPOINT" \
+			--endpoint-url "$$ECONUMO_R2_ENDPOINT" \
 			--content-type application/octet-stream \
 			--cache-control "$$cache" || exit 1; \
 	done; \

--- a/docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md
+++ b/docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md
@@ -7,7 +7,8 @@
 
 Release binaries (`econumo-linux-amd64`, `econumo-linux-arm64`, `SHA256SUMS`)
 are attached only to GitHub Releases today. We want them additionally mirrored
-to a Cloudflare R2 bucket, served publicly from `cdn.econumo.com`, addressable
+to a **private** Cloudflare R2 bucket (no public custom domain — objects are
+retrieved via the S3 API / signed URLs by credential holders), addressable
 by channel:
 
 - per version — `vX.Y.Z`
@@ -22,9 +23,10 @@ And `make publish-dev` — which today only builds and pushes the multi-arch
 | Choice | Value |
 |---|---|
 | Upload tool | `aws` S3 CLI (S3-compatible R2 API). Preinstalled on GitHub runners; assumed present locally. |
-| Key layout | `s3://<bucket>/<channel>/econumo-linux-{amd64,arm64}` + `SHA256SUMS`, one `SHA256SUMS` per channel prefix. |
+| Key layout | `s3://<bucket>/<project>/<channel>/econumo-linux-{amd64,arm64}` + `SHA256SUMS`, one `SHA256SUMS` per channel prefix. |
+| Project | `econumo` — hardcoded default, overridable via `R2_PROJECT`. Namespaces the bucket so it can host multiple projects. |
 | Channel | `dev` \| `latest` \| `vX.Y.Z` |
-| Public base URL | `https://cdn.econumo.com` → `https://cdn.econumo.com/<channel>/econumo-linux-amd64` |
+| Bucket visibility | **Private** — no public custom domain; retrieved via the S3 API / signed URLs by credential holders. |
 | Bucket | `econumo` — hardcoded default, overridable via `R2_BUCKET` |
 | Endpoint | `R2_ENDPOINT` from env/secret (`https://<account_id>.r2.cloudflarestorage.com`) — never committed |
 | Credentials | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from env/secrets |
@@ -36,8 +38,8 @@ The Makefile and the workflow share one interface:
 - `R2_ENDPOINT` — required for any upload; `https://<account_id>.r2.cloudflarestorage.com`.
 - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — R2 API-token credentials.
 - `R2_BUCKET ?= econumo` — hardcoded default, overridable.
-- `CDN_BASE_URL ?= https://cdn.econumo.com` — hardcoded default, used only to print
-  human-readable download URLs after upload.
+- `R2_PROJECT ?= econumo` — project namespace under the bucket, overridable.
+- `CDN_SRC ?= release-out` — directory holding the built binaries + `SHA256SUMS`.
 
 New GitHub Actions secrets: `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`,
 `R2_SECRET_ACCESS_KEY` (the latter two mapped to the `AWS_*` env names inside
@@ -50,17 +52,16 @@ the upload step).
 Parameterized by `CHANNEL` (required) and `SRC` (defaults `release-out`).
 Behavior:
 
-1. Fail with a clear message if `R2_ENDPOINT` is empty.
-2. Upload `$(SRC)/econumo-linux-amd64`, `$(SRC)/econumo-linux-arm64`, and
-   `$(SRC)/SHA256SUMS` to `s3://$(R2_BUCKET)/$(CHANNEL)/` using
+1. Fail with a clear message if `CHANNEL` is empty or `R2_ENDPOINT` is empty.
+2. Upload `$(CDN_SRC)/econumo-linux-amd64`, `$(CDN_SRC)/econumo-linux-arm64`, and
+   `$(CDN_SRC)/SHA256SUMS` to `s3://$(R2_BUCKET)/$(R2_PROJECT)/$(CHANNEL)/` using
    `aws s3 cp --endpoint-url $(R2_ENDPOINT) --content-type application/octet-stream`.
 3. Cache headers: `--cache-control "no-cache"` for `dev`/`latest`,
    `--cache-control "public, max-age=31536000, immutable"` for a `vX.Y.Z` channel.
-4. Print the resulting `$(CDN_BASE_URL)/$(CHANNEL)/...` URLs.
+4. Print the `s3://$(R2_BUCKET)/$(R2_PROJECT)/$(CHANNEL)/` destination.
 
-Sets `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` (or
-`--checksum-algorithm CRC32`) so the aws CLI v2 default integrity headers that
-R2 rejects are not sent.
+Exports `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` so the aws CLI v2
+default integrity headers that R2 rejects are not sent.
 
 ### `publish-dev`
 
@@ -72,13 +73,16 @@ duplication for a local dev-publish.)
 
 ## Release workflow changes (`.github/workflows/publish-release.yml`)
 
-In the existing `build-binaries` job, after the `sha256sum` step, add upload
-step(s) that run the aws CLI with the three R2 secrets in env
-(`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`R2_ENDPOINT`):
+In the existing `build-binaries` job, after the `sha256sum` step, add one
+upload step with the three R2 secrets in env
+(`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`R2_ENDPOINT`) that reuses the
+Makefile target (DRY — same upload logic as local):
 
-- **Always** upload `s3://econumo/${VERSION}/` (immutable cache).
-- Upload `latest/` **only when** `push_latest == 'true'` (no-cache).
-- Upload `dev/` **only when** `push_dev == 'true'` (no-cache).
+```sh
+make cdn-upload CHANNEL="$VERSION"                                  # always
+[ "$PUSH_LATEST" = "true" ] && make cdn-upload CHANNEL=latest       # gated
+[ "$PUSH_DEV" = "true" ]    && make cdn-upload CHANNEL=dev          # gated
+```
 
 This mirrors exactly how the Docker image tags already gate in the `create-tag`
 job. The upload reuses the `release-out/` directory already produced in the
@@ -86,9 +90,8 @@ job; the same three files go to each selected channel prefix.
 
 ## Documentation
 
-- `docs/run-without-docker.md`: mention the CDN mirror
-  (`https://cdn.econumo.com/latest/econumo-linux-amd64`) as an alternative to
-  the GitHub release download.
+- No user-facing docs change: the bucket is private, so `docs/run-without-docker.md`
+  keeps pointing at the public GitHub release download.
 - No `.env.example` change: `R2_*` are build/publish-time credentials, not
   runtime server config.
 
@@ -101,7 +104,7 @@ job; the same three files go to each selected channel prefix.
 
 ## Out of scope
 
-- Creating the R2 bucket, API token, and `cdn.econumo.com` custom domain
-  (assumed to exist / provisioned by the maintainer).
+- Creating the R2 bucket and API token (assumed to exist / provisioned by the
+  maintainer). The bucket stays private — no custom domain / public access.
 - Updating the `econumo.com/releases/latest.json` update feed (separate system).
 - Windows/macOS binaries (only linux amd64/arm64 are built today).

--- a/docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md
+++ b/docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md
@@ -1,0 +1,107 @@
+# Publish release binaries to Cloudflare R2 (CDN)
+
+**Date:** 2026-07-22
+**Status:** Approved (design)
+
+## Problem
+
+Release binaries (`econumo-linux-amd64`, `econumo-linux-arm64`, `SHA256SUMS`)
+are attached only to GitHub Releases today. We want them additionally mirrored
+to a Cloudflare R2 bucket, served publicly from `cdn.econumo.com`, addressable
+by channel:
+
+- per version — `vX.Y.Z`
+- `latest`
+- `dev`
+
+And `make publish-dev` — which today only builds and pushes the multi-arch
+`:dev` Docker image — should also upload the `dev` binaries to the CDN.
+
+## Decisions
+
+| Choice | Value |
+|---|---|
+| Upload tool | `aws` S3 CLI (S3-compatible R2 API). Preinstalled on GitHub runners; assumed present locally. |
+| Key layout | `s3://<bucket>/<channel>/econumo-linux-{amd64,arm64}` + `SHA256SUMS`, one `SHA256SUMS` per channel prefix. |
+| Channel | `dev` \| `latest` \| `vX.Y.Z` |
+| Public base URL | `https://cdn.econumo.com` → `https://cdn.econumo.com/<channel>/econumo-linux-amd64` |
+| Bucket | `econumo` — hardcoded default, overridable via `R2_BUCKET` |
+| Endpoint | `R2_ENDPOINT` from env/secret (`https://<account_id>.r2.cloudflarestorage.com`) — never committed |
+| Credentials | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from env/secrets |
+
+## Config surface
+
+The Makefile and the workflow share one interface:
+
+- `R2_ENDPOINT` — required for any upload; `https://<account_id>.r2.cloudflarestorage.com`.
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — R2 API-token credentials.
+- `R2_BUCKET ?= econumo` — hardcoded default, overridable.
+- `CDN_BASE_URL ?= https://cdn.econumo.com` — hardcoded default, used only to print
+  human-readable download URLs after upload.
+
+New GitHub Actions secrets: `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY` (the latter two mapped to the `AWS_*` env names inside
+the upload step).
+
+## Makefile changes
+
+### New internal target `cdn-upload`
+
+Parameterized by `CHANNEL` (required) and `SRC` (defaults `release-out`).
+Behavior:
+
+1. Fail with a clear message if `R2_ENDPOINT` is empty.
+2. Upload `$(SRC)/econumo-linux-amd64`, `$(SRC)/econumo-linux-arm64`, and
+   `$(SRC)/SHA256SUMS` to `s3://$(R2_BUCKET)/$(CHANNEL)/` using
+   `aws s3 cp --endpoint-url $(R2_ENDPOINT) --content-type application/octet-stream`.
+3. Cache headers: `--cache-control "no-cache"` for `dev`/`latest`,
+   `--cache-control "public, max-age=31536000, immutable"` for a `vX.Y.Z` channel.
+4. Print the resulting `$(CDN_BASE_URL)/$(CHANNEL)/...` URLs.
+
+Sets `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` (or
+`--checksum-algorithm CRC32`) so the aws CLI v2 default integrity headers that
+R2 rejects are not sent.
+
+### `publish-dev`
+
+Gains a `release-binaries` prerequisite invoked with `VERSION=dev`, then runs
+`cdn-upload CHANNEL=dev`. Net effect: `make publish-dev` pushes the `:dev`
+image **and** uploads the `dev/` binaries to the CDN. (Building the binaries
+runs the SPA build a second time vs. the buildx image build — acceptable
+duplication for a local dev-publish.)
+
+## Release workflow changes (`.github/workflows/publish-release.yml`)
+
+In the existing `build-binaries` job, after the `sha256sum` step, add upload
+step(s) that run the aws CLI with the three R2 secrets in env
+(`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`R2_ENDPOINT`):
+
+- **Always** upload `s3://econumo/${VERSION}/` (immutable cache).
+- Upload `latest/` **only when** `push_latest == 'true'` (no-cache).
+- Upload `dev/` **only when** `push_dev == 'true'` (no-cache).
+
+This mirrors exactly how the Docker image tags already gate in the `create-tag`
+job. The upload reuses the `release-out/` directory already produced in the
+job; the same three files go to each selected channel prefix.
+
+## Documentation
+
+- `docs/run-without-docker.md`: mention the CDN mirror
+  (`https://cdn.econumo.com/latest/econumo-linux-amd64`) as an alternative to
+  the GitHub release download.
+- No `.env.example` change: `R2_*` are build/publish-time credentials, not
+  runtime server config.
+
+## Testing / verification
+
+- No Go or frontend code changes → no unit/integration/parity impact.
+- Manual verification of the aws command shape (dry echo of the composed
+  commands); a real end-to-end upload requires live R2 credentials held by the
+  maintainer and is out of scope for automated tests.
+
+## Out of scope
+
+- Creating the R2 bucket, API token, and `cdn.econumo.com` custom domain
+  (assumed to exist / provisioned by the maintainer).
+- Updating the `econumo.com/releases/latest.json` update feed (separate system).
+- Windows/macOS binaries (only linux amd64/arm64 are built today).

--- a/docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md
+++ b/docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md
@@ -35,15 +35,22 @@ And `make publish-dev` — which today only builds and pushes the multi-arch
 
 The Makefile and the workflow share one interface:
 
-- `R2_ENDPOINT` — required for any upload; `https://<account_id>.r2.cloudflarestorage.com`.
-- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — R2 API-token credentials.
+Credential/endpoint names are `ECONUMO_`-prefixed (matching the repo's env
+convention) so several projects' R2 endpoints/keys can coexist in one shell
+without colliding:
+
+- `ECONUMO_R2_ENDPOINT` — required for any upload; `https://<account_id>.r2.cloudflarestorage.com`.
+- `ECONUMO_R2_ACCESS_KEY_ID` / `ECONUMO_R2_SECRET_ACCESS_KEY` — R2 API-token
+  credentials. **Optional**: when both are set they are mapped to `AWS_*` for
+  the `aws` subprocess only; when unset, aws falls back to its own resolution
+  (e.g. the `~/.aws` default profile).
 - `R2_BUCKET ?= econumo` — hardcoded default, overridable.
 - `R2_PROJECT ?= econumo` — project namespace under the bucket, overridable.
 - `CDN_SRC ?= release-out` — directory holding the built binaries + `SHA256SUMS`.
 
-New GitHub Actions secrets: `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`,
-`R2_SECRET_ACCESS_KEY` (the latter two mapped to the `AWS_*` env names inside
-the upload step).
+GitHub Actions secrets: `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`
+(per-repo, so no cross-project collision there), mapped in the upload step's
+`env:` to the `ECONUMO_R2_*` names the Makefile reads.
 
 ## Makefile changes
 
@@ -52,7 +59,7 @@ the upload step).
 Parameterized by `CHANNEL` (required) and `SRC` (defaults `release-out`).
 Behavior:
 
-1. Fail with a clear message if `CHANNEL` is empty or `R2_ENDPOINT` is empty.
+1. Fail with a clear message if `CHANNEL` is empty or `ECONUMO_R2_ENDPOINT` is empty.
 2. Upload `$(CDN_SRC)/econumo-linux-amd64`, `$(CDN_SRC)/econumo-linux-arm64`, and
    `$(CDN_SRC)/SHA256SUMS` to `s3://$(R2_BUCKET)/$(R2_PROJECT)/$(CHANNEL)/` using
    `aws s3 cp --endpoint-url $(R2_ENDPOINT) --content-type application/octet-stream`.
@@ -74,9 +81,9 @@ duplication for a local dev-publish.)
 ## Release workflow changes (`.github/workflows/publish-release.yml`)
 
 In the existing `build-binaries` job, after the `sha256sum` step, add one
-upload step with the three R2 secrets in env
-(`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`R2_ENDPOINT`) that reuses the
-Makefile target (DRY — same upload logic as local):
+upload step with the three R2 secrets in env (mapped to
+`ECONUMO_R2_ENDPOINT`/`ECONUMO_R2_ACCESS_KEY_ID`/`ECONUMO_R2_SECRET_ACCESS_KEY`)
+that reuses the Makefile target (DRY — same upload logic as local):
 
 ```sh
 make cdn-upload CHANNEL="$VERSION"                                  # always


### PR DESCRIPTION
## What

Mirror the cross-compiled linux release binaries (`econumo-linux-{amd64,arm64}` + `SHA256SUMS`) to a **private** Cloudflare R2 bucket, addressable by channel — per-version, `latest`, and `dev`.

- **`make publish-dev`** now also cross-compiles the binaries and uploads the `dev` channel to R2 (in addition to pushing the `:dev` image).
- **`publish-release.yml`** uploads the `vX.Y.Z` channel on every release, and `latest/` / `dev/` only when their checkbox is set — gating that mirrors the Docker image tags.

## Key layout

```
s3://$(R2_BUCKET)/$(R2_PROJECT)/<channel>/econumo-linux-amd64
```

Both `R2_BUCKET` and `R2_PROJECT` default to `econumo`, so the same private bucket can host multiple projects under their own top-level prefix. Channel ∈ `dev` | `latest` | `vX.Y.Z`. Bucket is private — no public domain; objects are fetched via the S3 API / signed URLs.

## Implementation

- New `cdn-upload` Makefile target (aws S3 CLI): `no-cache` for `dev`/`latest`, immutable cache for version channels; sets `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` so R2 accepts the upload. Reused by CI (DRY).
- Endpoint + credentials come from env/secrets, never committed.

## Config required before use

- Create the private R2 bucket `econumo` + an API token.
- GitHub secrets: `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`.
- Local `make publish-dev` needs the aws CLI + `R2_ENDPOINT` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the environment.

## Testing

No Go/frontend code changes. Verified: Makefile guards (missing `CHANNEL` / `R2_ENDPOINT`), correct key + cache-control shape via dry-run, env-supplied `R2_ENDPOINT` satisfies the guard, workflow YAML parses. A real end-to-end upload needs live R2 credentials (not available in this environment).

Design spec: `docs/superpowers/specs/2026-07-22-r2-binary-cdn-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)