### PR TITLE
fix: drop blank line before app link in transactional emails

### DIFF
--- a/internal/infra/mailer/mailer.go
+++ b/internal/infra/mailer/mailer.go
@@ -49,7 +49,7 @@ func New(provider, apiKey string) Mailer {
 }
 
 // WithAppLink wraps a Mailer so every message body ends with the instance's
-// public URL (ECONUMO_URL) on its own line. Applied once at composition time,
+// public URL (ECONUMO_URL) on the line directly below the body. Applied once at composition time,
 // it covers every current and future email without per-sender plumbing; when
 // the URL is unset the wrapper is not installed, so bodies are unchanged.
 func WithAppLink(inner Mailer, appURL string) Mailer {
@@ -62,7 +62,7 @@ type linkMailer struct {
 }
 
 func (m linkMailer) Send(ctx context.Context, msg Message) error {
-	msg.Text = strings.TrimRight(msg.Text, "\n") + "\n\n" + m.appURL
+	msg.Text = strings.TrimRight(msg.Text, "\n") + "\n" + m.appURL
 	return m.inner.Send(ctx, msg)
 }
 

--- a/internal/infra/mailer/mailer_test.go
+++ b/internal/infra/mailer/mailer_test.go
@@ -104,21 +104,21 @@ func TestWithAppLink(t *testing.T) {
 	c := &captureMailer{}
 	m := WithAppLink(c, "https://money.example.com")
 
-	// A body with a trailing newline (reset/verify shape) gets exactly one
-	// blank line before the bare URL.
+	// A body with a trailing newline (reset/verify shape) puts the bare URL on
+	// the line directly below the body, no blank line between.
 	if err := m.Send(context.Background(), Message{Text: "line one\nfooter\n"}); err != nil {
 		t.Fatalf("send: %v", err)
 	}
-	if want := "line one\nfooter\n\nhttps://money.example.com"; c.msg.Text != want {
+	if want := "line one\nfooter\nhttps://money.example.com"; c.msg.Text != want {
 		t.Fatalf("trailing-newline body:\n%q\nwant:\n%q", c.msg.Text, want)
 	}
 
 	// A body with no trailing newline (change-email shape) gets the same
-	// single blank-line separator.
+	// single-newline separator.
 	if err := m.Send(context.Background(), Message{Text: "no footer here"}); err != nil {
 		t.Fatalf("send: %v", err)
 	}
-	if want := "no footer here\n\nhttps://money.example.com"; c.msg.Text != want {
+	if want := "no footer here\nhttps://money.example.com"; c.msg.Text != want {
 		t.Fatalf("no-newline body:\n%q\nwant:\n%q", c.msg.Text, want)
 	}
 }


### PR DESCRIPTION
## What

The `ECONUMO_URL` app link appended to every transactional email now sits on the line **directly below** the email body, instead of being separated by a blank line.

Before:
```
Econumo — Manage money. Together.

https://test.econumo.com
```

After:
```
Econumo — Manage money. Together.
https://test.econumo.com
```

## Why

The blank line made the app link look detached from the signature. Placing it directly under the body reads as part of the footer.

## How

`linkMailer.Send` (`internal/infra/mailer/mailer.go`) now joins the trimmed body and the URL with a single `\n` instead of `\n\n`. Applied once at composition time via `WithAppLink`, so it covers every current and future transactional email. The change is inert when `ECONUMO_URL` is unset (wrapper not installed).

The `--` separator and signature line come from each email's own template body and are untouched — only the gap the wrapper inserts changed.

## Tests

Updated `TestWithAppLink` for both body shapes (trailing-newline and no-newline). `go test ./internal/infra/mailer/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)