### PR TITLE
feat(cli): data:import-sqlite — SQLite→PostgreSQL data migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,10 @@ the PostgreSQL migrations on the target first (so a bare `createdb` works in one
 step), then copies all app data in one transaction — `access_tokens` and
 `currencies` included, the dead `messenger_messages` and the migration
 bookkeeping tables excluded. It aborts if the target already holds data unless
-`--force` is given, which truncates and replaces.
+`--force` is given, which truncates and replaces. The source SQLite must
+already be on the current schema — boot the current econumo binary against it
+once before importing — and the command refuses with a clear error on a
+schema-version mismatch between source and target.
 
 In the distroless image these run via the binary directly, e.g.
 `docker exec <container> /app/econumo user:create …`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,6 +510,7 @@ currency:update-rates [date]
 currency:add <code> [name] [fraction-digits]
 token:purge [days]
 data:remove-salt
+data:import-sqlite [--force] <sqlite-path>
 ```
 
 `data:remove-salt` is a one-off migration that decrypts every user's email
@@ -522,6 +523,14 @@ Run it **while the old salt is still set** (it needs it to decrypt), then
 unset `ECONUMO_DATA_SALT` and restart. It refuses to run with an empty salt,
 and is idempotent (already-plaintext rows are skipped).
 Back up the DB first — the decryption is one-way in practice.
+
+`data:import-sqlite` copies every table from an existing SQLite database into
+the configured PostgreSQL (`DATABASE_URL` must be a `postgres://` URL). It runs
+the PostgreSQL migrations on the target first (so a bare `createdb` works in one
+step), then copies all app data in one transaction — `access_tokens` and
+`currencies` included, the dead `messenger_messages` and the migration
+bookkeeping tables excluded. It aborts if the target already holds data unless
+`--force` is given, which truncates and replaces.
 
 In the distroless image these run via the binary directly, e.g.
 `docker exec <container> /app/econumo user:create …`.

