### PR TITLE
feat: append app link to all transactional emails via ECONUMO_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ ECONUMO_ALLOW_REGISTRATION=true
 # (`make web-run`, a separate port) set its origin explicitly, e.g.:
 # ECONUMO_CORS_ALLOW_ORIGIN=http://localhost:9000
 
+# Optional: this instance's public URL. When set, it is appended as a link at
+# the bottom of every transactional email (password reset, verification, email
+# change) so recipients can get back to the app. Must be an absolute http(s) URL
+# ECONUMO_URL=https://money.example.com
+
 # Optional: set ECONUMO_CHECK_UPDATES=false to disable the daily check for new
 # Econumo releases (a single request from the server to econumo.com).
 # ECONUMO_CHECK_UPDATES=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,12 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `POST /api/v1/user/create-billing-link` returns 400 and the SPA shows no billing UI.
   Merged into the served `econumo-config.js` as `BILLING_URL`, so one variable drives
   both halves. Requires `ECONUMO_ADMIN_TOKEN` (the signing key).
+- `ECONUMO_URL` — this instance's public URL. When set, `mailer.WithAppLink` wraps the
+  mail transport once at composition time (`server.BuildAPI` and the CLI container) so
+  every transactional email ends with the bare URL on its own line; unset (default) leaves
+  bodies byte-for-byte unchanged (the wrapper is not installed). Must be an absolute
+  http(s) URL — plain http is allowed (unlike `ECONUMO_BILLING_URL`, an app link carries no
+  signed token). Not a translatable string, so it touches no `emails.*` catalogue key.
 - `ECONUMO_CORS_ALLOW_ORIGIN` — comma-separated cross-origin allowlist. Empty (default) = same-domain
   only (no `Access-Control-Allow-Origin` emitted; the bundled SPA and API share an origin so it
   just works). A configured origin is reflected back with `Vary: Origin`; `*` allows any origin.

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -73,7 +73,11 @@ func newContainer(ctx context.Context) (*container, error) {
 	passwordReqRepo := userrepo.NewPasswordRequestRepo(cfg.DatabaseDriver, txm)
 	emailVerificationRepo := userrepo.NewEmailVerificationRepo(cfg.DatabaseDriver, txm)
 	emailChangeRepo := userrepo.NewEmailChangeRequestRepo(cfg.DatabaseDriver, txm)
-	resetMailer := mailer.NewResetSender(mailer.New(cfg.MailProvider, cfg.MailAPIKey), cfg.MailFrom, cfg.MailReplyTo)
+	mailTransport := mailer.Mailer(mailer.New(cfg.MailProvider, cfg.MailAPIKey))
+	if cfg.AppURL != "" {
+		mailTransport = mailer.WithAppLink(mailTransport, cfg.AppURL)
+	}
+	resetMailer := mailer.NewResetSender(mailTransport, cfg.MailFrom, cfg.MailReplyTo)
 	userSvc := appuser.NewService(
 		userRepo, txm, encodeSvc, hasher, accessTokens, currencyLookup, budgetExistence,
 		passwordReqRepo, resetMailer, emailVerificationRepo, nil,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	AdminPort  string // ECONUMO_ADMIN_PORT
 	AdminToken string // ECONUMO_ADMIN_TOKEN: bearer credential AND handoff HMAC key
 	BillingURL string // ECONUMO_BILLING_URL: payment portal; empty disables billing
+	AppURL     string // ECONUMO_URL: this instance's public URL; when set, appended as a link to every email
 
 	// Auth brute-force protection (see the 2026-07-09 auth-rate-limiting spec).
 	// Counts are attempts per key per RateLimitWindow; 0 disables a check.
@@ -175,6 +176,16 @@ func Load() (Config, error) {
 			return Config{}, fmt.Errorf("ECONUMO_BILLING_URL requires ECONUMO_ADMIN_TOKEN (the handoff signing key)")
 		}
 		c.BillingURL = v
+	}
+
+	if v := os.Getenv("ECONUMO_URL"); v != "" {
+		u, err := url.Parse(v)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return Config{}, fmt.Errorf("ECONUMO_URL: not an absolute http(s) URL: %q", v)
+		}
+		// Unlike ECONUMO_BILLING_URL this carries no signed token, so plain http
+		// stays allowed for LAN self-hosters.
+		c.AppURL = v
 	}
 
 	allowCustomAPI, err := getBoolOptional("ECONUMO_ALLOW_CUSTOM_API")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -390,6 +390,47 @@ func TestLoad_BillingURLAccepted(t *testing.T) {
 	}
 }
 
+func TestLoad_AppURL(t *testing.T) {
+	// Both http and https are accepted (no signed token in an app link, so no
+	// https-for-remote-hosts rule), and the value is stored verbatim.
+	for _, v := range []string{"https://money.example.test", "http://192.168.1.10:8181"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+			t.Setenv("ECONUMO_URL", v)
+			c, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.AppURL != v {
+				t.Fatalf("AppURL = %q, want %q", c.AppURL, v)
+			}
+		})
+	}
+
+	// Unset leaves it empty (no link appended to emails).
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+		c, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c.AppURL != "" {
+			t.Fatalf("AppURL = %q, want empty", c.AppURL)
+		}
+	})
+
+	// A relative or scheme-less value fails at boot.
+	for _, v := range []string{"/app", "money.example.test", "ftp://x.test"} {
+		t.Run("reject "+v, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+			t.Setenv("ECONUMO_URL", v)
+			if _, err := Load(); err == nil {
+				t.Fatalf("ECONUMO_URL=%q must fail at boot", v)
+			}
+		})
+	}
+}
+
 // The billing URL is followed by users' browsers carrying the signed handoff
 // token in the query string; a remote http portal would expose tokens in
 // transit. Loopback stays allowed so portal development against a real

