### PR TITLE
feat(user): ECONUMO_TRIAL as a day count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,9 +349,12 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   database has unreadable emails, so those users cannot log in (the intended push to migrate);
   `serve` logs a WARN at boot while it is set.
 - `ECONUMO_ALLOW_REGISTRATION` — enable/disable the register endpoint.
-- `ECONUMO_TRIAL` — access granted to a newly registered user: `none` (default, no
-  access grant) or `end-of-next-month` (full access until the first of the month
-  after next). Malformed values fail at boot. See `user:set-access` / `user:show`
+- `ECONUMO_TRIAL` — trial length in DAYS for a newly self-registered user. `0`
+  (default; also `none`/empty) grants no trial, so the user keeps permanent full
+  access — the self-hosted default. A positive integer `N` grants full access
+  until `N` days after registration, after which they lapse to `readonly`.
+  Negative, non-numeric, or the old `end-of-next-month` literal fail at boot.
+  CLI-created users never get a trial. See `user:set-access` / `user:show`
   below and the 402 rule in API conventions for how access is enforced afterward.
 - `ECONUMO_EMAIL_VERIFICATION` — require newly registered users to confirm an emailed
   code at login before their first session (default `false`; strict boolean, malformed

--- a/docs/superpowers/specs/2026-07-23-trial-days-config-design.md
+++ b/docs/superpowers/specs/2026-07-23-trial-days-config-design.md
@@ -1,0 +1,86 @@
+# ECONUMO_TRIAL as a day count
+
+## Problem
+
+`ECONUMO_TRIAL` today accepts two literals: `none` (default) and
+`end-of-next-month`. `none` sets no access expiry, so a newly registered user
+keeps their default `AccessLevelFull` forever — permanent full access.
+`end-of-next-month` time-boxes the grant: it calls `SetAccess(full, until)` with
+`until` = the first instant of the month after next, after which
+`EffectiveAccessLevel` collapses the user to `readonly` (402 on writes).
+
+We want the trial length to be configurable as a **number of days** instead of a
+fixed calendar span, while keeping the self-hosted default of permanent full
+access.
+
+## Semantics
+
+`ECONUMO_TRIAL` becomes an integer day count:
+
+- unset / empty / `0` / `none` (case-insensitive) → `0` → **no grant**. The new
+  user keeps the default `AccessLevelFull` with no expiry = permanent full
+  access. This is the default, so self-hosters get full access out of the box.
+- positive integer `N` → an **N-day trial**: full access from registration,
+  lapsing to `readonly` `N` days later.
+- anything else — a negative integer, a non-numeric string, or the removed
+  `end-of-next-month` literal — **fails at boot** with a clear message.
+
+`end-of-next-month` is dropped, not aliased. A deployment that still sets it must
+switch to a day count (e.g. `ECONUMO_TRIAL=30`); the boot error names the
+accepted forms.
+
+Unchanged: CLI-created users get no trial regardless of this setting
+(`selfService == false`); the readonly/402 enforcement and the apiparity
+lapsed-trial fixtures set access explicitly and are untouched.
+
+## Changes
+
+### `internal/config/config.go`
+- Replace the `Trial string` field with `TrialDays int`.
+- Parse `ECONUMO_TRIAL`: empty or `none` (case-insensitive) → `0`; otherwise
+  `strconv.Atoi`, rejecting parse errors and negative values. On rejection return
+  a boot error, e.g. `ECONUMO_TRIAL: invalid value %q (want a non-negative number
+  of days, 0, or none)`.
+- Update the field comment.
+
+### `internal/model/trial.go`
+- Change the signature to `TrialEnd(registeredAt time.Time, days int) time.Time`
+  returning `registeredAt.UTC().AddDate(0, 0, days)`.
+- Replace the calendar-month rationale in the doc comment: the fixed day count is
+  now the deliberate choice.
+
+### `internal/user/usecase.go`
+- Rename the `trial string` field to `trialDays int` and change the matching
+  constructor parameter.
+
+### `internal/user/register.go`
+- Replace the grant block:
+  ```go
+  if selfService && s.trialDays > 0 {
+      until := model.TrialEnd(now, s.trialDays)
+      u.SetAccess(model.AccessLevelFull, &until, now)
+  }
+  ```
+
+### Wiring
+- `internal/server/server.go` and `internal/cli/container.go` pass
+  `cfg.TrialDays` (int) instead of `cfg.Trial` (string).
+
+### Tests
+- `internal/config/config_test.go` — default `TrialDays == 0`; `ECONUMO_TRIAL=30`
+  → `30`; `none` → `0`; `end-of-next-month` and a negative/garbage value → boot
+  error.
+- `internal/user/trial_integration_test.go` — `newTrialSvc` takes an `int`; the
+  granted `AccessUntil` equals `now + N days`; a `0`-day service grants no expiry.
+- `internal/model/trial_test.go` — rewrite for the day count (`TrialEnd(t, N)` ==
+  `t.UTC() + N*24h`); drop the calendar-month-span test.
+
+### Docs
+- Update the `ECONUMO_TRIAL` paragraph in `CLAUDE.md`.
+- `.env.example` has no `ECONUMO_TRIAL` entry today; leave it as-is.
+
+## Out of scope
+
+- The billing/subscription banner, admin `set-access`, and CLI `user:set-access`
+  paths — they set access directly and don't read this config.
+- Any change to `EffectiveAccessLevel`, the 402 middleware, or trial fixtures.

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -78,7 +78,7 @@ func newContainer(ctx context.Context) (*container, error) {
 		userRepo, txm, encodeSvc, hasher, accessTokens, currencyLookup, budgetExistence,
 		passwordReqRepo, resetMailer, emailVerificationRepo, nil,
 		emailChangeRepo, nil,
-		appuser.NewRandomAvatarPicker(), clk, nil, cfg.AllowRegistration, cfg.Trial, cfg.EmailVerification,
+		appuser.NewRandomAvatarPicker(), clk, nil, cfg.AllowRegistration, cfg.TrialDays, cfg.EmailVerification,
 	)
 
 	currencyWriteRepo := currencyrepo.NewWriteRepo(cfg.DatabaseDriver, txm)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,10 +23,10 @@ type Config struct {
 	AllowRegistration bool
 	DataSalt          string // ECONUMO_DATA_SALT. DEPRECATED and IGNORED by the API/repositories (they run salt-free); consumed only by the data:remove-salt migration to decrypt existing data. Unset it after migrating.
 	SQLiteBusyTimeout int
-	CheckUpdates      bool   // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
-	Analytics         bool   // ECONUMO_ANALYTICS: SPA sends anonymous product events to PostHog (default true)
-	Trial             string // ECONUMO_TRIAL: "none" (default) or "end-of-next-month" — grants new registrations full access until the trial ends
-	EmailVerification bool   // ECONUMO_EMAIL_VERIFICATION: unverified users must confirm an emailed code at login (default false)
+	CheckUpdates      bool // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
+	Analytics         bool // ECONUMO_ANALYTICS: SPA sends anonymous product events to PostHog (default true)
+	TrialDays         int  // ECONUMO_TRIAL: length in days of the trial granted to a new self-service registration; 0 (default, also "none"/empty) grants no trial, i.e. permanent full access
+	EmailVerification bool // ECONUMO_EMAIL_VERIFICATION: unverified users must confirm an emailed code at login (default false)
 
 	// Admin listener for the payment portal. Both empty on a self-hosted
 	// instance, so the listener never opens and its routes exist on no mux.
@@ -134,9 +134,18 @@ func Load() (Config, error) {
 	}
 	c.Analytics = analytics
 
-	c.Trial = getEnv("ECONUMO_TRIAL", "none")
-	if c.Trial != "none" && c.Trial != "end-of-next-month" {
-		return Config{}, fmt.Errorf("ECONUMO_TRIAL: invalid value %q (want none or end-of-next-month)", c.Trial)
+	// Trial length in days. Empty or "none" (case-insensitive) means 0 = no
+	// trial grant, so a new user keeps permanent full access — the self-hosted
+	// default. A positive integer time-boxes the grant.
+	trialRaw := strings.TrimSpace(getEnv("ECONUMO_TRIAL", ""))
+	if trialRaw == "" || strings.EqualFold(trialRaw, "none") {
+		c.TrialDays = 0
+	} else {
+		days, derr := strconv.Atoi(trialRaw)
+		if derr != nil || days < 0 {
+			return Config{}, fmt.Errorf("ECONUMO_TRIAL: invalid value %q (want a non-negative number of days, 0, or none)", trialRaw)
+		}
+		c.TrialDays = days
 	}
 
 	// Strict parse for the same reason as ECONUMO_ANALYTICS: a typo must fail

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,22 +250,38 @@ func TestLoad_Trial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.Trial != "none" {
-		t.Fatal("Trial default = " + c.Trial + ", want none")
+	if c.TrialDays != 0 {
+		t.Fatalf("TrialDays default = %d, want 0", c.TrialDays)
 	}
-	t.Setenv("ECONUMO_TRIAL", "end-of-next-month")
+	t.Setenv("ECONUMO_TRIAL", "30")
 	c, err = Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.Trial != "end-of-next-month" {
-		t.Fatal("Trial with ECONUMO_TRIAL=end-of-next-month = " + c.Trial + ", want end-of-next-month")
+	if c.TrialDays != 30 {
+		t.Fatalf("TrialDays with ECONUMO_TRIAL=30 = %d, want 30", c.TrialDays)
 	}
-	// Strict parse: a typo while enabling trials fails at boot
-	// rather than silently disabling trials.
+	t.Setenv("ECONUMO_TRIAL", "none")
+	c, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.TrialDays != 0 {
+		t.Fatalf("TrialDays with ECONUMO_TRIAL=none = %d, want 0", c.TrialDays)
+	}
+	// The removed calendar-span literal now fails at boot.
+	t.Setenv("ECONUMO_TRIAL", "end-of-next-month")
+	if _, err = Load(); err == nil {
+		t.Fatal("Load with ECONUMO_TRIAL=end-of-next-month: err = nil, want boot error")
+	}
+	// Non-numeric and negative values fail at boot.
 	t.Setenv("ECONUMO_TRIAL", "weekly")
 	if _, err = Load(); err == nil {
 		t.Fatal("Load with ECONUMO_TRIAL=weekly: err = nil, want boot error")
+	}
+	t.Setenv("ECONUMO_TRIAL", "-5")
+	if _, err = Load(); err == nil {
+		t.Fatal("Load with ECONUMO_TRIAL=-5: err = nil, want boot error")
 	}
 }
 

--- a/internal/model/trial.go
+++ b/internal/model/trial.go
@@ -2,14 +2,9 @@ package model
 
 import "time"
 
-// TrialEnd returns the first instant of the month after next, relative to the
-// registration month.
-// The product's moment of value is a closed calendar month (plan against
-// actual), so the trial must span one whole month whatever day it starts on: a
-// fixed day count delivers that to nobody registering early in a month. Taking
-// the start of the following month rather than the last second of the previous
-// one avoids end-of-day arithmetic and leaves timezone slack.
-func TrialEnd(registeredAt time.Time) time.Time {
-	utc := registeredAt.UTC()
-	return time.Date(utc.Year(), utc.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 2, 0)
+// TrialEnd returns the instant a trial of the given number of days ends,
+// relative to the registration time (in UTC, since access expiry is compared
+// against a UTC clock).
+func TrialEnd(registeredAt time.Time, days int) time.Time {
+	return registeredAt.UTC().AddDate(0, 0, days)
 }

--- a/internal/model/trial_test.go
+++ b/internal/model/trial_test.go
@@ -9,34 +9,30 @@ func TestTrialEnd(t *testing.T) {
 	cases := []struct {
 		name         string
 		registeredAt time.Time
+		days         int
 		want         time.Time
 	}{
-		{"first of the month", time.Date(2026, 7, 1, 9, 30, 0, 0, time.UTC), time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)},
-		{"second of the month", time.Date(2026, 7, 2, 9, 30, 0, 0, time.UTC), time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)},
-		{"last day of a 31-day month", time.Date(2026, 7, 31, 23, 59, 0, 0, time.UTC), time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)},
-		{"february", time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC), time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)},
-		{"across the year boundary", time.Date(2026, 12, 15, 12, 0, 0, 0, time.UTC), time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC)},
-		{"november wraps to january", time.Date(2026, 11, 30, 12, 0, 0, 0, time.UTC), time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{"30 days", time.Date(2026, 7, 2, 9, 30, 0, 0, time.UTC), 30, time.Date(2026, 8, 1, 9, 30, 0, 0, time.UTC)},
+		{"1 day", time.Date(2026, 7, 31, 23, 59, 0, 0, time.UTC), 1, time.Date(2026, 8, 1, 23, 59, 0, 0, time.UTC)},
+		{"across the year boundary", time.Date(2026, 12, 15, 12, 0, 0, 0, time.UTC), 30, time.Date(2027, 1, 14, 12, 0, 0, 0, time.UTC)},
+		{"preserves time of day", time.Date(2026, 3, 10, 6, 15, 30, 0, time.UTC), 7, time.Date(2026, 3, 17, 6, 15, 30, 0, time.UTC)},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := TrialEnd(tc.registeredAt); !got.Equal(tc.want) {
+			if got := TrialEnd(tc.registeredAt, tc.days); !got.Equal(tc.want) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestTrialEndAlwaysSpansAFullCalendarMonth(t *testing.T) {
-	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	for i := 0; i < 400; i++ {
-		day := start.AddDate(0, 0, i)
-		end := TrialEnd(day)
-		nextMonth := time.Date(day.Year(), day.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, 0)
-		lastInstant := nextMonth.AddDate(0, 1, 0).Add(-time.Nanosecond)
-		if end.Before(lastInstant) {
-			t.Fatalf("registered %v: trial ends %v, before the full month ending %v", day, end, lastInstant)
-		}
+func TestTrialEndNormalizesToUTC(t *testing.T) {
+	loc := time.FixedZone("UTC+5", 5*3600)
+	registered := time.Date(2026, 7, 2, 3, 0, 0, 0, loc)
+	got := TrialEnd(registered, 10)
+	want := registered.UTC().AddDate(0, 0, 10)
+	if !got.Equal(want) || got.Location() != time.UTC {
+		t.Fatalf("got %v (%v), want %v (UTC)", got, got.Location(), want)
 	}
 }

--- a/internal/server/glue_timezone_test.go
+++ b/internal/server/glue_timezone_test.go
@@ -31,7 +31,7 @@ func newTimezoneTestUserSvc(t *testing.T, db *dbtest.DB) *appuser.Service {
 	return appuser.NewService(repo, db.TX, enc, hasher, tokens, lookup, budgets, nil, nil,
 		userrepo.NewEmailVerificationRepo(db.Engine, db.TX), nil,
 		userrepo.NewEmailChangeRequestRepo(db.Engine, db.TX), nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clock.New(), nil, false, "none", false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clock.New(), nil, false, 0, false)
 }
 
 func TestTimezoneTrackingAuthenticator(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,7 +151,7 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 		userRepo, txm, encodeSvc, hasher, accessTokens, currencyLookup, budgetAccess,
 		passwordReqRepo, resetMailer, emailVerificationRepo, verifyMailer,
 		emailChangeRepo, changeMailer,
-		avatars, clk, authLimiter, cfg.AllowRegistration, cfg.Trial, cfg.EmailVerification,
+		avatars, clk, authLimiter, cfg.AllowRegistration, cfg.TrialDays, cfg.EmailVerification,
 	)
 	userReadSvc := appuser.NewReadService(userReadRepo, encodeSvc, clk)
 	billingSvc := appuser.NewBillingService(cfg.BillingURL, handoff.NewSigner(cfg.AdminToken), clk)

--- a/internal/user/admin_integration_test.go
+++ b/internal/user/admin_integration_test.go
@@ -40,7 +40,7 @@ func newUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.EncodeServ
 	svc := appuser.NewService(repo, db.TX, enc, hasher, tokens, lookup, budgets, nil, nil,
 		userrepo.NewEmailVerificationRepo(db.Engine, db.TX), nil,
 		userrepo.NewEmailChangeRequestRepo(db.Engine, db.TX), nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clock.New(), nil, false, "", false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clock.New(), nil, false, 0, false)
 	return svc, enc, hasher
 }
 

--- a/internal/user/api/harness_test.go
+++ b/internal/user/api/harness_test.go
@@ -112,7 +112,7 @@ func newHarnessWithLimiter(t *testing.T, limiter appuser.AttemptLimiter) *harnes
 	svc := appuser.NewService(repo, txm, encode, hasher, tokens, currency, budgets, passwordReqs, resetMailer,
 		userrepo.NewEmailVerificationRepo("sqlite", txm), nil,
 		userrepo.NewEmailChangeRequestRepo("sqlite", txm), nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, limiter, cfg.AllowRegistration, "", false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, limiter, cfg.AllowRegistration, 0, false)
 	readSvc := appuser.NewReadService(readRepo, encode, clk)
 	billing := appuser.NewBillingService(
 		"https://pay.example.test/cloud/",

--- a/internal/user/authenticate_test.go
+++ b/internal/user/authenticate_test.go
@@ -57,7 +57,7 @@ func newAuthEnvFullOn(t *testing.T, db *dbtest.DB) (*appuser.Service, *userrepo.
 	svc := appuser.NewService(repo, db.TX, enc, hasher, tokens, lookup, budgets, pwreqs, nil,
 		userrepo.NewEmailVerificationRepo(db.Engine, db.TX), nil,
 		userrepo.NewEmailChangeRequestRepo(db.Engine, db.TX), nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, nil, false, "", false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, nil, false, 0, false)
 
 	uid, err := svc.AdminCreateUser(context.Background(), "Auth Tester", "auth@econumo.test", "secretpass")
 	if err != nil {

--- a/internal/user/change_email_integration_test.go
+++ b/internal/user/change_email_integration_test.go
@@ -60,7 +60,7 @@ func newChangeEmailEnv(t *testing.T) (svc *appuser.Service, repo *userrepo.Repo,
 	svc = appuser.NewService(repo, db.TX, enc, hasher, tokens, lookup, budgets, nil, nil,
 		evRepo, nil,
 		ecRepo, changeMailer,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, limiter, false, "", false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, limiter, false, 0, false)
 	return
 }
 

--- a/internal/user/migrate_test.go
+++ b/internal/user/migrate_test.go
@@ -31,7 +31,7 @@ func newSaltFreeUserSvc(t *testing.T, db *dbtest.DB) (*appuser.Service, *auth.Pa
 	svc := appuser.NewService(repo, db.TX, enc, hasher, tokens, lookup, budgets, nil, nil,
 		userrepo.NewEmailVerificationRepo("sqlite", db.TX), nil,
 		userrepo.NewEmailChangeRequestRepo("sqlite", db.TX), nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clock.New(), nil, false, "", false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clock.New(), nil, false, 0, false)
 	return svc, hasher
 }
 

--- a/internal/user/register.go
+++ b/internal/user/register.go
@@ -73,8 +73,8 @@ func (s *Service) createUser(ctx context.Context, name, email, password string, 
 
 	u := model.NewUser(s.repo.NextIdentity(), encryptedEmail, name, avatar, passwordHash, salt, now)
 	u.SeedDefaultOptions(s.repo.NextIdentity, now)
-	if selfService && s.trial == "end-of-next-month" {
-		until := model.TrialEnd(now)
+	if selfService && s.trialDays > 0 {
+		until := model.TrialEnd(now, s.trialDays)
 		u.SetAccess(model.AccessLevelFull, &until, now)
 	}
 	if selfService && s.emailVerification {

--- a/internal/user/trial_integration_test.go
+++ b/internal/user/trial_integration_test.go
@@ -14,15 +14,15 @@ import (
 	userrepo "github.com/econumo/econumo/internal/user/repo"
 )
 
-// trialNow is fixed so the assertion cannot straddle a month boundary between
-// the service's clock and the test's own time.Now().
+// trialNow is fixed so the granted access_until is computed from a known
+// instant rather than the wall clock.
 var trialNow = time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC)
 
 type trialClock struct{}
 
 func (trialClock) Now() time.Time { return trialNow }
 
-func newTrialSvc(t *testing.T, db *dbtest.DB, trial string) (*appuser.Service, *userrepo.Repo, *auth.EncodeService) {
+func newTrialSvc(t *testing.T, db *dbtest.DB, trialDays int) (*appuser.Service, *userrepo.Repo, *auth.EncodeService) {
 	t.Helper()
 	enc := auth.NewEncodeService("")
 	hasher := auth.NewPasswordHasher()
@@ -33,13 +33,13 @@ func newTrialSvc(t *testing.T, db *dbtest.DB, trial string) (*appuser.Service, *
 	svc := appuser.NewService(repo, db.TX, enc, hasher, tokens, lookup, budgets, nil, nil,
 		userrepo.NewEmailVerificationRepo(db.Engine, db.TX), nil,
 		userrepo.NewEmailChangeRequestRepo(db.Engine, db.TX), nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), trialClock{}, nil, true, trial, false)
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), trialClock{}, nil, true, trialDays, false)
 	return svc, repo, enc
 }
 
 func TestRegister_GrantsTrialWhenEnabled(t *testing.T) {
 	db := dbtest.New(t)
-	svc, repo, _ := newTrialSvc(t, db, "end-of-next-month")
+	svc, repo, _ := newTrialSvc(t, db, 30)
 	ctx := context.Background()
 
 	if _, err := svc.Register(ctx, model.RegisterRequest{
@@ -56,9 +56,9 @@ func TestRegister_GrantsTrialWhenEnabled(t *testing.T) {
 		t.Fatalf("level: got %q want full", u.AccessLevel)
 	}
 	if u.AccessUntil == nil {
-		t.Fatal("access_until: got nil, want the start of the month after next")
+		t.Fatal("access_until: got nil, want registration + 30 days")
 	}
-	want := model.TrialEnd(trialNow) // 2026-09-01 00:00:00 UTC
+	want := model.TrialEnd(trialNow, 30) // 2026-08-01 10:00:00 UTC
 	if !u.AccessUntil.Equal(want) {
 		t.Fatalf("access_until: got %v want %v", *u.AccessUntil, want)
 	}
@@ -66,7 +66,7 @@ func TestRegister_GrantsTrialWhenEnabled(t *testing.T) {
 
 func TestRegister_NoTrialByDefault(t *testing.T) {
 	db := dbtest.New(t)
-	svc, repo, _ := newTrialSvc(t, db, "none")
+	svc, repo, _ := newTrialSvc(t, db, 0)
 	ctx := context.Background()
 
 	if _, err := svc.Register(ctx, model.RegisterRequest{
@@ -86,7 +86,7 @@ func TestRegister_NoTrialByDefault(t *testing.T) {
 
 func TestAdminCreateUser_NeverGrantsTrial(t *testing.T) {
 	db := dbtest.New(t)
-	svc, repo, _ := newTrialSvc(t, db, "end-of-next-month")
+	svc, repo, _ := newTrialSvc(t, db, 30)
 	ctx := context.Background()
 
 	if _, err := svc.AdminCreateUser(ctx, "Ops User", "ops@econumo.test", "secretpass"); err != nil {

--- a/internal/user/usecase.go
+++ b/internal/user/usecase.go
@@ -42,7 +42,7 @@ type Service struct {
 	clock               port.Clock
 	limiter             AttemptLimiter
 	allowRegistration   bool
-	trial               string
+	trialDays           int
 	emailVerification   bool
 }
 
@@ -64,7 +64,7 @@ func NewService(
 	clock port.Clock,
 	limiter AttemptLimiter,
 	allowRegistration bool,
-	trial string,
+	trialDays int,
 	emailVerification bool,
 ) *Service {
 	return &Service{
@@ -85,7 +85,7 @@ func NewService(
 		clock:               clock,
 		limiter:             limiter,
 		allowRegistration:   allowRegistration,
-		trial:               trial,
+		trialDays:           trialDays,
 		emailVerification:   emailVerification,
 	}
 }

--- a/internal/user/verify_email_test.go
+++ b/internal/user/verify_email_test.go
@@ -65,7 +65,7 @@ func newVerifySvcClock(t *testing.T, db *dbtest.DB, cap *captureMailer, enabled 
 		prRepo, mailer.NewResetSender(cap, "noreply@econumo.test", ""),
 		evRepo, mailer.NewVerifySender(cap, "noreply@econumo.test", ""),
 		ecRepo, nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, nil, true, "", enabled), clk
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, nil, true, 0, enabled), clk
 }
 
 func newVerifySvc(t *testing.T, db *dbtest.DB, cap *captureMailer) *appuser.Service {
@@ -97,7 +97,7 @@ func newVerifySvcLimited(t *testing.T, db *dbtest.DB, cap *captureMailer, limit 
 		prRepo, mailer.NewResetSender(cap, "noreply@econumo.test", ""),
 		evRepo, mailer.NewVerifySender(cap, "noreply@econumo.test", ""),
 		ecRepo, nil,
-		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, limiter, true, "", true), clk
+		appuser.FixedAvatarPicker(appuser.DefaultAvatar), clk, limiter, true, 0, true), clk
 }
 
 // resendSeconds calls the resend use case and returns the advertised wait in


### PR DESCRIPTION
## Summary

Replaces the two-literal `ECONUMO_TRIAL` config (`none` / `end-of-next-month`) with an **integer number of days**.

- **Empty / `0` / `none`** (case-insensitive) → no trial grant → new self-registered users keep permanent full access. This is the default, so **self-hosters get full access out of the box**.
- **Positive integer `N`** → full access for `N` days from registration, after which the user lapses to `readonly` (402 on writes, unchanged enforcement).
- **Negative, non-numeric, or the removed `end-of-next-month` literal** → fail at boot with a clear message.

CLI-created users still never get a trial (operator-provisioned accounts are trusted access, not time-boxed leads).

## Behavior notes

- The prior default `none` already meant *no expiry → permanent full access*; `end-of-next-month` was the time-boxed option. The new default (`0`) preserves that permanent-full-access behavior, so self-hosted instances are unaffected.
- `TrialEnd(now, days)` is now `now.UTC() + days`, replacing the calendar-month-after-next span.

## ⚠️ Deploy note

Any instance currently setting `ECONUMO_TRIAL=end-of-next-month` (e.g. the cloud deployment) **must switch to a day count** (e.g. `ECONUMO_TRIAL=30`) — that literal now fails at boot.

## Testing

- `make go-test` smoke suite passes; coverage 80.5% (≥ 78% gate).
- `go vet` / `gofmt` clean.
- Config tests cover default `0`, `30`, `none`→`0`, and boot errors for `end-of-next-month`, non-numeric, and negative values.
- Trial integration tests assert `access_until == now + N days` and no grant when `0`.

Design spec: `docs/superpowers/specs/2026-07-23-trial-days-config-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)