--- a/docs/superpowers/plans/2026-07-23-sqlite-to-pgsql-import.md
+++ b/docs/superpowers/plans/2026-07-23-sqlite-to-pgsql-import.md
@@ -1,0 +1,862 @@
+# data:import-sqlite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a CLI command `data:import-sqlite <sqlite-path>` that copies all data from an existing SQLite database into the configured PostgreSQL database.
+
+**Architecture:** A new engine-agnostic copy package (`internal/infra/storage/sqliteimport`) introspects the **target** PostgreSQL `information_schema` for the table list, column types, and foreign-key topological order (nothing hardcoded, so it never drifts), then copies every app table from the source SQLite `*sql.DB` into the target `*sql.DB` inside one transaction with native type handling. A thin CLI command (`internal/cli/data_commands.go`) opens the source, runs the PostgreSQL migrations on the target (so a bare `createdb` works in one step), then calls the package and prints a per-table report.
+
+**Tech Stack:** Go stdlib `database/sql`, the existing `modernc.org/sqlite` + `pgx` (simple protocol) drivers already linked in the binary, the project's `migrate` runner and embedded `migrations`, and the `dbtest` test harness.
+
+## Global Constraints
+
+- **Source SQLite is opened via the registered backend** `backend.Get("sqlite").Open(ctx, path)` — the DSN accepts a plain file path; this applies `PRAGMA foreign_keys = ON` and registers the `modernc.org/sqlite` driver. Copied for reads only.
+- **Target driver name is `"postgresql"`** (value of `cfg.DatabaseDriver` for a `postgres://`/`postgresql://` URL; the pgsql backend's `Name` const is `"postgresql"`).
+- **Introspection filters on `current_schema()`**, never a literal `public` — production uses `public`, tests use a private per-test schema on the search_path.
+- **Excluded tables (never copied):** `messenger_messages` (dead Symfony leftover, only `BIGSERIAL` table), `schema_migrations` (owned by the migrate runner), `migration_versions` (legacy external bookkeeping).
+- **PostgreSQL uses `$N` placeholders**, not `?`.
+- **Comments are sparse** — only non-obvious *why* (per CLAUDE.md). No godoc that restates a signature; no references to the former PHP implementation.
+- **The copy runs in one transaction** on the target; any failure rolls back so a partial import never persists.
+
+---
+
+### Task 1: `sqliteimport` package skeleton + pure topological sort
+
+**Files:**
+- Create: `internal/infra/storage/sqliteimport/sqliteimport.go`
+- Test: `internal/infra/storage/sqliteimport/topo_test.go`
+
+**Interfaces:**
+- Consumes: nothing (leaf package; stdlib only in this task).
+- Produces:
+  - `var ErrTargetNotEmpty error`
+  - `type TableCount struct { Name string; Rows int64 }`
+  - `type Report struct { Tables []TableCount; Total int64 }`
+  - `func topoSort(nodes []string, deps map[string][]string) ([]string, error)` — unexported; returns nodes ordered parents-before-children; deterministic (sorted); errors on a cycle. `deps[child]` lists the tables `child` references.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package sqliteimport
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTopoSort_ParentsBeforeChildren(t *testing.T) {
+	// transactions -> accounts -> currencies; accounts -> users; transactions -> users
+	nodes := []string{"transactions", "accounts", "currencies", "users"}
+	deps := map[string][]string{
+		"accounts":     {"currencies", "users"},
+		"transactions": {"accounts", "users"},
+	}
+	got, err := topoSort(nodes, deps)
+	if err != nil {
+		t.Fatalf("topoSort: %v", err)
+	}
+	pos := map[string]int{}
+	for i, n := range got {
+		pos[n] = i
+	}
+	if len(got) != len(nodes) {
+		t.Fatalf("expected %d nodes, got %d (%v)", len(nodes), len(got), got)
+	}
+	for child, parents := range deps {
+		for _, p := range parents {
+			if pos[p] > pos[child] {
+				t.Errorf("parent %q (%d) must precede child %q (%d): %v", p, pos[p], child, pos[child], got)
+			}
+		}
+	}
+}
+
+func TestTopoSort_Deterministic(t *testing.T) {
+	nodes := []string{"b", "a", "c"}
+	got1, _ := topoSort(nodes, nil)
+	got2, _ := topoSort(nodes, nil)
+	if !reflect.DeepEqual(got1, got2) {
+		t.Fatalf("not deterministic: %v vs %v", got1, got2)
+	}
+	if !reflect.DeepEqual(got1, []string{"a", "b", "c"}) {
+		t.Fatalf("expected sorted order with no deps, got %v", got1)
+	}
+}
+
+func TestTopoSort_CycleErrors(t *testing.T) {
+	nodes := []string{"a", "b"}
+	deps := map[string][]string{"a": {"b"}, "b": {"a"}}
+	_, err := topoSort(nodes, deps)
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+}
+
+func TestTopoSort_EdgeToUnknownNodeIgnored(t *testing.T) {
+	// A parent that is not in the node set (e.g. an excluded table) is skipped.
+	nodes := []string{"a"}
+	deps := map[string][]string{"a": {"excluded"}}
+	got, err := topoSort(nodes, deps)
+	if err != nil {
+		t.Fatalf("topoSort: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"a"}) {
+		t.Fatalf("expected [a], got %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/infra/storage/sqliteimport/ -run TestTopoSort -v`
+Expected: FAIL — `undefined: topoSort` (package won't compile).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Package sqliteimport copies an Econumo SQLite database into an
+// already-migrated PostgreSQL database. It introspects the target schema for the
+// table list, column types, and foreign-key order, so it carries no hardcoded
+// schema and does not drift as migrations evolve.
+package sqliteimport
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ErrTargetNotEmpty is returned by Import when the target already holds user
+// data and force is false; nothing is copied in that case.
+var ErrTargetNotEmpty = errors.New("target database already contains data")
+
+type TableCount struct {
+	Name string
+	Rows int64
+}
+
+type Report struct {
+	Tables []TableCount
+	Total  int64
+}
+
+// topoSort orders nodes so every table precedes the tables that reference it.
+// deps[child] lists child's referenced (parent) tables; edges to names outside
+// the node set are ignored (e.g. FKs into excluded tables). Order is
+// deterministic. A foreign-key cycle is an error.
+func topoSort(nodes []string, deps map[string][]string) ([]string, error) {
+	inSet := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		inSet[n] = true
+	}
+	sorted := append([]string(nil), nodes...)
+	sort.Strings(sorted)
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(nodes))
+	var order []string
+
+	var visit func(n string) error
+	visit = func(n string) error {
+		switch color[n] {
+		case black:
+			return nil
+		case gray:
+			return fmt.Errorf("sqliteimport: foreign-key cycle at table %q", n)
+		}
+		color[n] = gray
+		parents := append([]string(nil), deps[n]...)
+		sort.Strings(parents)
+		for _, p := range parents {
+			if p == n || !inSet[p] {
+				continue
+			}
+			if err := visit(p); err != nil {
+				return err
+			}
+		}
+		color[n] = black
+		order = append(order, n)
+		return nil
+	}
+	for _, n := range sorted {
+		if err := visit(n); err != nil {
+			return nil, err
+		}
+	}
+	return order, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/infra/storage/sqliteimport/ -run TestTopoSort -v`
+Expected: PASS (all four).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/infra/storage/sqliteimport/
+git commit -m "feat(sqliteimport): package skeleton + topological sort"
+```
+
+---
+
+### Task 2: Introspection + copy engine (`Import`)
+
+**Files:**
+- Modify: `internal/infra/storage/sqliteimport/sqliteimport.go`
+- Test: `internal/infra/storage/sqliteimport/import_test.go` (build tag `enginecompare`)
+
+**Interfaces:**
+- Consumes: `topoSort`, `ErrTargetNotEmpty`, `Report`, `TableCount` from Task 1.
+- Produces:
+  - `func Import(ctx context.Context, src, dst *sql.DB, force bool) (Report, error)` — copies every non-excluded base table from `src` (migrated SQLite) into `dst` (migrated PostgreSQL) in one `dst` transaction. If `dst` already has rows in `users` and `force` is false, returns `ErrTargetNotEmpty` and copies nothing. Otherwise truncates the copied tables (removing migration seed rows) and copies parents-before-children.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+//go:build enginecompare
+
+package sqliteimport_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/econumo/econumo/internal/infra/storage/sqliteimport"
+	"github.com/econumo/econumo/internal/test/dbtest"
+)
+
+// seedSource inserts one user, one currency, one account and one transaction into
+// a migrated SQLite DB, covering a boolean (is_deleted), a NUMERIC amount, a
+// timestamp, and a NULL FK (category_id). Returns the user id.
+func seedSource(t *testing.T, src *dbtest.DB) string {
+	t.Helper()
+	const uid = "0190a0aa-0000-7000-8000-000000000001"
+	const cid = "0190a0aa-0000-7000-8000-0000000000c1"
+	const aid = "0190a0aa-0000-7000-8000-0000000000a1"
+	const tid = "0190a0aa-0000-7000-8000-0000000000t1"
+	ts := "2026-07-23 10:00:00"
+	src.Exec(t, `INSERT INTO currencies (id, code, symbol, created_at) VALUES (?,?,?,?)`,
+		cid, "EUR", "€", ts)
+	src.Exec(t, `INSERT INTO users (id, identifier, email, name, avatar, password, salt, algorithm, language, is_active, email_verified, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		uid, uid, "a@b.test", "A", "diamond:sky", "x", "", "argon2id", "en", 1, 1, ts, ts)
+	src.Exec(t, `INSERT INTO accounts (id, currency_id, user_id, name, type, icon, is_deleted, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?)`,
+		aid, cid, uid, "Cash", 1, "wallet", 1, ts, ts)
+	src.Exec(t, `INSERT INTO transactions (id, user_id, account_id, type, amount, description, created_at, updated_at, spent_at)
+		VALUES (?,?,?,?,?,?,?,?,?)`,
+		tid, uid, aid, 1, "42.50", "lunch", ts, ts, ts)
+	return uid
+}
+
+func TestImport_CopiesAllTablesWithTypes(t *testing.T) {
+	ctx := context.Background()
+	src := dbtest.NewSQLite(t)
+	dst := dbtest.NewPostgres(t) // migrated; seeds the default USD currency
+
+	seedSource(t, src)
+
+	report, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, false)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if report.Total == 0 {
+		t.Fatal("expected rows copied, got 0")
+	}
+
+	// Row counts: the source's currency replaced the seeded USD row.
+	var accounts, currencies, txns int
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM accounts`).Scan(&accounts)
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM currencies`).Scan(&currencies)
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM transactions`).Scan(&txns)
+	if accounts != 1 || txns != 1 {
+		t.Fatalf("expected 1 account and 1 transaction, got %d / %d", accounts, txns)
+	}
+	if currencies != 1 {
+		t.Fatalf("expected only the source currency (seed replaced), got %d", currencies)
+	}
+
+	// Boolean round-trip: is_deleted was 1 in SQLite -> true in Postgres.
+	var isDeleted bool
+	if err := dst.Raw.QueryRowContext(ctx, `SELECT is_deleted FROM accounts`).Scan(&isDeleted); err != nil {
+		t.Fatalf("scan is_deleted: %v", err)
+	}
+	if !isDeleted {
+		t.Fatal("expected is_deleted = true")
+	}
+
+	// NUMERIC round-trip: 42.50.
+	var amount string
+	if err := dst.Raw.QueryRowContext(ctx, `SELECT amount::text FROM transactions`).Scan(&amount); err != nil {
+		t.Fatalf("scan amount: %v", err)
+	}
+	if amount != "42.50" {
+		t.Fatalf("expected amount 42.50, got %q", amount)
+	}
+
+	// NULL FK preserved.
+	var categoryNull bool
+	dst.Raw.QueryRowContext(ctx, `SELECT category_id IS NULL FROM transactions`).Scan(&categoryNull)
+	if !categoryNull {
+		t.Fatal("expected category_id to be NULL")
+	}
+}
+
+func TestImport_AbortsWhenTargetHasUsersWithoutForce(t *testing.T) {
+	ctx := context.Background()
+	src := dbtest.NewSQLite(t)
+	dst := dbtest.NewPostgres(t)
+	seedSource(t, src)
+
+	// Put a user into the target so the guard trips.
+	dst.Exec(t, dst.Rebind(`INSERT INTO users (id, identifier, email, name, avatar, password, salt, algorithm, language, is_active, email_verified, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`),
+		"0190a0aa-0000-7000-8000-0000000000e1", "0190a0aa-0000-7000-8000-0000000000e1", "x@y.test", "X", "diamond:sky", "x", "",
+		"argon2id", "en", true, true, "2026-07-23 10:00:00", "2026-07-23 10:00:00")
+
+	if _, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, false); !errors.Is(err, sqliteimport.ErrTargetNotEmpty) {
+		t.Fatalf("expected ErrTargetNotEmpty, got %v", err)
+	}
+
+	// With force it replaces cleanly.
+	if _, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, true); err != nil {
+		t.Fatalf("Import(force): %v", err)
+	}
+	var users int
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM users`).Scan(&users)
+	if users != 1 {
+		t.Fatalf("expected 1 user after forced replace, got %d", users)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -tags enginecompare ./internal/infra/storage/sqliteimport/ -run TestImport -v`
+Expected: FAIL — `undefined: sqliteimport.Import` (or SKIP if `DATABASE_TEST_PGSQL_URL` is unset; if skipped, provision Postgres with `make test-repo-pgsql`'s compose stack or set the env var, then re-run — the test must actually execute to validate this task).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/infra/storage/sqliteimport/sqliteimport.go` (add `context`, `database/sql`, `strings` to the import block):
+
+```go
+var excludedTables = map[string]bool{
+	"messenger_messages": true,
+	"schema_migrations":  true,
+	"migration_versions": true,
+}
+
+type column struct {
+	name   string
+	isBool bool
+}
+
+func Import(ctx context.Context, src, dst *sql.DB, force bool) (Report, error) {
+	tables, err := listTables(ctx, dst)
+	if err != nil {
+		return Report{}, err
+	}
+	deps, err := fkEdges(ctx, dst, tables)
+	if err != nil {
+		return Report{}, err
+	}
+	ordered, err := topoSort(tables, deps)
+	if err != nil {
+		return Report{}, err
+	}
+
+	if !force {
+		var users int64
+		if err := dst.QueryRowContext(ctx, `SELECT count(*) FROM users`).Scan(&users); err != nil {
+			return Report{}, fmt.Errorf("sqliteimport: count users: %w", err)
+		}
+		if users > 0 {
+			return Report{}, ErrTargetNotEmpty
+		}
+	}
+
+	tx, err := dst.BeginTx(ctx, nil)
+	if err != nil {
+		return Report{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Clear the copied tables (including migration seed rows) so the result is a
+	// faithful replica; CASCADE + the FK-safe insert order below keep it consistent.
+	quoted := make([]string, len(ordered))
+	for i, t := range ordered {
+		quoted[i] = pgIdent(t)
+	}
+	if _, err := tx.ExecContext(ctx, "TRUNCATE TABLE "+strings.Join(quoted, ", ")+" RESTART IDENTITY CASCADE"); err != nil {
+		return Report{}, fmt.Errorf("sqliteimport: truncate: %w", err)
+	}
+
+	report := Report{}
+	for _, table := range ordered {
+		cols, err := tableColumns(ctx, dst, table)
+		if err != nil {
+			return Report{}, err
+		}
+		n, err := copyTable(ctx, src, tx, table, cols)
+		if err != nil {
+			return Report{}, fmt.Errorf("sqliteimport: copy %q: %w", table, err)
+		}
+		report.Tables = append(report.Tables, TableCount{Name: table, Rows: n})
+		report.Total += n
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Report{}, err
+	}
+	return report, nil
+}
+
+func listTables(ctx context.Context, dst *sql.DB) ([]string, error) {
+	rows, err := dst.QueryContext(ctx, `
+		SELECT table_name FROM information_schema.tables
+		WHERE table_schema = current_schema() AND table_type = 'BASE TABLE'`)
+	if err != nil {
+		return nil, fmt.Errorf("sqliteimport: list tables: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		if excludedTables[name] {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
+}
+
+func tableColumns(ctx context.Context, dst *sql.DB, table string) ([]column, error) {
+	rows, err := dst.QueryContext(ctx, `
+		SELECT column_name, data_type FROM information_schema.columns
+		WHERE table_schema = current_schema() AND table_name = $1
+		ORDER BY ordinal_position`, table)
+	if err != nil {
+		return nil, fmt.Errorf("sqliteimport: columns of %q: %w", table, err)
+	}
+	defer rows.Close()
+	var out []column
+	for rows.Next() {
+		var name, dataType string
+		if err := rows.Scan(&name, &dataType); err != nil {
+			return nil, err
+		}
+		out = append(out, column{name: name, isBool: dataType == "boolean"})
+	}
+	return out, rows.Err()
+}
+
+func fkEdges(ctx context.Context, dst *sql.DB, tables []string) (map[string][]string, error) {
+	inSet := make(map[string]bool, len(tables))
+	for _, t := range tables {
+		inSet[t] = true
+	}
+	rows, err := dst.QueryContext(ctx, `
+		SELECT tc.table_name AS child, ccu.table_name AS parent
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.constraint_column_usage ccu
+		  ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
+		WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = current_schema()`)
+	if err != nil {
+		return nil, fmt.Errorf("sqliteimport: fk edges: %w", err)
+	}
+	defer rows.Close()
+	deps := map[string][]string{}
+	for rows.Next() {
+		var child, parent string
+		if err := rows.Scan(&child, &parent); err != nil {
+			return nil, err
+		}
+		if inSet[child] && inSet[parent] {
+			deps[child] = append(deps[child], parent)
+		}
+	}
+	return deps, rows.Err()
+}
+
+func copyTable(ctx context.Context, src *sql.DB, dstTx *sql.Tx, table string, cols []column) (int64, error) {
+	names := make([]string, len(cols))
+	placeholders := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = pgIdent(c.name)
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+	selectSQL := "SELECT " + strings.Join(names, ", ") + " FROM " + pgIdent(table)
+	insertSQL := "INSERT INTO " + pgIdent(table) + " (" + strings.Join(names, ", ") +
+		") VALUES (" + strings.Join(placeholders, ", ") + ")"
+
+	rows, err := src.QueryContext(ctx, selectSQL)
+	if err != nil {
+		return 0, fmt.Errorf("read: %w", err)
+	}
+	defer rows.Close()
+
+	stmt, err := dstTx.PrepareContext(ctx, insertSQL)
+	if err != nil {
+		return 0, fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	var count int64
+	vals := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	for rows.Next() {
+		if err := rows.Scan(ptrs...); err != nil {
+			return 0, fmt.Errorf("scan: %w", err)
+		}
+		for i, c := range cols {
+			switch v := vals[i].(type) {
+			case []byte:
+				vals[i] = string(v) // uuid/numeric/text columns reject bytea in simple protocol
+			case int64:
+				if c.isBool {
+					vals[i] = v != 0
+				}
+			}
+		}
+		if _, err := stmt.ExecContext(ctx, vals...); err != nil {
+			return 0, fmt.Errorf("insert: %w", err)
+		}
+		count++
+	}
+	return count, rows.Err()
+}
+
+// pgIdent double-quotes a PostgreSQL identifier. Table/column names here come
+// from information_schema (the target's own catalog), not user input.
+func pgIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -tags enginecompare ./internal/infra/storage/sqliteimport/ -run TestImport -v`
+Expected: PASS (both `TestImport_*`). Also run the pure suite to confirm no regression: `go test ./internal/infra/storage/sqliteimport/ -v`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/infra/storage/sqliteimport/
+git commit -m "feat(sqliteimport): schema-driven copy engine with FK order + type coercion"
+```
+
+---
+
+### Task 3: `data:import-sqlite` CLI command + registration + docs
+
+**Files:**
+- Create: `internal/cli/data_commands.go`
+- Modify: `internal/cli/cli.go` (add `dataCommands()` to `commandList()`)
+- Test: `internal/cli/data_commands_test.go`
+- Modify: `CLAUDE.md` (add the command to the CLI list)
+
+**Interfaces:**
+- Consumes: `sqliteimport.Import`, `sqliteimport.ErrTargetNotEmpty`, `sqliteimport.Report` (Task 2); `container.db` (`*sql.DB`, the target) and `container.cfg` (`config.Config`) from `internal/cli/container.go`; `migrate.Run`, `migrations.Pgsql`, `backend.Get` from infra.
+- Produces:
+  - `func dataCommands() []command`
+  - `func parseImportArgs(args []string) (path string, force bool, err error)` — unexported, pure, unit-testable.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/econumo/econumo/internal/config"
+)
+
+func TestParseImportArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		path    string
+		force   bool
+		wantErr bool
+	}{
+		{"path only", []string{"db.sqlite"}, "db.sqlite", false, false},
+		{"force before path", []string{"--force", "db.sqlite"}, "db.sqlite", true, false},
+		{"force after path", []string{"db.sqlite", "--force"}, "db.sqlite", true, false},
+		{"missing path", []string{}, "", false, true},
+		{"missing path with force", []string{"--force"}, "", false, true},
+		{"two paths", []string{"a.sqlite", "b.sqlite"}, "", false, true},
+		{"unknown flag", []string{"--nope", "db.sqlite"}, "", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, force, err := parseImportArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got path=%q force=%v", path, force)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if path != tc.path || force != tc.force {
+				t.Fatalf("got (%q,%v), want (%q,%v)", path, force, tc.path, tc.force)
+			}
+		})
+	}
+}
+
+func TestImportSQLite_RejectsNonPostgresTarget(t *testing.T) {
+	c := &container{cfg: config.Config{DatabaseDriver: "sqlite"}}
+	err := runImportSQLite(context.Background(), c, []string{"db.sqlite"})
+	if err == nil || !strings.Contains(err.Error(), "PostgreSQL") {
+		t.Fatalf("expected a PostgreSQL-required error, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/ -run 'TestParseImportArgs|TestImportSQLite' -v`
+Expected: FAIL — `undefined: parseImportArgs` / `undefined: runImportSQLite`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/cli/data_commands.go`:
+
+```go
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/econumo/econumo/internal/infra/storage/backend"
+	"github.com/econumo/econumo/internal/infra/storage/migrate"
+	"github.com/econumo/econumo/internal/infra/storage/migrations"
+	"github.com/econumo/econumo/internal/infra/storage/sqliteimport"
+)
+
+func dataCommands() []command {
+	return []command{
+		{
+			name:    "data:import-sqlite",
+			summary: "Copy all data from a SQLite DB into the configured PostgreSQL: data:import-sqlite [--force] <sqlite-path>",
+			run:     runImportSQLite,
+		},
+	}
+}
+
+func parseImportArgs(args []string) (path string, force bool, err error) {
+	const usage = "data:import-sqlite [--force] <sqlite-path>"
+	for _, a := range args {
+		switch {
+		case a == "--force":
+			force = true
+		case strings.HasPrefix(a, "-"):
+			return "", false, usageErr(usage)
+		default:
+			if path != "" {
+				return "", false, usageErr(usage)
+			}
+			path = a
+		}
+	}
+	if path == "" {
+		return "", false, usageErr(usage)
+	}
+	return path, force, nil
+}
+
+func runImportSQLite(ctx context.Context, c *container, args []string) error {
+	path, force, err := parseImportArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if c.cfg.DatabaseDriver != "postgresql" {
+		return fmt.Errorf("data:import-sqlite requires DATABASE_URL to point at PostgreSQL; current engine is %q", c.cfg.DatabaseDriver)
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return fmt.Errorf("source sqlite file: %w", err)
+	}
+
+	be, ok := backend.Get("sqlite")
+	if !ok {
+		return errors.New("sqlite backend not registered")
+	}
+	src, err := be.Open(ctx, abs)
+	if err != nil {
+		return fmt.Errorf("open source sqlite: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	// Bring the target to the current schema (schema + schema_migrations), so a
+	// bare createdb'd Postgres works in one command; migrate.Run is idempotent.
+	if err := migrate.Run(ctx, c.db, toMigratePg(migrations.Pgsql())); err != nil {
+		return fmt.Errorf("migrate target: %w", err)
+	}
+
+	start := time.Now()
+	report, err := sqliteimport.Import(ctx, src, c.db, force)
+	if err != nil {
+		if errors.Is(err, sqliteimport.ErrTargetNotEmpty) {
+			return errors.New("the target PostgreSQL already contains data; re-run with --force to truncate and replace it")
+		}
+		return err
+	}
+
+	for _, t := range report.Tables {
+		fmt.Printf("  %-32s %d\n", t.Name, t.Rows)
+	}
+	fmt.Printf("Imported %d row(s) across %d table(s) in %s.\n",
+		report.Total, len(report.Tables), time.Since(start).Round(time.Millisecond))
+	return nil
+}
+
+func toMigratePg(files []migrations.File) []migrate.Migration {
+	out := make([]migrate.Migration, len(files))
+	for i, f := range files {
+		out[i] = migrate.Migration{Version: f.Version, SQL: f.SQL}
+	}
+	return out
+}
+```
+
+Then register it in `internal/cli/cli.go` — add to `commandList()`:
+
+```go
+func commandList() []command {
+	var cs []command
+	cs = append(cs, userCommands()...)
+	cs = append(cs, currencyCommands()...)
+	cs = append(cs, tokenCommands()...)
+	cs = append(cs, dataCommands()...)
+	return cs
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/ -run 'TestParseImportArgs|TestImportSQLite' -v`
+Expected: PASS. Then `go build ./...` and `go vet ./...` to confirm the new imports wire up.
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+In the "CLI / management commands" list, add under the existing `data:remove-salt` grouping:
+
+```
+data:import-sqlite [--force] <sqlite-path>
+```
+
+And add a sentence after the `data:remove-salt` paragraph:
+
+> `data:import-sqlite` copies every table from an existing SQLite database into
+> the configured PostgreSQL (`DATABASE_URL` must be a `postgres://` URL). It runs
+> the PostgreSQL migrations on the target first (so a bare `createdb` works in one
+> step), then copies all app data in one transaction — `access_tokens` and
+> `currencies` included, the dead `messenger_messages` and the migration
+> bookkeeping tables excluded. It aborts if the target already holds data unless
+> `--force` is given, which truncates and replaces.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/data_commands.go internal/cli/cli.go internal/cli/data_commands_test.go CLAUDE.md
+git commit -m "feat(cli): data:import-sqlite command for SQLite->PostgreSQL migration"
+```
+
+---
+
+### Task 4: Full smoke + gofmt/vet gate
+
+**Files:** none (verification task).
+
+- [ ] **Step 1: Run gofmt check**
+
+Run: `gofmt -l internal/infra/storage/sqliteimport/ internal/cli/`
+Expected: no output (all files formatted).
+
+- [ ] **Step 2: Run the smoke suite**
+
+Run: `make go-test`
+Expected: PASS, coverage gate (`GO_COVER_MIN=78`) satisfied. `sqliteimport`'s pure `topoSort` tests and the CLI unit tests run here; the `enginecompare` integration test does not (correct — it's build-tagged).
+
+- [ ] **Step 3: Run the engine-comparison / pgsql suite (needs Postgres)**
+
+Run: `go test -tags enginecompare ./internal/infra/storage/sqliteimport/ -v`
+Expected: PASS (or SKIP only if `DATABASE_TEST_PGSQL_URL` is unset — in CI it runs; locally provision via the compose stack). If it SKIPs, note that the copy path is unverified until Postgres is available.
+
+- [ ] **Step 4: Manual end-to-end verification (documented, optional but recommended)**
+
+```bash
+# Build, seed a scratch SQLite instance, then import into a fresh Postgres.
+go build -o /tmp/econumo ./cmd/econumo
+# (Assuming a populated sqlite at /tmp/src.sqlite and a running empty Postgres.)
+DATABASE_URL='postgres://econumo:econumo@localhost:5432/econumo_new?sslmode=disable' \
+  /tmp/econumo data:import-sqlite /tmp/src.sqlite
+# Expect a per-table count report ending in "Imported N row(s) across M table(s)".
+# Then point the server at the same DATABASE_URL and confirm it boots (migrations
+# already recorded, so it runs none) and a known user can log in.
+```
+
+- [ ] **Step 5: Commit (if any formatting fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore(sqliteimport): gofmt + verification" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Command `data:import-sqlite <sqlite-path>` → Task 3.
+- Target-must-be-Postgres guard → Task 3 (`TestImportSQLite_RejectsNonPostgresTarget`).
+- Source opened read-only via registered sqlite backend → Task 3.
+- Command runs migrations on the target → Task 3 (`migrate.Run` before `Import`).
+- Overwrite policy: abort if target has data, `--force` truncates+replaces → Task 2 (`ErrTargetNotEmpty` + `TestImport_AbortsWhenTargetHasUsersWithoutForce`), surfaced in Task 3.
+- One transaction, FK-topological order, schema-derived from `information_schema` → Task 2 (`Import`, `listTables`, `tableColumns`, `fkEdges`, `topoSort`).
+- Boolean/NUMERIC/timestamp/UUID/NULL handling → Task 2 (`copyTable` + `TestImport_CopiesAllTablesWithTypes`).
+- Excluded tables → Task 1/2 (`excludedTables`).
+- Included: access_tokens, currencies (seed replaced) → Task 2 (truncate-then-copy; currency count assertion).
+- Testing: integration under enginecompare + pure unit tests → Tasks 1, 2, 3, 4.
+- Docs (CLAUDE.md) → Task 3 Step 5.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has an expected result.
+
+**Type consistency:** `Import`, `Report`, `TableCount`, `ErrTargetNotEmpty`, `topoSort`, `column`, `parseImportArgs`, `runImportSQLite`, `toMigratePg` are defined once and referenced with matching signatures across tasks. Driver name `"postgresql"` and backend key `"sqlite"` used consistently. `current_schema()` used in every introspection query.
+
+## Out of scope
+- PostgreSQL → SQLite (reverse).
+- Live/incremental sync (this is one-shot, offline).
+- Any schema change to either engine.

--- a/docs/superpowers/specs/2026-07-23-sqlite-to-pgsql-import-design.md
+++ b/docs/superpowers/specs/2026-07-23-sqlite-to-pgsql-import-design.md
@@ -1,0 +1,167 @@
+# Design: `data:import-sqlite` — SQLite → PostgreSQL data migration
+
+Date: 2026-07-23
+Status: Approved (pending spec review)
+
+## Problem
+
+A self-hoster running Econumo on the default SQLite engine wants to move to
+PostgreSQL. There is currently no supported path to carry existing data across.
+The two engines have genuinely different column types (Postgres `BOOLEAN`,
+`NUMERIC`, `UUID`, `TIMESTAMP` vs SQLite's `TEXT`/`INTEGER` affinity), so a naive
+SQL dump does not import cleanly (bare integer `0` will not go into a Postgres
+`BOOLEAN` column).
+
+## Chosen approach
+
+A new CLI subcommand under the existing `internal/cli` `resource:action`
+convention:
+
+```bash
+# DATABASE_URL points at the (fresh) Postgres target
+econumo data:import-sqlite /path/to/db.sqlite
+```
+
+It reads the source SQLite file and writes the configured Postgres database. A Go
+command is chosen over a bash/SQL-text generator because the binary already links
+both `modernc.org/sqlite` and `pgx` drivers: it reads real typed rows and writes
+them through `pgx`, so type coercion (booleans, decimals, timestamps, UUIDs) is
+handled by the drivers instead of fragile string substitution. It also fits the
+existing CLI pattern and is testable against the `enginecompare` Postgres
+provisioning.
+
+### Rejected alternatives
+
+- **Bash script emitting a `.sql` file** (the original idea): fragile boolean
+  handling, needs per-column schema knowledge in `sed`/`awk`, and must reproduce
+  the schema + `schema_migrations` by hand. The Go command sidesteps all of it.
+- **Data-only command assuming a pre-migrated target**: simpler command, but
+  needs a separate "boot the app once / run migrate" step first. Rejected in
+  favour of a true one-command flow (see Schema setup).
+
+## Command behaviour
+
+### 1. Guards
+
+- **Target must be Postgres.** If `cfg.DatabaseDriver` is not the Postgres
+  engine, abort with a clear message (importing SQLite→SQLite is a foot-gun/no-op).
+- **Source must exist.** Open the SQLite path read-only via the registered
+  `sqlite` backend (`backend.Get("sqlite").Open(ctx, "sqlite:///<abs-path>")`),
+  so the same pragmas (`foreign_keys`, busy timeout) apply. A missing/unreadable
+  file aborts with a clear message. The path argument is required; no arg → usage
+  error (exit 2), matching the other CLI commands.
+
+### 2. Schema setup — the command runs migrations on the target
+
+Before copying, run the normal migrate runner against the target:
+`migrate.Run(ctx, targetDB, pgsqlBackend.Migrations())`. This makes a bare
+`createdb`'d Postgres work in a single command: it creates the schema and fully
+populates `schema_migrations`, so a later app boot runs nothing. Migrations also
+insert their seed rows (the default USD currency `dffc2a06-…`, backfills) — these
+are removed and replaced by the source's own rows during the copy (see Overwrite
+policy), so no primary-key clash occurs.
+
+### 3. Overwrite policy — abort by default, `--force` to replace
+
+- If the target already holds real data (`SELECT count(*) FROM users > 0`), the
+  command **aborts** with a message telling the user to pass `--force`. This
+  prevents overwriting a live database.
+- With `--force`, the command truncates all app tables it is about to copy
+  (`TRUNCATE ... RESTART IDENTITY CASCADE`) inside the copy transaction, then
+  copies. The freshly-migrated seed rows (USD currency) are removed by this
+  truncate and replaced by the source rows, giving a faithful replica.
+- A freshly-migrated empty target (only seed rows, zero users) proceeds without
+  `--force`.
+
+### 4. Copy — one transaction, FK-topological order, schema-derived
+
+All copying happens in a single Postgres transaction (all-or-nothing). The
+command is schema-driven — it introspects the **target** `information_schema`
+rather than hardcoding anything, so it does not drift as migrations evolve:
+
+1. **Table list.** All base tables in the `public` schema, minus the exclusion
+   set (below).
+2. **Column names + types** per table from `information_schema.columns`. A column
+   with `data_type = 'boolean'` marks a boolean column.
+3. **FK topological order** from `information_schema` referential constraints:
+   parents before children, so inserts satisfy FK constraints without disabling
+   them. (The app schema has no table-level FK cycles.)
+
+For each table, in order: `SELECT <cols> FROM <table>` on the SQLite source; for
+each row, insert into Postgres with the same column list. Value handling:
+
+- **Boolean columns:** SQLite `0`/`1` (int64) → Go `bool`.
+- **Everything else** (TEXT ids/UUIDs, NUMERIC decimals stored as text,
+  `"2006-01-02 15:04:05"` timestamps, SMALLINT) passes through as its scanned
+  value; Postgres coerces from the text/number exactly. Decimal and timestamp
+  fidelity is preserved because the source stores them as canonical text already.
+- **NULLs** pass through as `NULL`.
+
+Inserts are batched (prepared statement reused, or `pgx.CopyFrom` as an
+optimisation) — dataset sizes for personal finance are modest (thousands of
+transactions), so correctness is prioritised over throughput; `CopyFrom` is a
+noted optional optimisation, not required for v1.
+
+### 5. Excluded tables
+
+- `messenger_messages` — dead Symfony leftover, unused, and the only `BIGSERIAL`
+  table (avoids sequence handling entirely).
+- `schema_migrations` — owned by the migrate runner (populated in step 2).
+- `migration_versions` — legacy external bookkeeping table; not part of the app
+  schema. (It only exists on very old installs; the runner reads it for drop-in
+  imports but the app never creates it.)
+
+Everything else is copied, **including**:
+
+- `access_tokens` — sessions and PATs survive the move (no forced re-login).
+- `currencies` — the seeded USD row is replaced by the source copy (same id).
+- `operation_requests_ids` — transient idempotency cache; copied for completeness
+  (harmless).
+
+### 6. Output
+
+- A per-table line: table name → rows copied.
+- A final summary: total rows, elapsed time.
+- Exit non-zero on any failure; the transaction rolls back so a failed import
+  never leaves a partial database.
+
+## Files
+
+- `internal/cli/data_commands.go` (new) — `dataCommands()` returning the
+  `data:import-sqlite` command; add `dataCommands()...` to `commandList()` in
+  `cli.go`. (The existing `data:remove-salt` command lives in
+  `user_commands.go`; leave it there — moving it is out of scope for this change.)
+- The copy engine (introspection + topo-sort + row copy) lives in a small
+  focused unit — e.g. `internal/cli/sqliteimport/` or an unexported helper in
+  `internal/infra/storage/` — so it is unit-testable independent of CLI plumbing.
+  Final placement decided in the implementation plan.
+- `internal/cli/container.go` — the command needs the raw target `*sql.DB`
+  (already on `container.db`) plus the ability to open the source SQLite and
+  fetch the pgsql backend's migrations; both via the `backend` registry already
+  imported.
+- Help text / usage in `cli.go` updated to list the new command.
+- `CLAUDE.md` — add `data:import-sqlite <sqlite-path>` to the CLI commands list.
+
+## Testing
+
+- **Integration test** (under the `enginecompare` tag, which provisions
+  Postgres): build a source SQLite fixture with `dbtest` + `fixture` (users,
+  accounts, transactions covering boolean/decimal/timestamp/NULL columns), run
+  the import into a fresh Postgres schema, then assert:
+  - per-table row counts match the source;
+  - a spot-check of representative rows round-trips byte-identically (a boolean
+    `is_deleted`, a `NUMERIC` amount, a timestamp, a NULL FK);
+  - the `--force`/abort guard: a second import without `--force` aborts; with
+    `--force` it replaces cleanly.
+- **Unit test** for the FK topological sort and boolean-column detection against
+  a synthetic `information_schema` shape (no DB needed), so the ordering logic is
+  covered cheaply.
+- No new golden files (this is a CLI/data path, not an HTTP route), so `apiparity`
+  is untouched.
+
+## Out of scope
+
+- PostgreSQL → SQLite (reverse direction).
+- Live/zero-downtime migration or incremental sync — this is a one-shot,
+  offline copy into a fresh target.
+- Any schema change to either engine.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,6 +25,7 @@ func commandList() []command {
 	cs = append(cs, userCommands()...)
 	cs = append(cs, currencyCommands()...)
 	cs = append(cs, tokenCommands()...)
+	cs = append(cs, dataCommands()...)
 	return cs
 }
 

--- a/internal/cli/data_commands.go
+++ b/internal/cli/data_commands.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/econumo/econumo/internal/infra/storage/backend"
+	"github.com/econumo/econumo/internal/infra/storage/migrate"
+	"github.com/econumo/econumo/internal/infra/storage/migrations"
+	"github.com/econumo/econumo/internal/infra/storage/sqliteimport"
+)
+
+func dataCommands() []command {
+	return []command{
+		{
+			name:    "data:import-sqlite",
+			summary: "Copy all data from a SQLite DB into the configured PostgreSQL: data:import-sqlite [--force] <sqlite-path>",
+			run:     runImportSQLite,
+		},
+	}
+}
+
+func parseImportArgs(args []string) (path string, force bool, err error) {
+	const usage = "data:import-sqlite [--force] <sqlite-path>"
+	for _, a := range args {
+		switch {
+		case a == "--force":
+			force = true
+		case strings.HasPrefix(a, "-"):
+			return "", false, usageErr(usage)
+		default:
+			if path != "" {
+				return "", false, usageErr(usage)
+			}
+			path = a
+		}
+	}
+	if path == "" {
+		return "", false, usageErr(usage)
+	}
+	return path, force, nil
+}
+
+func runImportSQLite(ctx context.Context, c *container, args []string) error {
+	path, force, err := parseImportArgs(args)
+	if err != nil {
+		return err
+	}
+
+	if c.cfg.DatabaseDriver != "postgresql" {
+		return fmt.Errorf("data:import-sqlite requires DATABASE_URL to point at PostgreSQL; current engine is %q", c.cfg.DatabaseDriver)
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return fmt.Errorf("source sqlite file: %w", err)
+	}
+
+	be, ok := backend.Get("sqlite")
+	if !ok {
+		return errors.New("sqlite backend not registered")
+	}
+	src, err := be.Open(ctx, abs)
+	if err != nil {
+		return fmt.Errorf("open source sqlite: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	// Bring the target to the current schema (schema + schema_migrations), so a
+	// bare createdb'd Postgres works in one command; migrate.Run is idempotent.
+	if err := migrate.Run(ctx, c.db, toMigratePg(migrations.Pgsql())); err != nil {
+		return fmt.Errorf("migrate target: %w", err)
+	}
+
+	start := time.Now()
+	report, err := sqliteimport.Import(ctx, src, c.db, force)
+	if err != nil {
+		if errors.Is(err, sqliteimport.ErrTargetNotEmpty) {
+			return errors.New("the target PostgreSQL already contains data; re-run with --force to truncate and replace it")
+		}
+		return err
+	}
+
+	for _, t := range report.Tables {
+		fmt.Printf("  %-32s %d\n", t.Name, t.Rows)
+	}
+	fmt.Printf("Imported %d row(s) across %d table(s) in %s.\n",
+		report.Total, len(report.Tables), time.Since(start).Round(time.Millisecond))
+	return nil
+}
+
+func toMigratePg(files []migrations.File) []migrate.Migration {
+	out := make([]migrate.Migration, len(files))
+	for i, f := range files {
+		out[i] = migrate.Migration{Version: f.Version, SQL: f.SQL}
+	}
+	return out
+}

--- a/internal/cli/data_commands_test.go
+++ b/internal/cli/data_commands_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/econumo/econumo/internal/config"
+)
+
+func TestParseImportArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		path    string
+		force   bool
+		wantErr bool
+	}{
+		{"path only", []string{"db.sqlite"}, "db.sqlite", false, false},
+		{"force before path", []string{"--force", "db.sqlite"}, "db.sqlite", true, false},
+		{"force after path", []string{"db.sqlite", "--force"}, "db.sqlite", true, false},
+		{"missing path", []string{}, "", false, true},
+		{"missing path with force", []string{"--force"}, "", false, true},
+		{"two paths", []string{"a.sqlite", "b.sqlite"}, "", false, true},
+		{"unknown flag", []string{"--nope", "db.sqlite"}, "", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, force, err := parseImportArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got path=%q force=%v", path, force)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if path != tc.path || force != tc.force {
+				t.Fatalf("got (%q,%v), want (%q,%v)", path, force, tc.path, tc.force)
+			}
+		})
+	}
+}
+
+func TestImportSQLite_RejectsNonPostgresTarget(t *testing.T) {
+	c := &container{cfg: config.Config{DatabaseDriver: "sqlite"}}
+	err := runImportSQLite(context.Background(), c, []string{"db.sqlite"})
+	if err == nil || !strings.Contains(err.Error(), "PostgreSQL") {
+		t.Fatalf("expected a PostgreSQL-required error, got %v", err)
+	}
+}

--- a/internal/infra/storage/sqliteimport/import_test.go
+++ b/internal/infra/storage/sqliteimport/import_test.go
@@ -50,7 +50,9 @@ func TestImport_CopiesAllTablesWithTypes(t *testing.T) {
 		t.Fatal("expected rows copied, got 0")
 	}
 
-	// Row counts: the source's currency replaced the seeded USD row.
+	// Row counts: TRUNCATE ... CASCADE removed the target's seeded USD row, then
+	// the copy inserted the source's rows (its own migration-seeded USD plus the
+	// inserted EUR).
 	var accounts, currencies, txns int
 	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM accounts`).Scan(&accounts)
 	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM currencies`).Scan(&currencies)
@@ -115,5 +117,21 @@ func TestImport_AbortsWhenTargetHasUsersWithoutForce(t *testing.T) {
 	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM users`).Scan(&users)
 	if users != 1 {
 		t.Fatalf("expected 1 user after forced replace, got %d", users)
+	}
+}
+
+func TestImport_AbortsOnSchemaVersionMismatch(t *testing.T) {
+	ctx := context.Background()
+	src := dbtest.NewSQLite(t)
+	dst := dbtest.NewPostgres(t)
+	seedSource(t, src)
+
+	// Simulate a source at an older schema by dropping one recorded migration
+	// version from its bookkeeping table. force=true proves the schema check
+	// runs regardless of the overwrite guard.
+	src.Exec(t, `DELETE FROM schema_migrations WHERE version = (SELECT max(version) FROM schema_migrations)`)
+
+	if _, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, true); !errors.Is(err, sqliteimport.ErrSchemaMismatch) {
+		t.Fatalf("expected ErrSchemaMismatch, got %v", err)
 	}
 }

--- a/internal/infra/storage/sqliteimport/import_test.go
+++ b/internal/infra/storage/sqliteimport/import_test.go
@@ -1,0 +1,119 @@
+//go:build enginecompare
+
+package sqliteimport_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/econumo/econumo/internal/infra/storage/sqliteimport"
+	"github.com/econumo/econumo/internal/test/dbtest"
+)
+
+// seedSource inserts one user, one currency, one account and one transaction into
+// a migrated SQLite DB, covering a boolean (is_deleted), a NUMERIC amount, a
+// timestamp, and a NULL FK (category_id). Returns the user id.
+func seedSource(t *testing.T, src *dbtest.DB) string {
+	t.Helper()
+	const uid = "0190a0aa-0000-7000-8000-000000000001"
+	const cid = "0190a0aa-0000-7000-8000-0000000000c1"
+	const aid = "0190a0aa-0000-7000-8000-0000000000a1"
+	const tid = "0190a0aa-0000-7000-8000-0000000000d1"
+	ts := "2026-07-23 10:00:00"
+	src.Exec(t, `INSERT INTO currencies (id, code, symbol, created_at) VALUES (?,?,?,?)`,
+		cid, "EUR", "€", ts)
+	src.Exec(t, `INSERT INTO users (id, identifier, email, name, avatar, password, salt, algorithm, language, is_active, email_verified, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		uid, uid, "a@b.test", "A", "diamond:sky", "x", "", "argon2id", "en", 1, 1, ts, ts)
+	src.Exec(t, `INSERT INTO accounts (id, currency_id, user_id, name, type, icon, is_deleted, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?)`,
+		aid, cid, uid, "Cash", 1, "wallet", 1, ts, ts)
+	src.Exec(t, `INSERT INTO transactions (id, user_id, account_id, type, amount, description, created_at, updated_at, spent_at)
+		VALUES (?,?,?,?,?,?,?,?,?)`,
+		tid, uid, aid, 1, "42.50", "lunch", ts, ts, ts)
+	return uid
+}
+
+func TestImport_CopiesAllTablesWithTypes(t *testing.T) {
+	ctx := context.Background()
+	src := dbtest.NewSQLite(t)
+	dst := dbtest.NewPostgres(t) // migrated; seeds the default USD currency
+
+	seedSource(t, src)
+
+	report, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, false)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if report.Total == 0 {
+		t.Fatal("expected rows copied, got 0")
+	}
+
+	// Row counts: the source's currency replaced the seeded USD row.
+	var accounts, currencies, txns int
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM accounts`).Scan(&accounts)
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM currencies`).Scan(&currencies)
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM transactions`).Scan(&txns)
+	if accounts != 1 || txns != 1 {
+		t.Fatalf("expected 1 account and 1 transaction, got %d / %d", accounts, txns)
+	}
+	// Both engines' migrations seed a default USD currency, so the source itself
+	// carries that seed plus the inserted EUR; the target's own seed row is
+	// truncated and replaced entirely by the source's two rows.
+	if currencies != 2 {
+		t.Fatalf("expected 2 currencies from the source (migration seed + inserted EUR), got %d", currencies)
+	}
+
+	// Boolean round-trip: is_deleted was 1 in SQLite -> true in Postgres.
+	var isDeleted bool
+	if err := dst.Raw.QueryRowContext(ctx, `SELECT is_deleted FROM accounts`).Scan(&isDeleted); err != nil {
+		t.Fatalf("scan is_deleted: %v", err)
+	}
+	if !isDeleted {
+		t.Fatal("expected is_deleted = true")
+	}
+
+	// NUMERIC round-trip: 42.50, rendered at the column's NUMERIC(19,8) scale.
+	var amount string
+	if err := dst.Raw.QueryRowContext(ctx, `SELECT amount::text FROM transactions`).Scan(&amount); err != nil {
+		t.Fatalf("scan amount: %v", err)
+	}
+	if amount != "42.50000000" {
+		t.Fatalf("expected amount 42.50000000, got %q", amount)
+	}
+
+	// NULL FK preserved.
+	var categoryNull bool
+	dst.Raw.QueryRowContext(ctx, `SELECT category_id IS NULL FROM transactions`).Scan(&categoryNull)
+	if !categoryNull {
+		t.Fatal("expected category_id to be NULL")
+	}
+}
+
+func TestImport_AbortsWhenTargetHasUsersWithoutForce(t *testing.T) {
+	ctx := context.Background()
+	src := dbtest.NewSQLite(t)
+	dst := dbtest.NewPostgres(t)
+	seedSource(t, src)
+
+	// Put a user into the target so the guard trips.
+	dst.Exec(t, dst.Rebind(`INSERT INTO users (id, identifier, email, name, avatar, password, salt, algorithm, language, is_active, email_verified, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`),
+		"0190a0aa-0000-7000-8000-0000000000e1", "0190a0aa-0000-7000-8000-0000000000e1", "x@y.test", "X", "diamond:sky", "x", "",
+		"argon2id", "en", true, true, "2026-07-23 10:00:00", "2026-07-23 10:00:00")
+
+	if _, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, false); !errors.Is(err, sqliteimport.ErrTargetNotEmpty) {
+		t.Fatalf("expected ErrTargetNotEmpty, got %v", err)
+	}
+
+	// With force it replaces cleanly.
+	if _, err := sqliteimport.Import(ctx, src.Raw, dst.Raw, true); err != nil {
+		t.Fatalf("Import(force): %v", err)
+	}
+	var users int
+	dst.Raw.QueryRowContext(ctx, `SELECT count(*) FROM users`).Scan(&users)
+	if users != 1 {
+		t.Fatalf("expected 1 user after forced replace, got %d", users)
+	}
+}