--- a/internal/infra/mailer/mailer.go
+++ b/internal/infra/mailer/mailer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/resend/resend-go/v3"
 )
@@ -45,6 +46,24 @@ func New(provider, apiKey string) Mailer {
 	default:
 		return console{out: os.Stdout}
 	}
+}
+
+// WithAppLink wraps a Mailer so every message body ends with the instance's
+// public URL (ECONUMO_URL) on its own line. Applied once at composition time,
+// it covers every current and future email without per-sender plumbing; when
+// the URL is unset the wrapper is not installed, so bodies are unchanged.
+func WithAppLink(inner Mailer, appURL string) Mailer {
+	return linkMailer{inner: inner, appURL: appURL}
+}
+
+type linkMailer struct {
+	inner  Mailer
+	appURL string
+}
+
+func (m linkMailer) Send(ctx context.Context, msg Message) error {
+	msg.Text = strings.TrimRight(msg.Text, "\n") + "\n\n" + m.appURL
+	return m.inner.Send(ctx, msg)
 }
 
 // console renders each message to out (stdout in production) instead of sending

--- a/internal/infra/mailer/mailer_test.go
+++ b/internal/infra/mailer/mailer_test.go
@@ -100,6 +100,29 @@ func TestResetEmailEnglishUnchanged(t *testing.T) {
 	}
 }
 
+func TestWithAppLink(t *testing.T) {
+	c := &captureMailer{}
+	m := WithAppLink(c, "https://money.example.com")
+
+	// A body with a trailing newline (reset/verify shape) gets exactly one
+	// blank line before the bare URL.
+	if err := m.Send(context.Background(), Message{Text: "line one\nfooter\n"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if want := "line one\nfooter\n\nhttps://money.example.com"; c.msg.Text != want {
+		t.Fatalf("trailing-newline body:\n%q\nwant:\n%q", c.msg.Text, want)
+	}
+
+	// A body with no trailing newline (change-email shape) gets the same
+	// single blank-line separator.
+	if err := m.Send(context.Background(), Message{Text: "no footer here"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if want := "no footer here\n\nhttps://money.example.com"; c.msg.Text != want {
+		t.Fatalf("no-newline body:\n%q\nwant:\n%q", c.msg.Text, want)
+	}
+}
+
 func TestResetEmailRussian(t *testing.T) {
 	ctx := reqctx.WithLanguage(context.Background(), "ru")
 	msg := sendResetCapture(t, ctx, "u@example.test", "Алиса", "123456")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,6 +129,9 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 	if mailTransport == nil {
 		mailTransport = mailer.New(cfg.MailProvider, cfg.MailAPIKey)
 	}
+	if cfg.AppURL != "" {
+		mailTransport = mailer.WithAppLink(mailTransport, cfg.AppURL)
+	}
 	resetMailer := mailer.NewResetSender(mailTransport, cfg.MailFrom, cfg.MailReplyTo)
 	verifyMailer := mailer.NewVerifySender(mailTransport, cfg.MailFrom, cfg.MailReplyTo)
 	changeMailer := mailer.NewChangeEmailSender(mailTransport, cfg.MailFrom, cfg.MailReplyTo)


### PR DESCRIPTION
## Summary

Adds an optional `ECONUMO_URL` env var carrying the instance's public URL. When set, every transactional email (password reset, email verification, email change) ends with the URL on its own line so recipients can get back to the app. Unset (the default) leaves email bodies **byte-for-byte unchanged**.

## How it works

- **Config** (`internal/config/config.go`): new optional `AppURL` field from `ECONUMO_URL`, validated as an absolute `http(s)` URL with a host. Plain http is allowed — unlike `ECONUMO_BILLING_URL`, an app link carries no signed token, so LAN self-hosters on http work.
- **Rendering** (`internal/infra/mailer/mailer.go`): a `WithAppLink` decorator wraps the `Mailer` once at composition time and appends the bare URL as a footer line (`TrimRight(body, "\n") + "\n\n" + url`). One choke point covers all current emails and any future one — no per-sender plumbing.
- **Wiring** (`server.go`, `cli/container.go`): the wrapper is installed only when `ECONUMO_URL` is set.
- **No i18n change**: a bare URL isn't translatable, so no `emails.*` catalogue keys or guards are touched.

Rendered reset email with `ECONUMO_URL=https://money.example.com`:

```
...
--
Econumo — Manage money. Together.

https://money.example.com
```

## Tests

- `TestWithAppLink` — trailing-newline (reset/verify) and no-newline (change-email) body shapes both get a single blank-line separator before the URL.
- `TestLoad_AppURL` — http and https accepted, unset stays empty, relative/scheme-less values rejected at boot.
- Full `make go-test` smoke tier passes at 80.5% coverage (gate 78%).

## Docs

- `ECONUMO_URL` documented in `.env.example` and `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)