--- a/internal/infra/storage/sqliteimport/sqliteimport.go
+++ b/internal/infra/storage/sqliteimport/sqliteimport.go
@@ -17,6 +17,12 @@ import (
 // data and force is false; nothing is copied in that case.
 var ErrTargetNotEmpty = errors.New("target database already contains data")
 
+// ErrSchemaMismatch is returned when the source and target databases are at
+// different migration versions. The copier selects the target's columns out of
+// the source, so a version skew would silently drop columns/tables the two do
+// not share; refusing is safer than a partial import that reports success.
+var ErrSchemaMismatch = errors.New("source and target schema versions differ")
+
 type TableCount struct {
 	Name string
 	Rows int64
@@ -40,7 +46,6 @@ func topoSort(nodes []string, deps map[string][]string) ([]string, error) {
 	sort.Strings(sorted)
 
 	const (
-		white = 0
 		gray  = 1
 		black = 2
 	)
@@ -78,6 +83,35 @@ func topoSort(nodes []string, deps map[string][]string) ([]string, error) {
 	return order, nil
 }
 
+func schemaVersions(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	set := map[string]bool{}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		set[v] = true
+	}
+	return set, rows.Err()
+}
+
+func sameVersionSet(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
 var excludedTables = map[string]bool{
 	"messenger_messages": true,
 	"schema_migrations":  true,
@@ -90,6 +124,18 @@ type column struct {
 }
 
 func Import(ctx context.Context, src, dst *sql.DB, force bool) (Report, error) {
+	srcVers, err := schemaVersions(ctx, src)
+	if err != nil {
+		return Report{}, fmt.Errorf("sqliteimport: read source schema_migrations (was the SQLite database migrated by econumo?): %w", err)
+	}
+	dstVers, err := schemaVersions(ctx, dst)
+	if err != nil {
+		return Report{}, fmt.Errorf("sqliteimport: read target schema_migrations: %w", err)
+	}
+	if !sameVersionSet(srcVers, dstVers) {
+		return Report{}, fmt.Errorf("%w (source has %d applied migration(s), target has %d); boot the current econumo binary against the source SQLite once so it is on the latest schema, then retry", ErrSchemaMismatch, len(srcVers), len(dstVers))
+	}
+
 	tables, err := listTables(ctx, dst)
 	if err != nil {
 		return Report{}, err
@@ -98,6 +144,8 @@ func Import(ctx context.Context, src, dst *sql.DB, force bool) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
+	// The schema has no self-referential foreign keys, so rows within a table
+	// carry no intra-table ordering constraint; only cross-table order matters.
 	ordered, err := topoSort(tables, deps)
 	if err != nil {
 		return Report{}, err

--- a/internal/infra/storage/sqliteimport/sqliteimport.go
+++ b/internal/infra/storage/sqliteimport/sqliteimport.go
@@ -5,9 +5,12 @@
 package sqliteimport
 
 import (
+	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // ErrTargetNotEmpty is returned by Import when the target already holds user
@@ -73,4 +76,208 @@ func topoSort(nodes []string, deps map[string][]string) ([]string, error) {
 		}
 	}
 	return order, nil
+}
+
+var excludedTables = map[string]bool{
+	"messenger_messages": true,
+	"schema_migrations":  true,
+	"migration_versions": true,
+}
+
+type column struct {
+	name   string
+	isBool bool
+}
+
+func Import(ctx context.Context, src, dst *sql.DB, force bool) (Report, error) {
+	tables, err := listTables(ctx, dst)
+	if err != nil {
+		return Report{}, err
+	}
+	deps, err := fkEdges(ctx, dst, tables)
+	if err != nil {
+		return Report{}, err
+	}
+	ordered, err := topoSort(tables, deps)
+	if err != nil {
+		return Report{}, err
+	}
+
+	// Introspect every table's columns BEFORE opening the transaction: the copy
+	// runs inside a tx, and a constrained pool (tests pin MaxOpenConns=1) would
+	// deadlock if a metadata query needed a second connection mid-transaction.
+	cols := make(map[string][]column, len(ordered))
+	for _, table := range ordered {
+		c, err := tableColumns(ctx, dst, table)
+		if err != nil {
+			return Report{}, err
+		}
+		cols[table] = c
+	}
+
+	if !force {
+		var users int64
+		if err := dst.QueryRowContext(ctx, `SELECT count(*) FROM users`).Scan(&users); err != nil {
+			return Report{}, fmt.Errorf("sqliteimport: count users: %w", err)
+		}
+		if users > 0 {
+			return Report{}, ErrTargetNotEmpty
+		}
+	}
+
+	tx, err := dst.BeginTx(ctx, nil)
+	if err != nil {
+		return Report{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	quoted := make([]string, len(ordered))
+	for i, t := range ordered {
+		quoted[i] = pgIdent(t)
+	}
+	if _, err := tx.ExecContext(ctx, "TRUNCATE TABLE "+strings.Join(quoted, ", ")+" RESTART IDENTITY CASCADE"); err != nil {
+		return Report{}, fmt.Errorf("sqliteimport: truncate: %w", err)
+	}
+
+	report := Report{}
+	for _, table := range ordered {
+		n, err := copyTable(ctx, src, tx, table, cols[table])
+		if err != nil {
+			return Report{}, fmt.Errorf("sqliteimport: copy %q: %w", table, err)
+		}
+		report.Tables = append(report.Tables, TableCount{Name: table, Rows: n})
+		report.Total += n
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Report{}, err
+	}
+	return report, nil
+}
+
+func listTables(ctx context.Context, dst *sql.DB) ([]string, error) {
+	rows, err := dst.QueryContext(ctx, `
+		SELECT table_name FROM information_schema.tables
+		WHERE table_schema = current_schema() AND table_type = 'BASE TABLE'`)
+	if err != nil {
+		return nil, fmt.Errorf("sqliteimport: list tables: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		if excludedTables[name] {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
+}
+
+func tableColumns(ctx context.Context, dst *sql.DB, table string) ([]column, error) {
+	rows, err := dst.QueryContext(ctx, `
+		SELECT column_name, data_type FROM information_schema.columns
+		WHERE table_schema = current_schema() AND table_name = $1
+		ORDER BY ordinal_position`, table)
+	if err != nil {
+		return nil, fmt.Errorf("sqliteimport: columns of %q: %w", table, err)
+	}
+	defer rows.Close()
+	var out []column
+	for rows.Next() {
+		var name, dataType string
+		if err := rows.Scan(&name, &dataType); err != nil {
+			return nil, err
+		}
+		out = append(out, column{name: name, isBool: dataType == "boolean"})
+	}
+	return out, rows.Err()
+}
+
+func fkEdges(ctx context.Context, dst *sql.DB, tables []string) (map[string][]string, error) {
+	inSet := make(map[string]bool, len(tables))
+	for _, t := range tables {
+		inSet[t] = true
+	}
+	rows, err := dst.QueryContext(ctx, `
+		SELECT tc.table_name AS child, ccu.table_name AS parent
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.constraint_column_usage ccu
+		  ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
+		WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = current_schema()`)
+	if err != nil {
+		return nil, fmt.Errorf("sqliteimport: fk edges: %w", err)
+	}
+	defer rows.Close()
+	deps := map[string][]string{}
+	for rows.Next() {
+		var child, parent string
+		if err := rows.Scan(&child, &parent); err != nil {
+			return nil, err
+		}
+		if inSet[child] && inSet[parent] {
+			deps[child] = append(deps[child], parent)
+		}
+	}
+	return deps, rows.Err()
+}
+
+func copyTable(ctx context.Context, src *sql.DB, dstTx *sql.Tx, table string, cols []column) (int64, error) {
+	names := make([]string, len(cols))
+	placeholders := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = pgIdent(c.name)
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+	selectSQL := "SELECT " + strings.Join(names, ", ") + " FROM " + pgIdent(table)
+	insertSQL := "INSERT INTO " + pgIdent(table) + " (" + strings.Join(names, ", ") +
+		") VALUES (" + strings.Join(placeholders, ", ") + ")"
+
+	rows, err := src.QueryContext(ctx, selectSQL)
+	if err != nil {
+		return 0, fmt.Errorf("read: %w", err)
+	}
+	defer rows.Close()
+
+	stmt, err := dstTx.PrepareContext(ctx, insertSQL)
+	if err != nil {
+		return 0, fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	var count int64
+	vals := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	for rows.Next() {
+		if err := rows.Scan(ptrs...); err != nil {
+			return 0, fmt.Errorf("scan: %w", err)
+		}
+		for i, c := range cols {
+			switch v := vals[i].(type) {
+			case []byte:
+				vals[i] = string(v) // uuid/numeric/text columns reject bytea in simple protocol
+			case int64:
+				if c.isBool {
+					vals[i] = v != 0
+				}
+			}
+		}
+		if _, err := stmt.ExecContext(ctx, vals...); err != nil {
+			return 0, fmt.Errorf("insert: %w", err)
+		}
+		count++
+	}
+	return count, rows.Err()
+}
+
+// pgIdent double-quotes a PostgreSQL identifier. Table/column names here come
+// from information_schema (the target's own catalog), not user input.
+func pgIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/internal/infra/storage/sqliteimport/sqliteimport.go
+++ b/internal/infra/storage/sqliteimport/sqliteimport.go
@@ -1,0 +1,76 @@
+// Package sqliteimport copies an Econumo SQLite database into an
+// already-migrated PostgreSQL database. It introspects the target schema for the
+// table list, column types, and foreign-key order, so it carries no hardcoded
+// schema and does not drift as migrations evolve.
+package sqliteimport
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ErrTargetNotEmpty is returned by Import when the target already holds user
+// data and force is false; nothing is copied in that case.
+var ErrTargetNotEmpty = errors.New("target database already contains data")
+
+type TableCount struct {
+	Name string
+	Rows int64
+}
+
+type Report struct {
+	Tables []TableCount
+	Total  int64
+}
+
+// topoSort orders nodes so every table precedes the tables that reference it.
+// deps[child] lists child's referenced (parent) tables; edges to names outside
+// the node set are ignored (e.g. FKs into excluded tables). Order is
+// deterministic. A foreign-key cycle is an error.
+func topoSort(nodes []string, deps map[string][]string) ([]string, error) {
+	inSet := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		inSet[n] = true
+	}
+	sorted := append([]string(nil), nodes...)
+	sort.Strings(sorted)
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(nodes))
+	var order []string
+
+	var visit func(n string) error
+	visit = func(n string) error {
+		switch color[n] {
+		case black:
+			return nil
+		case gray:
+			return fmt.Errorf("sqliteimport: foreign-key cycle at table %q", n)
+		}
+		color[n] = gray
+		parents := append([]string(nil), deps[n]...)
+		sort.Strings(parents)
+		for _, p := range parents {
+			if p == n || !inSet[p] {
+				continue
+			}
+			if err := visit(p); err != nil {
+				return err
+			}
+		}
+		color[n] = black
+		order = append(order, n)
+		return nil
+	}
+	for _, n := range sorted {
+		if err := visit(n); err != nil {
+			return nil, err
+		}
+	}
+	return order, nil
+}

--- a/internal/infra/storage/sqliteimport/topo_test.go
+++ b/internal/infra/storage/sqliteimport/topo_test.go
@@ -1,0 +1,68 @@
+package sqliteimport
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTopoSort_ParentsBeforeChildren(t *testing.T) {
+	// transactions -> accounts -> currencies; accounts -> users; transactions -> users
+	nodes := []string{"transactions", "accounts", "currencies", "users"}
+	deps := map[string][]string{
+		"accounts":     {"currencies", "users"},
+		"transactions": {"accounts", "users"},
+	}
+	got, err := topoSort(nodes, deps)
+	if err != nil {
+		t.Fatalf("topoSort: %v", err)
+	}
+	pos := map[string]int{}
+	for i, n := range got {
+		pos[n] = i
+	}
+	if len(got) != len(nodes) {
+		t.Fatalf("expected %d nodes, got %d (%v)", len(nodes), len(got), got)
+	}
+	for child, parents := range deps {
+		for _, p := range parents {
+			if pos[p] > pos[child] {
+				t.Errorf("parent %q (%d) must precede child %q (%d): %v", p, pos[p], child, pos[child], got)
+			}
+		}
+	}
+}
+
+func TestTopoSort_Deterministic(t *testing.T) {
+	nodes := []string{"b", "a", "c"}
+	got1, _ := topoSort(nodes, nil)
+	got2, _ := topoSort(nodes, nil)
+	if !reflect.DeepEqual(got1, got2) {
+		t.Fatalf("not deterministic: %v vs %v", got1, got2)
+	}
+	if !reflect.DeepEqual(got1, []string{"a", "b", "c"}) {
+		t.Fatalf("expected sorted order with no deps, got %v", got1)
+	}
+}
+
+func TestTopoSort_CycleErrors(t *testing.T) {
+	nodes := []string{"a", "b"}
+	deps := map[string][]string{"a": {"b"}, "b": {"a"}}
+	_, err := topoSort(nodes, deps)
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("expected cycle error, got %v", err)
+	}
+}
+
+func TestTopoSort_EdgeToUnknownNodeIgnored(t *testing.T) {
+	// A parent that is not in the node set (e.g. an excluded table) is skipped.
+	nodes := []string{"a"}
+	deps := map[string][]string{"a": {"excluded"}}
+	got, err := topoSort(nodes, deps)
+	if err != nil {
+		t.Fatalf("topoSort: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"a"}) {
+		t.Fatalf("expected [a], got %v", got)
+	}
+}


### PR DESCRIPTION
Adds a CLI command to migrate an existing SQLite install to PostgreSQL:

```bash
# DATABASE_URL points at the (fresh) Postgres target
econumo data:import-sqlite [--force] /path/to/db.sqlite
```

## Why a Go command (not a bash→.sql generator)
The binary already links both `modernc.org/sqlite` and `pgx`, so it reads real typed rows and writes them through the drivers — booleans, `NUMERIC`, timestamps, and UUIDs coerce natively instead of via fragile SQL-text substitution. Fits the existing `internal/cli` `resource:action` pattern and is testable against the `enginecompare` Postgres harness.

## Behaviour
- **Target must be Postgres**; source SQLite opened read-only via the registered backend.
- **Runs the pgsql migrations on the target itself**, so a bare `createdb` works in one command (schema + `schema_migrations` populated → a later app boot runs nothing).
- **Schema-driven copy:** table list, column types (boolean detection), and FK topological order all come from the target's `information_schema` (`current_schema()`) — nothing hardcoded, no drift.
- **One transaction**, truncate-then-copy for a faithful replica; boolean/NUMERIC/timestamp/UUID/NULL handled correctly.
- **Overwrite guard:** aborts if the target already holds data unless `--force` (truncate + replace).
- **Schema-version parity preflight:** refuses if source and target are at different migration versions (prevents a silent partial import) — boot the current binary against the SQLite once first.
- **Included:** `access_tokens` (sessions survive), `currencies`. **Excluded:** `messenger_messages` (dead) + the migration bookkeeping tables.

## Testing
- Unit: pure topological-sort + CLI arg-parsing/driver-guard.
- Integration (`enginecompare`, live Postgres): copies user/account/transaction covering bool/NUMERIC/NULL round-trips; both sides of the `--force` guard; the schema-mismatch abort.
- Smoke suite `make go-test`: PASS, coverage 79.4% (gate 78%).
- Real end-to-end: migrated SQLite → import → report "7 rows / 28 tables"; server boots against the imported DB (`/health` ok, zero new migrations); `user:show` reads data back; guard verified.

## Docs
- Design: `docs/superpowers/specs/2026-07-23-sqlite-to-pgsql-import-design.md`
- Plan: `docs/superpowers/plans/2026-07-23-sqlite-to-pgsql-import.md`
- CLAUDE.md CLI list updated.

Deferred (non-blocking): dedupe the 4-line `File→Migration` adapter into a shared `migrate.FromFiles` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)