### PR TITLE
feat(currency): in-process rate updates via ECONUMO_CURRENCY_UPDATE_INTERVAL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,14 +69,12 @@ ECONUMO_ALLOW_REGISTRATION=true
 
 # Multi-currency support (https://econumo.com/docs/self-hosting/multi-currency/):
 # base currency (default USD) + Open Exchange Rates API token for rate updates.
+# ECONUMO_CURRENCY_UPDATE_INTERVAL (1-31) refreshes rates in-process every N days
+# (requires the token); unset or 0 = off, so you drive currency:update-rates from
+# your own cron. When set, serve refreshes on boot and every N days, skipping the
+# fetch while stored rates are still within N days (so restarts don't waste quota).
 # ECONUMO_CURRENCY_BASE=USD
 # OPEN_EXCHANGE_RATES_TOKEN=
-
-# Optional: refresh exchange rates in-process every N days (requires
-# OPEN_EXCHANGE_RATES_TOKEN above). Unset or 0 = off; the server never fetches
-# rates on its own and you drive currency:update-rates from your own cron. When
-# set, serve refreshes on boot and every N days, skipping the fetch while stored
-# rates are still within N days (so restarts don't waste API quota).
 # ECONUMO_CURRENCY_UPDATE_INTERVAL=1
 
 # DEPRECATED email-at-rest salt. The app now runs salt-free, so if you have

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,13 @@ ECONUMO_ALLOW_REGISTRATION=true
 # ECONUMO_CURRENCY_BASE=USD
 # OPEN_EXCHANGE_RATES_TOKEN=
 
+# Optional: refresh exchange rates in-process every N days (requires
+# OPEN_EXCHANGE_RATES_TOKEN above). Unset or 0 = off; the server never fetches
+# rates on its own and you drive currency:update-rates from your own cron. When
+# set, serve refreshes on boot and every N days, skipping the fetch while stored
+# rates are still within N days (so restarts don't waste API quota).
+# ECONUMO_CURRENCY_UPDATE_INTERVAL=1
+
 # DEPRECATED email-at-rest salt. The app now runs salt-free, so if you have
 # existing salted data you MUST migrate it or those users can't log in: set your
 # OLD salt below, `docker compose up -d`, then run (back up your DB first):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,15 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   `console://`/`log://`). Parsed once in `config.Load` (a bad scheme fails at boot). Replaces the former
   `RESEND_API_KEY` / `ECONUMO_MAIL_FROM` / `ECONUMO_MAIL_REPLY_TO`.
 - `OPEN_EXCHANGE_RATES_TOKEN` — currency-rate updates.
+- `ECONUMO_CURRENCY_UPDATE_INTERVAL` — refresh exchange rates in-process every N
+  DAYS. `0` (default/unset) = off (drive `currency:update-rates` from an external
+  cron as before). A positive `N` starts a background poller in `serve` **only
+  when `OPEN_EXCHANGE_RATES_TOKEN` is also set** (interval-without-token logs a
+  WARN at boot and stays off). Negative/malformed fails at boot. The poller
+  refreshes on boot then every N days and is DB-aware: it skips the fetch while
+  the newest stored rate is within N days, so a restart loop never burns API
+  quota. Idempotent per `(date, currency, base)`, so it is safe alongside an
+  existing external cron.
 - `SQLITE_BUSY_TIMEOUT` — SQLite `busy_timeout` PRAGMA in ms (default `0`); bare name mirrors the engine pragma.
 - `ECONUMO_RATE_LIMIT_LOGIN` / `ECONUMO_RATE_LIMIT_RESET` / `ECONUMO_RATE_LIMIT_REMIND` /
   `ECONUMO_RATE_LIMIT_REGISTER` — brute-force protection for the public auth endpoints:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,8 @@ The Go server reads its environment from `.env` (see `.env.example`). Key vars:
   DAYS. `0` (default/unset) = off (drive `currency:update-rates` from an external
   cron as before). A positive `N` starts a background poller in `serve` **only
   when `OPEN_EXCHANGE_RATES_TOKEN` is also set** (interval-without-token logs a
-  WARN at boot and stays off). Negative/malformed fails at boot. The poller
+  WARN at boot and stays off). Valid range is `1`-`31`; negative/malformed/over-31
+  fails at boot. The poller
   refreshes on boot then every N days and is DB-aware: it skips the fetch while
   the newest stored rate is within N days, so a restart loop never burns API
   quota. Idempotent per `(date, currency, base)`, so it is safe alongside an

--- a/cmd/econumo/main.go
+++ b/cmd/econumo/main.go
@@ -219,8 +219,9 @@ func run(serveArgs []string) error {
 	slog.Info("migrations applied", "backend", be.Name())
 
 	updates := system.NewService(cfg.CheckUpdates, system.DefaultFeedURL)
-	handler, adminHandler := server.Build(cfg, db, server.Seams{Updates: updates})
+	handler, adminHandler, rateUpdater := server.Build(cfg, db, server.Seams{Updates: updates})
 	updates.StartPolling(ctx)
+	rateUpdater.StartPolling(ctx)
 
 	// newServer applies the shared timeouts: a slow or stalled request body must
 	// not hold a connection/goroutine indefinitely, and WriteTimeout also bounds

--- a/docs/superpowers/plans/2026-07-23-in-process-currency-rate-updater.md
+++ b/docs/superpowers/plans/2026-07-23-in-process-currency-rate-updater.md
@@ -1,0 +1,724 @@
+# In-process Currency-Rate Updater Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `serve` refresh exchange rates in-process on a configurable day cadence when an Open Exchange Rates token is present, removing the need for an external cron.
+
+**Architecture:** A new opt-in env var `ECONUMO_CURRENCY_UPDATE_INTERVAL` (integer days) drives a background `RateUpdater` in `internal/currency` that mirrors the existing `system.Service.StartPolling` pattern (fetch on boot, then `time.Ticker`). Each run is DB-aware: it reads the newest stored rate date via a new `GetLatestRateDate` query and skips fetching when rates are already fresh, so restart loops don't burn API quota. Wired in `server.Build`, started only by `serve`; no new HTTP/MCP routes.
+
+**Tech Stack:** Go stdlib (`net/http`, `time`, `log/slog`), sqlc (per-engine query codegen), `internal/test/dbtest` for repo integration tests.
+
+## Global Constraints
+
+- Env naming: app-owned config is prefixed `ECONUMO_`. The new var is `ECONUMO_CURRENCY_UPDATE_INTERVAL` (integer day count).
+- Opt-in: unset/`0` = feature OFF (byte-identical to today's behavior). A negative or malformed value FAILS at boot.
+- The updater is enabled only when the interval is `> 0` AND `OPEN_EXCHANGE_RATES_TOKEN` (`cfg.OpenExchangeRatesToken`) is non-empty.
+- Background jobs never crash the server: every fetch error is logged and swallowed (mirror `system.Service.fetch`).
+- Rates are keyed by `(published_at, currency_id, base_currency_id)`; `published_at` is midnight UTC. The clock is UTC.
+- sqlc query `.sql` comments must stay ASCII-only (a multi-byte comment corrupts sqlite codegen in sqlc v1.30 — see the note atop `currency_write.sql`).
+- No new routes → do NOT regenerate or edit apiparity/mcpparity goldens.
+- Coverage gate: `make go-test` enforces `GO_COVER_MIN` (78). New code needs the tests in this plan.
+
+---
+
+### Task 1: Config — `ECONUMO_CURRENCY_UPDATE_INTERVAL`
+
+**Files:**
+- Modify: `internal/config/config.go` (struct field ~line 26; parse in `Load` after the `ECONUMO_TRIAL` block ~line 149)
+- Test: `internal/config/config_test.go`
+
+**Interfaces:**
+- Produces: `config.Config.CurrencyUpdateIntervalDays int` — days between in-process rate refreshes; `0` = disabled. Parsed with the existing `getIntStrict(key, def)` helper (fails at boot on negative/malformed).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/config/config_test.go`:
+
+```go
+func TestLoad_CurrencyUpdateInterval(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+
+	// Default: unset -> 0 (disabled).
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CurrencyUpdateIntervalDays != 0 {
+		t.Errorf("default = %d, want 0", c.CurrencyUpdateIntervalDays)
+	}
+
+	// Positive value is parsed.
+	t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", "3")
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CurrencyUpdateIntervalDays != 3 {
+		t.Errorf("interval = %d, want 3", c.CurrencyUpdateIntervalDays)
+	}
+}
+
+func TestLoad_CurrencyUpdateIntervalBadValueFailsBoot(t *testing.T) {
+	for _, bad := range []string{"-1", "abc", "1.5"} {
+		t.Run(bad, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+			t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", bad)
+			if _, err := Load(); err == nil {
+				t.Fatalf("Load: want error for %q, got nil", bad)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run TestLoad_CurrencyUpdateInterval -v`
+Expected: FAIL — `c.CurrencyUpdateIntervalDays` undefined (compile error).
+
+- [ ] **Step 3: Add the struct field**
+
+In `internal/config/config.go`, in the "Econumo behavior" block (next to `CheckUpdates`, ~line 26):
+
+```go
+	CurrencyUpdateIntervalDays int // ECONUMO_CURRENCY_UPDATE_INTERVAL: days between in-process rate refreshes; 0 (default) = off (requires OPEN_EXCHANGE_RATES_TOKEN)
+```
+
+- [ ] **Step 4: Parse it in `Load`**
+
+In `internal/config/config.go`, immediately after the `ECONUMO_TRIAL` block (after `c.TrialDays = days` closes, ~line 150):
+
+```go
+	// In-process rate refresh cadence in DAYS; 0 (default) disables it. Strict
+	// parse (like the rate limits): a negative/typo'd value must fail at boot,
+	// not silently disable the poller.
+	interval, err := getIntStrict("ECONUMO_CURRENCY_UPDATE_INTERVAL", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	c.CurrencyUpdateIntervalDays = interval
+```
+
+Note: `err` is already declared earlier in `Load` (used by `parseMailerDSN`), so use `=` not `:=` — the code above uses `interval, err :=` with a fresh `interval`, which is valid because `interval` is new. If the compiler complains `err` is unused/redeclared, switch to two lines: `var perr error; interval, perr := ...; if perr != nil { return Config{}, perr }`. Prefer the `interval, err :=` form first.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -run TestLoad_CurrencyUpdateInterval -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): ECONUMO_CURRENCY_UPDATE_INTERVAL (days; opt-in, strict)"
+```
+
+---
+
+### Task 2: Persistence — newest stored rate date
+
+**Files:**
+- Modify: `internal/infra/storage/sqlc/query/sqlite/currency_write.sql`
+- Modify: `internal/infra/storage/sqlc/query/pgsql/currency_write.sql`
+- Generate: `internal/infra/storage/sqlc/gen/{sqlite,pgsql}/currency_write.sql.go` + `querier.go` (via `go generate`)
+- Modify: `internal/currency/admin.go` (add method to `WriteModel` interface + `WriteService`; add `time` import)
+- Modify: `internal/currency/repo/write.go` (implement on `WriteRepo` + `writeQuerier` + both engine shims)
+- Test: `internal/currency/repo/write_integration_test.go` (new)
+
+**Interfaces:**
+- Produces: `currency.WriteModel.LatestRateDate(ctx context.Context) (time.Time, bool, error)` — newest stored rate date; `ok == false` means "no rates yet". Delegated by `(*currency.WriteService).LatestRateDate(ctx) (time.Time, bool, error)`.
+- Consumes: existing `seededUSD` const (`= "dffc2a06-6f29-4704-8575-31709adee926"`) from `internal/currency/repo/lookup_read_integration_test.go` (same `repo_test` package).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `internal/currency/repo/write_integration_test.go`:
+
+```go
+package repo_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	currencyrepo "github.com/econumo/econumo/internal/currency/repo"
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/shared/vo"
+	"github.com/econumo/econumo/internal/test/dbtest"
+)
+
+func TestWriteRepo_LatestRateDate(t *testing.T) {
+	db := dbtest.New(t)
+	w := currencyrepo.NewWriteRepo(db.Engine, db.TX)
+	ctx := context.Background()
+
+	// No rates yet -> ok=false.
+	if _, ok, err := w.LatestRateDate(ctx); err != nil || ok {
+		t.Fatalf("empty: ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+
+	// Seed two rates on different days; the newest wins.
+	for _, d := range []time.Time{
+		time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC),
+	} {
+		if err := w.UpsertRate(ctx, model.RateRow{
+			ID:             vo.NewId().String(),
+			CurrencyID:     seededUSD,
+			BaseCurrencyID: seededUSD,
+			Date:           d,
+			Rate:           "1.00000000",
+		}); err != nil {
+			t.Fatalf("UpsertRate: %v", err)
+		}
+	}
+
+	got, ok, err := w.LatestRateDate(ctx)
+	if err != nil || !ok {
+		t.Fatalf("LatestRateDate: ok=%v err=%v", ok, err)
+	}
+	if got.Format("2006-01-02") != "2026-07-22" {
+		t.Errorf("LatestRateDate = %s, want 2026-07-22", got.Format("2006-01-02"))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/currency/repo/ -run TestWriteRepo_LatestRateDate -v`
+Expected: FAIL — `w.LatestRateDate` undefined (compile error).
+
+- [ ] **Step 3: Add the query to BOTH engine `.sql` files**
+
+Append to `internal/infra/storage/sqlc/query/sqlite/currency_write.sql`:
+
+```sql
+-- name: GetLatestRateDate :one
+-- Newest stored rate date, for the in-process rate updater's freshness check.
+-- ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+-- (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+SELECT published_at FROM currencies_rates ORDER BY published_at DESC LIMIT 1;
+```
+
+Append to `internal/infra/storage/sqlc/query/pgsql/currency_write.sql` (identical SQL; keep the comment ASCII-only):
+
+```sql
+-- name: GetLatestRateDate :one
+-- Newest stored rate date, for the in-process rate updater's freshness check.
+-- ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+-- (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+SELECT published_at FROM currencies_rates ORDER BY published_at DESC LIMIT 1;
+```
+
+- [ ] **Step 4: Regenerate sqlc**
+
+Run: `go generate ./internal/infra/storage/sqlc/...`
+Then verify the generated signature in both engines is `GetLatestRateDate(ctx context.Context) (time.Time, error)`:
+
+Run: `grep -rn "func (q \*Queries) GetLatestRateDate" internal/infra/storage/sqlc/gen/`
+Expected: two matches, each returning `(time.Time, error)`.
+
+- [ ] **Step 5: Add the method to `writeQuerier` + both engine shims**
+
+In `internal/currency/repo/write.go`:
+
+Add to the `writeQuerier` interface:
+
+```go
+	GetLatestRateDate(ctx context.Context, db backend.DBTX) (time.Time, error)
+```
+
+Add the `WriteRepo` method (place after `UpsertRate`):
+
+```go
+// LatestRateDate returns the newest stored rate date; ok=false when no rates
+// exist yet (the in-process updater treats that as "must fetch").
+func (r *WriteRepo) LatestRateDate(ctx context.Context) (time.Time, bool, error) {
+	t, err := r.q.GetLatestRateDate(ctx, r.db(ctx))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, err
+	}
+	return t, true, nil
+}
+```
+
+Add to `sqliteWriteQuerier`:
+
+```go
+func (sqliteWriteQuerier) GetLatestRateDate(ctx context.Context, db backend.DBTX) (time.Time, error) {
+	return sqlitegen.New(db).GetLatestRateDate(ctx)
+}
+```
+
+Add to `pgsqlWriteQuerier`:
+
+```go
+func (pgsqlWriteQuerier) GetLatestRateDate(ctx context.Context, db backend.DBTX) (time.Time, error) {
+	return pgsqlgen.New(db).GetLatestRateDate(ctx)
+}
+```
+
+(`time`, `errors`, and `database/sql` are already imported in `write.go`.)
+
+- [ ] **Step 6: Extend `WriteModel` + `WriteService` in `admin.go`**
+
+In `internal/currency/admin.go`, add `"time"` to the import block, then add to the `WriteModel` interface (after `UpsertRate`):
+
+```go
+	// LatestRateDate returns the newest stored rate date; ok=false when none
+	// exist yet.
+	LatestRateDate(ctx context.Context) (time.Time, bool, error)
+```
+
+Add the `WriteService` delegate (place after `AvailableCodes`):
+
+```go
+// LatestRateDate returns the newest stored rate date; ok=false when no rates
+// exist yet. Used by the in-process rate updater's freshness check.
+func (s *WriteService) LatestRateDate(ctx context.Context) (time.Time, bool, error) {
+	return s.write.LatestRateDate(ctx)
+}
+```
+
+- [ ] **Step 7: Run the integration test + build**
+
+Run: `go build ./... && go test ./internal/currency/... -run TestWriteRepo_LatestRateDate -v`
+Expected: build OK; test PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/infra/storage/sqlc internal/currency/admin.go internal/currency/repo/write.go internal/currency/repo/write_integration_test.go
+git commit -m "feat(currency): GetLatestRateDate query + WriteService.LatestRateDate"
+```
+
+---
+
+### Task 3: The `RateUpdater` background poller
+
+**Files:**
+- Create: `internal/currency/rateupdater.go`
+- Test: `internal/currency/rateupdater_test.go` (package `currency`, white-box)
+
+**Interfaces:**
+- Consumes: `(*WriteService).LatestRateDate/AvailableCodes/UpdateRates` (Task 2 + existing), `port.Clock`, `model.RateInput`.
+- Produces:
+  - `type RateLoader interface { Load(ctx context.Context, date time.Time, base string, symbols []string) ([]model.RateInput, error) }` — satisfied by `repo.Loader`.
+  - `func NewRateUpdater(enabled bool, intervalDays int, base string, loader RateLoader, svc rateStore, clock port.Clock) *RateUpdater`
+  - `func (u *RateUpdater) StartPolling(ctx context.Context)` — no-op when disabled; else one goroutine (boot run + `time.Ticker`).
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `internal/currency/rateupdater_test.go`:
+
+```go
+package currency
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/econumo/econumo/internal/model"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (c fakeClock) Now() time.Time { return c.now }
+
+type fakeLoader struct {
+	calls   int
+	lastDay time.Time
+	rates   []model.RateInput
+}
+
+func (l *fakeLoader) Load(_ context.Context, date time.Time, _ string, _ []string) ([]model.RateInput, error) {
+	l.calls++
+	l.lastDay = date
+	return l.rates, nil
+}
+
+type fakeStore struct {
+	latest      time.Time
+	latestOK    bool
+	codes       []string
+	updated     int
+	updateCalls int
+}
+
+func (s *fakeStore) LatestRateDate(context.Context) (time.Time, bool, error) {
+	return s.latest, s.latestOK, nil
+}
+func (s *fakeStore) AvailableCodes(context.Context) ([]string, error) { return s.codes, nil }
+func (s *fakeStore) UpdateRates(_ context.Context, rates []model.RateInput) (int, error) {
+	s.updateCalls++
+	s.updated = len(rates)
+	return len(rates), nil
+}
+
+var today = time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC)
+
+func TestRateUpdater_DisabledNeverFetches(t *testing.T) {
+	loader := &fakeLoader{}
+	store := &fakeStore{}
+	u := NewRateUpdater(false, 1, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 0 || store.updateCalls != 0 {
+		t.Fatalf("disabled updater fetched: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+}
+
+func TestRateUpdater_FreshSkips(t *testing.T) {
+	loader := &fakeLoader{}
+	// Newest rate is today; interval 1 day -> fresh -> skip.
+	store := &fakeStore{latest: time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC), latestOK: true}
+	u := NewRateUpdater(true, 1, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 0 || store.updateCalls != 0 {
+		t.Fatalf("fresh rates should skip: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+}
+
+func TestRateUpdater_StaleFetches(t *testing.T) {
+	loader := &fakeLoader{rates: []model.RateInput{{Code: "EUR", Base: "USD", Rate: "0.9", Date: today}}}
+	// Newest rate is 3 days old; interval 1 day -> stale -> fetch.
+	store := &fakeStore{latest: time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC), latestOK: true, codes: []string{"EUR"}}
+	u := NewRateUpdater(true, 1, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 1 || store.updateCalls != 1 {
+		t.Fatalf("stale rates should fetch: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+	if loader.lastDay.Format("2006-01-02") != "2026-07-22" {
+		t.Errorf("loader called for %s, want 2026-07-22", loader.lastDay.Format("2006-01-02"))
+	}
+	if store.updated != 1 {
+		t.Errorf("updated %d rates, want 1", store.updated)
+	}
+}
+
+func TestRateUpdater_NoRatesFetches(t *testing.T) {
+	loader := &fakeLoader{rates: []model.RateInput{{Code: "EUR", Base: "USD", Rate: "0.9", Date: today}}}
+	store := &fakeStore{latestOK: false, codes: []string{"EUR"}} // empty DB
+	u := NewRateUpdater(true, 7, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 1 || store.updateCalls != 1 {
+		t.Fatalf("empty DB should fetch: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/currency/ -run TestRateUpdater -v`
+Expected: FAIL — `NewRateUpdater`/`updateOnce`/`rateStore` undefined (compile error).
+
+- [ ] **Step 3: Implement `internal/currency/rateupdater.go`**
+
+```go
+package currency
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/shared/port"
+)
+
+// RateLoader fetches exchange rates for a date/base/symbol set. The Open
+// Exchange Rates adapter (currency/repo.Loader) satisfies it; declared here so
+// this package does not import its own repo subpackage.
+type RateLoader interface {
+	Load(ctx context.Context, date time.Time, base string, symbols []string) ([]model.RateInput, error)
+}
+
+// rateStore is the write-side surface the updater needs. *WriteService satisfies it.
+type rateStore interface {
+	LatestRateDate(ctx context.Context) (time.Time, bool, error)
+	AvailableCodes(ctx context.Context) ([]string, error)
+	UpdateRates(ctx context.Context, rates []model.RateInput) (int, error)
+}
+
+// RateUpdater periodically refreshes exchange rates in-process. Only serve
+// starts it; when disabled (no interval, or no OER token) StartPolling is a
+// no-op, so tests and the CLI stay hermetic.
+type RateUpdater struct {
+	enabled  bool
+	interval time.Duration
+	base     string
+	loader   RateLoader
+	svc      rateStore
+	clock    port.Clock
+}
+
+// NewRateUpdater wires the updater. intervalDays is the refresh cadence in days;
+// enabled must already fold in the OER-token presence.
+func NewRateUpdater(enabled bool, intervalDays int, base string, loader RateLoader, svc rateStore, clock port.Clock) *RateUpdater {
+	return &RateUpdater{
+		enabled:  enabled,
+		interval: time.Duration(intervalDays) * 24 * time.Hour,
+		base:     base,
+		loader:   loader,
+		svc:      svc,
+		clock:    clock,
+	}
+}
+
+// StartPolling launches the background refresh (boot + every interval). No-op
+// when disabled. Only serve calls this; it exits on ctx cancellation.
+func (u *RateUpdater) StartPolling(ctx context.Context) {
+	if !u.enabled {
+		return
+	}
+	go func() {
+		u.updateOnce(ctx)
+		ticker := time.NewTicker(u.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				u.updateOnce(ctx)
+			}
+		}
+	}()
+}
+
+// updateOnce refreshes rates unless the newest stored rate is already within the
+// interval (DB-aware skip, so restart loops don't burn OER quota). All errors
+// are logged and swallowed: a background job must never crash the server.
+func (u *RateUpdater) updateOnce(ctx context.Context) {
+	if !u.enabled {
+		return
+	}
+	now := u.clock.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	if latest, ok, err := u.svc.LatestRateDate(ctx); err != nil {
+		slog.Debug("rate updater: latest-date check failed", "err", err)
+		// Fall through and try to fetch; a transient read error should not wedge
+		// the schedule.
+	} else if ok && today.Sub(latest) < u.interval {
+		slog.Debug("rate updater: rates fresh, skipping", "latest", latest.Format("2006-01-02"))
+		return
+	}
+
+	codes, err := u.svc.AvailableCodes(ctx)
+	if err != nil {
+		slog.Warn("rate updater: available-codes failed", "err", err)
+		return
+	}
+	rates, err := u.loader.Load(ctx, now, u.base, codes)
+	if err != nil {
+		slog.Warn("rate updater: load failed", "err", err)
+		return
+	}
+	n, err := u.svc.UpdateRates(ctx, rates)
+	if err != nil {
+		slog.Warn("rate updater: update failed", "err", err)
+		return
+	}
+	slog.Info("rate updater: rates refreshed", "loaded", len(rates), "updated", n)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/currency/ -run TestRateUpdater -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/currency/rateupdater.go internal/currency/rateupdater_test.go
+git commit -m "feat(currency): in-process RateUpdater (DB-aware, opt-in poller)"
+```
+
+---
+
+### Task 4: Wiring — build the updater in `server.Build`, start it in `serve`
+
+**Files:**
+- Modify: `internal/server/server.go` (`Build` signature + return; construct write repo/service, loader, updater)
+- Modify: `internal/server/server.go` (`BuildAPI` — discard the new return)
+- Modify: `cmd/econumo/main.go` (`serve` — start the updater)
+- Modify: `internal/server/glue_admin_test.go:37` (discard the new return)
+
+**Interfaces:**
+- Consumes: `config.Config.CurrencyUpdateIntervalDays`, `config.Config.OpenExchangeRatesToken` (Task 1), `appcurrency.NewRateUpdater` (Task 3), `appcurrency.NewWriteService`, `currencyrepo.NewWriteRepo`, `currencyrepo.NewLoader` (existing).
+- Produces: `func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handler, *appcurrency.RateUpdater)`.
+
+- [ ] **Step 1: Change `Build` to construct + return the updater**
+
+In `internal/server/server.go`, change the `Build` signature:
+
+```go
+func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handler, *appcurrency.RateUpdater) {
+```
+
+Near the existing currency read wiring (after line ~186, `currencyHandlers := handlercurrency.NewHandlers(currencyReadSvc)`), add the write-side + updater construction:
+
+```go
+	// In-process exchange-rate updater. Enabled only when a cadence is set AND an
+	// OER token is present; serve starts its poller (Build's third return),
+	// BuildAPI and tests discard it (a disabled updater never polls).
+	currencyWriteRepo := currencyrepo.NewWriteRepo(cfg.DatabaseDriver, txm)
+	currencyWriteSvc := appcurrency.NewWriteService(currencyWriteRepo, txm, clk)
+	rateLoader := currencyrepo.NewLoader(cfg.OpenExchangeRatesToken, clk.Now)
+	rateUpdaterEnabled := cfg.CurrencyUpdateIntervalDays > 0 && cfg.OpenExchangeRatesToken != ""
+	if cfg.CurrencyUpdateIntervalDays > 0 && cfg.OpenExchangeRatesToken == "" {
+		slog.Warn("ECONUMO_CURRENCY_UPDATE_INTERVAL is set but OPEN_EXCHANGE_RATES_TOKEN is empty; in-process rate updates are disabled")
+	}
+	rateUpdater := appcurrency.NewRateUpdater(
+		rateUpdaterEnabled, cfg.CurrencyUpdateIntervalDays, cfg.CurrencyBase,
+		rateLoader, currencyWriteSvc, clk,
+	)
+```
+
+`Build` currently ends (~line 311) with an inline first value:
+
+```go
+	return router.New(router.Deps{
+		Cfg:                cfg,
+		DB:                 pinger{db},
+		RegisterAPI:        registerAPI,
+		SupportedLanguages: i18n.Supported,
+		MCP:                mcpHandler,
+		SPA:                spaFS,
+		SPAVersion:         spaVersion,
+	}), adminHandler
+```
+
+Add `rateUpdater` as the third value — change the final line `}), adminHandler` to:
+
+```go
+	}), adminHandler, rateUpdater
+```
+
+Ensure `"log/slog"` is imported in `server.go` (add it if absent).
+
+- [ ] **Step 2: Update `BuildAPI` to discard the third value**
+
+In `internal/server/server.go`, `BuildAPI`:
+
+```go
+func BuildAPI(cfg config.Config, db *sql.DB, seams Seams) http.Handler {
+	api, _, _ := Build(cfg, db, seams)
+	return api
+}
+```
+
+- [ ] **Step 3: Update the admin glue test caller**
+
+In `internal/server/glue_admin_test.go:37`:
+
+```go
+	_, adminHandler, _ := server.Build(cfg, db.Raw, server.Seams{})
+```
+
+- [ ] **Step 4: Start the poller in `serve`**
+
+In `cmd/econumo/main.go`, at the `server.Build` call (~line 222) and the poller start (~line 223):
+
+```go
+	handler, adminHandler, rateUpdater := server.Build(cfg, db, server.Seams{Updates: updates})
+	updates.StartPolling(ctx)
+	rateUpdater.StartPolling(ctx)
+```
+
+- [ ] **Step 5: Build the whole tree + run the server + config + currency suites**
+
+Run: `go build ./... && go test ./internal/server/... ./internal/config/... ./internal/currency/...`
+Expected: build OK; all PASS. (No golden/parity changes — those suites must still pass untouched.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/server.go internal/server/glue_admin_test.go cmd/econumo/main.go
+git commit -m "feat(server): wire + start the in-process currency-rate updater"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `.env.example` (near `OPEN_EXCHANGE_RATES_TOKEN`, ~line 68)
+- Modify: `CLAUDE.md` (configuration list)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add the `.env.example` entry**
+
+In `.env.example`, after the `# OPEN_EXCHANGE_RATES_TOKEN=` line (~line 68):
+
+```bash
+# Optional: refresh exchange rates in-process every N days (requires
+# OPEN_EXCHANGE_RATES_TOKEN above). Unset or 0 = off; the server never fetches
+# rates on its own and you drive currency:update-rates from your own cron. When
+# set, serve refreshes on boot and every N days, skipping the fetch while stored
+# rates are still within N days (so restarts don't waste API quota).
+# ECONUMO_CURRENCY_UPDATE_INTERVAL=1
+```
+
+- [ ] **Step 2: Add the CLAUDE.md config entry**
+
+In `CLAUDE.md`, in the configuration bullet list, add an entry after the `OPEN_EXCHANGE_RATES_TOKEN` line (search for `OPEN_EXCHANGE_RATES_TOKEN — currency-rate updates.`):
+
+```markdown
+- `ECONUMO_CURRENCY_UPDATE_INTERVAL` — refresh exchange rates in-process every N
+  DAYS. `0` (default/unset) = off (drive `currency:update-rates` from an external
+  cron as before). A positive `N` starts a background poller in `serve` **only
+  when `OPEN_EXCHANGE_RATES_TOKEN` is also set** (interval-without-token logs a
+  WARN at boot and stays off). Negative/malformed fails at boot. The poller
+  refreshes on boot then every N days and is DB-aware: it skips the fetch while
+  the newest stored rate is within N days, so a restart loop never burns API
+  quota. Idempotent per `(date, currency, base)`, so it is safe alongside an
+  existing external cron.
+```
+
+- [ ] **Step 3: Verify docs render / no stray tokens**
+
+Run: `grep -n "ECONUMO_CURRENCY_UPDATE_INTERVAL" .env.example CLAUDE.md`
+Expected: one match in each file (plus the commented example line in `.env.example`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example CLAUDE.md
+git commit -m "docs: ECONUMO_CURRENCY_UPDATE_INTERVAL (.env.example + CLAUDE.md)"
+```
+
+---
+
+### Task 6: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the smoke suite**
+
+Run: `make go-test`
+Expected: PASS — build + vet + gofmt + OpenAPI-fresh + sqlite unit/integration + coverage ≥ 78. In particular apiparity/mcpparity goldens pass UNCHANGED (no new routes).
+
+- [ ] **Step 2: (If Postgres available) run the pgsql repo suite**
+
+Run: `make test-repo-pgsql`
+Expected: PASS — exercises the pgsql `GetLatestRateDate` adapter. If no Postgres is provisioned locally, note it as skipped; CI covers it.
+
+- [ ] **Step 3: Final gofmt/vet sweep**
+
+Run: `gofmt -l internal cmd && go vet ./...`
+Expected: no gofmt output; vet clean.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** config var (Task 1), DB-aware freshness query (Task 2), poller with boot+ticker and error-swallowing (Task 3), enablement gate + token WARN + wiring + serve start (Task 4), `.env.example`/CLAUDE.md docs (Task 5), no-new-routes verification (Task 6). All spec sections mapped.
+- **Type consistency:** `LatestRateDate(ctx) (time.Time, bool, error)` is identical across `WriteModel`, `WriteRepo`, `WriteService`, and the test `fakeStore`. `RateLoader.Load` matches `repo.Loader.Load` exactly. `NewRateUpdater(enabled, intervalDays, base, loader, svc, clock)` matches every call site (test + wiring). `Build` returns 3 values; all three callers (`BuildAPI`, `main.go`, `glue_admin_test.go`) updated.
+- **Freshness math:** `today.Sub(latest) < interval` with `interval = days*24h` and both dates at midnight UTC → with `days=1`, same-day skips, previous-day fetches (once per calendar day). Matches intent.

--- a/docs/superpowers/specs/2026-07-23-in-process-currency-rate-updater-design.md
+++ b/docs/superpowers/specs/2026-07-23-in-process-currency-rate-updater-design.md
@@ -1,0 +1,150 @@
+# In-process currency-rate updater
+
+**Date:** 2026-07-23
+**Status:** Approved design, pending implementation
+
+## Problem
+
+Exchange-rate updates today run only through the `currency:update-rates` CLI
+command, which self-hosters must drive from an external cron. We want the
+server itself to refresh rates on a schedule when it holds an Open Exchange
+Rates token, removing the need for an outside process.
+
+## Goals
+
+- A new env var sets how often (in days) `serve` refreshes rates in-process.
+- The feature is **opt-in**: unset/`0` keeps today's behavior (no in-process
+  updates), so existing external-cron deployments are unaffected.
+- Restart-safe: a frequently-restarting server must not burn OER API quota by
+  re-fetching on every boot.
+- No new HTTP/MCP surface; the CLI command stays as-is.
+
+## Non-goals
+
+- No change to `currency:update-rates` or the OER `Loader`.
+- No per-currency or per-base scheduling; one instance-wide cadence.
+- No backfill of historical dates; the poller fetches "today" only.
+
+## Configuration
+
+New field on `config.Config`:
+
+```go
+CurrencyUpdateIntervalDays int // ECONUMO_CURRENCY_UPDATE_INTERVAL: days between
+                               // in-process rate refreshes; 0 (default) = off
+```
+
+- Parsed with `getInt("ECONUMO_CURRENCY_UPDATE_INTERVAL", 0)`.
+- Validation in `config.Load` (with the other strict validators): a **negative**
+  value fails at boot with a clear message. `0` is valid (disabled).
+- The updater is enabled only when `CurrencyUpdateIntervalDays > 0` **and**
+  `OpenExchangeRatesToken != ""`. If the interval is set (`> 0`) but the token is
+  empty, `serve` logs a WARN at boot and the updater stays disabled — never a
+  silent no-op. (The WARN lives in `serve`/wiring, not `config.Load`, matching how
+  other "configured-but-inert" combinations are surfaced.)
+
+## Poller
+
+New type in a new file `internal/currency/rateupdater.go`, mirroring
+`system.Service.StartPolling`:
+
+```go
+type RateUpdater struct {
+    enabled  bool
+    interval time.Duration // intervalDays * 24h
+    days     int
+    base     string
+    loader   RateLoader
+    svc      *WriteService
+    clock    port.Clock
+}
+```
+
+- `RateLoader` is a small interface declared in the `currency` package so the
+  package does not import its own `repo` subpackage (keeps archtest clean):
+
+  ```go
+  type RateLoader interface {
+      Load(ctx context.Context, date time.Time, base string, symbols []string) ([]model.RateInput, error)
+  }
+  ```
+
+  The concrete `repo.Loader` already satisfies it and is injected at wiring time.
+
+- `StartPolling(ctx)` — no-op when `!enabled`; otherwise launches ONE goroutine
+  that runs `updateOnce` immediately (boot), then on a `time.Ticker` of
+  `intervalDays * 24h`, exiting on `ctx.Done()`. Only `serve` calls it; `BuildAPI`
+  (tests, CLI) never does, and a disabled updater no-ops regardless — so goldens
+  and parity stay hermetic.
+
+- `updateOnce(ctx)` (DB-aware skip):
+  1. `latest, ok := svc.LatestRateDate(ctx)` — newest stored rate date.
+  2. If `ok` and `today - latest < intervalDays`, skip with a DEBUG log
+     (this is what makes restart loops cheap — no fetch when rates are fresh).
+  3. Else `codes := svc.AvailableCodes(ctx)`, `rates := loader.Load(ctx, today, base, codes)`,
+     `n := svc.UpdateRates(ctx, rates)`, then an INFO line with loaded/updated counts.
+  - Any error is logged (WARN/DEBUG) and swallowed; a background job must never
+    crash the server, matching the release poller.
+
+"today" is `clock.Now()` truncated to the UTC date, consistent with how the CLI
+passes its date to the loader and how rates are keyed (`published_at` at midnight
+UTC).
+
+## Persistence
+
+New write query (both engines), regenerated with sqlc:
+
+```sql
+-- name: GetLatestRateDate :one
+-- Newest published_at across all stored rates; NULL when none exist yet.
+SELECT MAX(published_at) FROM currencies_rates;
+```
+
+- Implemented in `internal/currency/repo/write.go`; the nullable result maps to
+  `(time.Time, bool, error)` where `ok == false` means "no rates yet".
+- Added to the `currency.WriteModel` interface; `WriteService` gains a thin
+  `LatestRateDate(ctx) (time.Time, bool, error)` delegating to it.
+- The two engines differ in how `MAX(published_at)` comes back (sqlite text vs
+  pgsql), handled by the existing per-engine adapter shims — no branching in the
+  method body. `enginecompare` is not exercised here (no wire surface), but
+  `make test-repo-pgsql` covers the pgsql adapter.
+
+## Wiring
+
+In `server.Build`:
+
+- Build `currencyWriteRepo := currencyrepo.NewWriteRepo(...)` and
+  `currencyWriteSvc := appcurrency.NewWriteService(currencyWriteRepo, txm, clk)`
+  (today built only in the CLI container).
+- Build `loader := currencyrepo.NewLoader(cfg.OpenExchangeRatesToken, clk.Now)`.
+- Build the updater:
+  `rateUpdater := appcurrency.NewRateUpdater(enabled, cfg.CurrencyUpdateIntervalDays, cfg.CurrencyBase, loader, currencyWriteSvc, clk)`
+  where `enabled = cfg.CurrencyUpdateIntervalDays > 0 && cfg.OpenExchangeRatesToken != ""`.
+  Emit the token-missing WARN here when `interval > 0 && token == ""`.
+- `Build` returns the updater as an additional value; `BuildAPI` discards it.
+- `serve` (`cmd/econumo/main.go`) calls `rateUpdater.StartPolling(ctx)` right
+  after `updates.StartPolling(ctx)`.
+
+## Docs
+
+- `.env.example`: a commented `# ECONUMO_CURRENCY_UPDATE_INTERVAL=` line next to
+  `OPEN_EXCHANGE_RATES_TOKEN`, explaining opt-in + token requirement.
+- `CLAUDE.md`: an entry in the configuration list describing the var, its opt-in
+  default, the token dependency, and the DB-aware restart behavior.
+
+## Testing
+
+- `config_test.go`: parses a positive value; `0`/unset → disabled; a negative
+  value fails `Load`.
+- `internal/currency/rateupdater_test.go`: a fake `RateLoader` + a fake service
+  (implementing `LatestRateDate`/`AvailableCodes`/`UpdateRates`) covering:
+  - disabled (interval 0, or token empty) → `updateOnce` never fetches;
+  - fresh rates (latest within interval) → skip, no `Load` call;
+  - stale/absent rates → `Load` + `UpdateRates` called with today's date.
+- No new routes → apiparity/mcpparity goldens untouched.
+
+## Rollout / compatibility
+
+Purely additive and opt-in. Unset var = byte-identical behavior to today.
+Setting the var on an instance that also runs external cron is harmless: rate
+upserts are idempotent per `(date, currency, base)`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,14 +19,15 @@ type Config struct {
 	DatabaseDriver string // "sqlite" | "postgresql" — DERIVED from DatabaseURL's scheme
 
 	// Econumo behavior
-	CurrencyBase      string // default "USD"
-	AllowRegistration bool
-	DataSalt          string // ECONUMO_DATA_SALT. DEPRECATED and IGNORED by the API/repositories (they run salt-free); consumed only by the data:remove-salt migration to decrypt existing data. Unset it after migrating.
-	SQLiteBusyTimeout int
-	CheckUpdates      bool // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
-	Analytics         bool // ECONUMO_ANALYTICS: SPA sends anonymous product events to PostHog (default true)
-	TrialDays         int  // ECONUMO_TRIAL: length in days of the trial granted to a new self-service registration; 0 (default, also "none"/empty) grants no trial, i.e. permanent full access
-	EmailVerification bool // ECONUMO_EMAIL_VERIFICATION: unverified users must confirm an emailed code at login (default false)
+	CurrencyBase               string // default "USD"
+	AllowRegistration          bool
+	DataSalt                   string // ECONUMO_DATA_SALT. DEPRECATED and IGNORED by the API/repositories (they run salt-free); consumed only by the data:remove-salt migration to decrypt existing data. Unset it after migrating.
+	SQLiteBusyTimeout          int
+	CheckUpdates               bool // ECONUMO_CHECK_UPDATES: poll econumo.com for the latest release (default true)
+	Analytics                  bool // ECONUMO_ANALYTICS: SPA sends anonymous product events to PostHog (default true)
+	TrialDays                  int  // ECONUMO_TRIAL: length in days of the trial granted to a new self-service registration; 0 (default, also "none"/empty) grants no trial, i.e. permanent full access
+	EmailVerification          bool // ECONUMO_EMAIL_VERIFICATION: unverified users must confirm an emailed code at login (default false)
+	CurrencyUpdateIntervalDays int  // ECONUMO_CURRENCY_UPDATE_INTERVAL: days between in-process rate refreshes; 0 (default) = off (requires OPEN_EXCHANGE_RATES_TOKEN)
 
 	// Admin listener for the payment portal. Both empty on a self-hosted
 	// instance, so the listener never opens and its routes exist on no mux.
@@ -156,6 +157,15 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	c.EmailVerification = emailVerification
+
+	// In-process rate refresh cadence in DAYS; 0 (default) disables it. Strict
+	// parse (like the rate limits): a negative/typo'd value must fail at boot,
+	// not silently disable the poller.
+	interval, err := getIntStrict("ECONUMO_CURRENCY_UPDATE_INTERVAL", 0)
+	if err != nil {
+		return Config{}, err
+	}
+	c.CurrencyUpdateIntervalDays = interval
 
 	c.AdminPort = getEnv("ECONUMO_ADMIN_PORT", "")
 	c.AdminToken = getEnv("ECONUMO_ADMIN_TOKEN", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,11 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	// Sanity cap: a rate-refresh cadence beyond ~10 years is a misconfiguration,
+	// and a huge value would overflow the time.Duration used for the poller ticker.
+	if interval > 3650 {
+		return Config{}, fmt.Errorf("ECONUMO_CURRENCY_UPDATE_INTERVAL %d is too large (max 3650 days)", interval)
+	}
 	c.CurrencyUpdateIntervalDays = interval
 
 	c.AdminPort = getEnv("ECONUMO_ADMIN_PORT", "")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,10 +165,11 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	// Sanity cap: a rate-refresh cadence beyond ~10 years is a misconfiguration,
-	// and a huge value would overflow the time.Duration used for the poller ticker.
-	if interval > 3650 {
-		return Config{}, fmt.Errorf("ECONUMO_CURRENCY_UPDATE_INTERVAL %d is too large (max 3650 days)", interval)
+	// A refresh cadence beyond a month is a misconfiguration (rates are daily),
+	// so cap it; this also keeps the poller's time.Duration ticker well clear of
+	// overflow.
+	if interval > 31 {
+		return Config{}, fmt.Errorf("ECONUMO_CURRENCY_UPDATE_INTERVAL %d is too large (max 31 days)", interval)
 	}
 	c.CurrencyUpdateIntervalDays = interval
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -514,3 +514,38 @@ func TestLoad_EmailVerification(t *testing.T) {
 		t.Error("malformed ECONUMO_EMAIL_VERIFICATION must fail at boot")
 	}
 }
+
+func TestLoad_CurrencyUpdateInterval(t *testing.T) {
+	t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+
+	// Default: unset -> 0 (disabled).
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CurrencyUpdateIntervalDays != 0 {
+		t.Errorf("default = %d, want 0", c.CurrencyUpdateIntervalDays)
+	}
+
+	// Positive value is parsed.
+	t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", "3")
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CurrencyUpdateIntervalDays != 3 {
+		t.Errorf("interval = %d, want 3", c.CurrencyUpdateIntervalDays)
+	}
+}
+
+func TestLoad_CurrencyUpdateIntervalBadValueFailsBoot(t *testing.T) {
+	for _, bad := range []string{"-1", "abc", "1.5"} {
+		t.Run(bad, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
+			t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", bad)
+			if _, err := Load(); err == nil {
+				t.Fatalf("Load: want error for %q, got nil", bad)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -539,7 +539,7 @@ func TestLoad_CurrencyUpdateInterval(t *testing.T) {
 }
 
 func TestLoad_CurrencyUpdateIntervalBadValueFailsBoot(t *testing.T) {
-	for _, bad := range []string{"-1", "abc", "1.5"} {
+	for _, bad := range []string{"-1", "abc", "1.5", "99999999"} {
 		t.Run(bad, func(t *testing.T) {
 			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
 			t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", bad)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -536,10 +536,21 @@ func TestLoad_CurrencyUpdateInterval(t *testing.T) {
 	if c.CurrencyUpdateIntervalDays != 3 {
 		t.Errorf("interval = %d, want 3", c.CurrencyUpdateIntervalDays)
 	}
+
+	// 31 is the maximum accepted value (one month).
+	t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", "31")
+	c, err = Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CurrencyUpdateIntervalDays != 31 {
+		t.Errorf("interval = %d, want 31", c.CurrencyUpdateIntervalDays)
+	}
 }
 
 func TestLoad_CurrencyUpdateIntervalBadValueFailsBoot(t *testing.T) {
-	for _, bad := range []string{"-1", "abc", "1.5", "99999999"} {
+	// -1/abc/1.5 are malformed; 32 is just over the 31-day cap; 99999999 is absurd.
+	for _, bad := range []string{"-1", "abc", "1.5", "32", "99999999"} {
 		t.Run(bad, func(t *testing.T) {
 			t.Setenv("DATABASE_URL", "sqlite:///tmp/x.sqlite")
 			t.Setenv("ECONUMO_CURRENCY_UPDATE_INTERVAL", bad)

--- a/internal/currency/admin.go
+++ b/internal/currency/admin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/econumo/econumo/internal/model"
 	"github.com/econumo/econumo/internal/shared/errs"
@@ -29,6 +30,9 @@ type WriteModel interface {
 	InsertCurrency(ctx context.Context, c model.CurrencyRow) error
 	// UpsertRate inserts or updates a single (date, currency, base) rate.
 	UpsertRate(ctx context.Context, r model.RateRow) error
+	// LatestRateDate returns the newest stored rate date; ok=false when none
+	// exist yet.
+	LatestRateDate(ctx context.Context) (time.Time, bool, error)
 }
 
 // WriteService is the currency write-use-case orchestrator.
@@ -59,6 +63,12 @@ func (s *WriteService) AvailableCodes(ctx context.Context) ([]string, error) {
 	// deterministic (the source map iteration order is not).
 	sort.Strings(out)
 	return out, nil
+}
+
+// LatestRateDate returns the newest stored rate date; ok=false when no rates
+// exist yet. Used by the in-process rate updater's freshness check.
+func (s *WriteService) LatestRateDate(ctx context.Context) (time.Time, bool, error) {
+	return s.write.LatestRateDate(ctx)
 }
 
 // UpdateRates upserts every loaded rate whose currency AND base code both resolve

--- a/internal/currency/rateupdater.go
+++ b/internal/currency/rateupdater.go
@@ -80,7 +80,7 @@ func (u *RateUpdater) updateOnce(ctx context.Context) {
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 
 	if latest, ok, err := u.svc.LatestRateDate(ctx); err != nil {
-		slog.Debug("rate updater: latest-date check failed", "err", err)
+		slog.Warn("rate updater: latest-date check failed", "err", err)
 		// Fall through and try to fetch; a transient read error should not wedge
 		// the schedule.
 	} else if ok && today.Sub(latest) < u.interval {

--- a/internal/currency/rateupdater.go
+++ b/internal/currency/rateupdater.go
@@ -1,0 +1,107 @@
+package currency
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/shared/port"
+)
+
+// RateLoader fetches exchange rates for a date/base/symbol set. The Open
+// Exchange Rates adapter (currency/repo.Loader) satisfies it; declared here so
+// this package does not import its own repo subpackage.
+type RateLoader interface {
+	Load(ctx context.Context, date time.Time, base string, symbols []string) ([]model.RateInput, error)
+}
+
+// rateStore is the write-side surface the updater needs. *WriteService satisfies it.
+type rateStore interface {
+	LatestRateDate(ctx context.Context) (time.Time, bool, error)
+	AvailableCodes(ctx context.Context) ([]string, error)
+	UpdateRates(ctx context.Context, rates []model.RateInput) (int, error)
+}
+
+// RateUpdater periodically refreshes exchange rates in-process. Only serve
+// starts it; when disabled (no interval, or no OER token) StartPolling is a
+// no-op, so tests and the CLI stay hermetic.
+type RateUpdater struct {
+	enabled  bool
+	interval time.Duration
+	base     string
+	loader   RateLoader
+	svc      rateStore
+	clock    port.Clock
+}
+
+// NewRateUpdater wires the updater. intervalDays is the refresh cadence in days;
+// enabled must already fold in the OER-token presence.
+func NewRateUpdater(enabled bool, intervalDays int, base string, loader RateLoader, svc rateStore, clock port.Clock) *RateUpdater {
+	return &RateUpdater{
+		enabled:  enabled,
+		interval: time.Duration(intervalDays) * 24 * time.Hour,
+		base:     base,
+		loader:   loader,
+		svc:      svc,
+		clock:    clock,
+	}
+}
+
+// StartPolling launches the background refresh (boot + every interval). No-op
+// when disabled. Only serve calls this; it exits on ctx cancellation.
+func (u *RateUpdater) StartPolling(ctx context.Context) {
+	if !u.enabled {
+		return
+	}
+	go func() {
+		u.updateOnce(ctx)
+		ticker := time.NewTicker(u.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				u.updateOnce(ctx)
+			}
+		}
+	}()
+}
+
+// updateOnce refreshes rates unless the newest stored rate is already within the
+// interval (DB-aware skip, so restart loops don't burn OER quota). All errors
+// are logged and swallowed: a background job must never crash the server.
+func (u *RateUpdater) updateOnce(ctx context.Context) {
+	if !u.enabled {
+		return
+	}
+	now := u.clock.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	if latest, ok, err := u.svc.LatestRateDate(ctx); err != nil {
+		slog.Debug("rate updater: latest-date check failed", "err", err)
+		// Fall through and try to fetch; a transient read error should not wedge
+		// the schedule.
+	} else if ok && today.Sub(latest) < u.interval {
+		slog.Debug("rate updater: rates fresh, skipping", "latest", latest.Format("2006-01-02"))
+		return
+	}
+
+	codes, err := u.svc.AvailableCodes(ctx)
+	if err != nil {
+		slog.Warn("rate updater: available-codes failed", "err", err)
+		return
+	}
+	rates, err := u.loader.Load(ctx, now, u.base, codes)
+	if err != nil {
+		slog.Warn("rate updater: load failed", "err", err)
+		return
+	}
+	n, err := u.svc.UpdateRates(ctx, rates)
+	if err != nil {
+		slog.Warn("rate updater: update failed", "err", err)
+		return
+	}
+	slog.Info("rate updater: rates refreshed", "loaded", len(rates), "updated", n)
+}

--- a/internal/currency/rateupdater_test.go
+++ b/internal/currency/rateupdater_test.go
@@ -1,0 +1,93 @@
+package currency
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/econumo/econumo/internal/model"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (c fakeClock) Now() time.Time { return c.now }
+
+type fakeLoader struct {
+	calls   int
+	lastDay time.Time
+	rates   []model.RateInput
+}
+
+func (l *fakeLoader) Load(_ context.Context, date time.Time, _ string, _ []string) ([]model.RateInput, error) {
+	l.calls++
+	l.lastDay = date
+	return l.rates, nil
+}
+
+type fakeStore struct {
+	latest      time.Time
+	latestOK    bool
+	codes       []string
+	updated     int
+	updateCalls int
+}
+
+func (s *fakeStore) LatestRateDate(context.Context) (time.Time, bool, error) {
+	return s.latest, s.latestOK, nil
+}
+func (s *fakeStore) AvailableCodes(context.Context) ([]string, error) { return s.codes, nil }
+func (s *fakeStore) UpdateRates(_ context.Context, rates []model.RateInput) (int, error) {
+	s.updateCalls++
+	s.updated = len(rates)
+	return len(rates), nil
+}
+
+var today = time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC)
+
+func TestRateUpdater_DisabledNeverFetches(t *testing.T) {
+	loader := &fakeLoader{}
+	store := &fakeStore{}
+	u := NewRateUpdater(false, 1, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 0 || store.updateCalls != 0 {
+		t.Fatalf("disabled updater fetched: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+}
+
+func TestRateUpdater_FreshSkips(t *testing.T) {
+	loader := &fakeLoader{}
+	// Newest rate is today; interval 1 day -> fresh -> skip.
+	store := &fakeStore{latest: time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC), latestOK: true}
+	u := NewRateUpdater(true, 1, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 0 || store.updateCalls != 0 {
+		t.Fatalf("fresh rates should skip: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+}
+
+func TestRateUpdater_StaleFetches(t *testing.T) {
+	loader := &fakeLoader{rates: []model.RateInput{{Code: "EUR", Base: "USD", Rate: "0.9", Date: today}}}
+	// Newest rate is 3 days old; interval 1 day -> stale -> fetch.
+	store := &fakeStore{latest: time.Date(2026, 7, 19, 0, 0, 0, 0, time.UTC), latestOK: true, codes: []string{"EUR"}}
+	u := NewRateUpdater(true, 1, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 1 || store.updateCalls != 1 {
+		t.Fatalf("stale rates should fetch: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+	if loader.lastDay.Format("2006-01-02") != "2026-07-22" {
+		t.Errorf("loader called for %s, want 2026-07-22", loader.lastDay.Format("2006-01-02"))
+	}
+	if store.updated != 1 {
+		t.Errorf("updated %d rates, want 1", store.updated)
+	}
+}
+
+func TestRateUpdater_NoRatesFetches(t *testing.T) {
+	loader := &fakeLoader{rates: []model.RateInput{{Code: "EUR", Base: "USD", Rate: "0.9", Date: today}}}
+	store := &fakeStore{latestOK: false, codes: []string{"EUR"}} // empty DB
+	u := NewRateUpdater(true, 7, "USD", loader, store, fakeClock{today})
+	u.updateOnce(context.Background())
+	if loader.calls != 1 || store.updateCalls != 1 {
+		t.Fatalf("empty DB should fetch: load=%d update=%d", loader.calls, store.updateCalls)
+	}
+}

--- a/internal/currency/repo/write.go
+++ b/internal/currency/repo/write.go
@@ -30,6 +30,7 @@ type writeQuerier interface {
 	GetCurrencyByCode(ctx context.Context, db backend.DBTX, code string) error
 	InsertCurrency(ctx context.Context, db backend.DBTX, p insertCurrencyP) error
 	UpsertCurrencyRate(ctx context.Context, db backend.DBTX, p upsertRateP) error
+	GetLatestRateDate(ctx context.Context, db backend.DBTX) (time.Time, error)
 }
 
 // WriteRepo implements app/currency.WriteModel over the sqlc write queries.
@@ -105,6 +106,19 @@ func (r *WriteRepo) UpsertRate(ctx context.Context, rr model.RateRow) error {
 	})
 }
 
+// LatestRateDate returns the newest stored rate date; ok=false when no rates
+// exist yet (the in-process updater treats that as "must fetch").
+func (r *WriteRepo) LatestRateDate(ctx context.Context) (time.Time, bool, error) {
+	t, err := r.q.GetLatestRateDate(ctx, r.db(ctx))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, err
+	}
+	return t, true, nil
+}
+
 // sqliteWriteQuerier is the native passthrough (canonical types ARE sqlite's).
 type sqliteWriteQuerier struct{}
 
@@ -125,6 +139,10 @@ func (sqliteWriteQuerier) InsertCurrency(ctx context.Context, db backend.DBTX, p
 
 func (sqliteWriteQuerier) UpsertCurrencyRate(ctx context.Context, db backend.DBTX, p upsertRateP) error {
 	return sqlitegen.New(db).UpsertCurrencyRate(ctx, p)
+}
+
+func (sqliteWriteQuerier) GetLatestRateDate(ctx context.Context, db backend.DBTX) (time.Time, error) {
+	return sqlitegen.New(db).GetLatestRateDate(ctx)
 }
 
 // pgsqlWriteQuerier is the thin whole-struct conversion shim.
@@ -155,4 +173,8 @@ func (pgsqlWriteQuerier) InsertCurrency(ctx context.Context, db backend.DBTX, p 
 
 func (pgsqlWriteQuerier) UpsertCurrencyRate(ctx context.Context, db backend.DBTX, p upsertRateP) error {
 	return pgsqlgen.New(db).UpsertCurrencyRate(ctx, pgsqlgen.UpsertCurrencyRateParams(p))
+}
+
+func (pgsqlWriteQuerier) GetLatestRateDate(ctx context.Context, db backend.DBTX) (time.Time, error) {
+	return pgsqlgen.New(db).GetLatestRateDate(ctx)
 }

--- a/internal/currency/repo/write_integration_test.go
+++ b/internal/currency/repo/write_integration_test.go
@@ -1,0 +1,47 @@
+package repo_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	currencyrepo "github.com/econumo/econumo/internal/currency/repo"
+	"github.com/econumo/econumo/internal/model"
+	"github.com/econumo/econumo/internal/shared/vo"
+	"github.com/econumo/econumo/internal/test/dbtest"
+)
+
+func TestWriteRepo_LatestRateDate(t *testing.T) {
+	db := dbtest.New(t)
+	w := currencyrepo.NewWriteRepo(db.Engine, db.TX)
+	ctx := context.Background()
+
+	// No rates yet -> ok=false.
+	if _, ok, err := w.LatestRateDate(ctx); err != nil || ok {
+		t.Fatalf("empty: ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+
+	// Seed two rates on different days; the newest wins.
+	for _, d := range []time.Time{
+		time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC),
+	} {
+		if err := w.UpsertRate(ctx, model.RateRow{
+			ID:             vo.NewId().String(),
+			CurrencyID:     seededUSD,
+			BaseCurrencyID: seededUSD,
+			Date:           d,
+			Rate:           "1.00000000",
+		}); err != nil {
+			t.Fatalf("UpsertRate: %v", err)
+		}
+	}
+
+	got, ok, err := w.LatestRateDate(ctx)
+	if err != nil || !ok {
+		t.Fatalf("LatestRateDate: ok=%v err=%v", ok, err)
+	}
+	if got.Format("2006-01-02") != "2026-07-22" {
+		t.Errorf("LatestRateDate = %s, want 2026-07-22", got.Format("2006-01-02"))
+	}
+}

--- a/internal/infra/storage/sqlc/gen/pgsql/currency_write.sql.go
+++ b/internal/infra/storage/sqlc/gen/pgsql/currency_write.sql.go
@@ -40,6 +40,20 @@ func (q *Queries) GetCurrencyByCode(ctx context.Context, code string) (GetCurren
 	return i, err
 }
 
+const getLatestRateDate = `-- name: GetLatestRateDate :one
+SELECT published_at FROM currencies_rates ORDER BY published_at DESC LIMIT 1
+`
+
+// Newest stored rate date, for the in-process rate updater's freshness check.
+// ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+// (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+func (q *Queries) GetLatestRateDate(ctx context.Context) (time.Time, error) {
+	row := q.db.QueryRowContext(ctx, getLatestRateDate)
+	var published_at time.Time
+	err := row.Scan(&published_at)
+	return published_at, err
+}
+
 const insertCurrency = `-- name: InsertCurrency :exec
 INSERT INTO currencies (id, code, symbol, name, fraction_digits, created_at)
 VALUES ($1, $2, $3, $4, $5, $6)

--- a/internal/infra/storage/sqlc/gen/pgsql/querier.go
+++ b/internal/infra/storage/sqlc/gen/pgsql/querier.go
@@ -92,6 +92,10 @@ type Querier interface {
 	GetFolderByID(ctx context.Context, id string) (Folder, error)
 	GetLatestCurrencyRateDate(ctx context.Context, arg GetLatestCurrencyRateDateParams) (time.Time, error)
 	GetLatestCurrencyRateListView(ctx context.Context) ([]GetLatestCurrencyRateListViewRow, error)
+	// Newest stored rate date, for the in-process rate updater's freshness check.
+	// ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+	// (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+	GetLatestRateDate(ctx context.Context) (time.Time, error)
 	GetOperationId(ctx context.Context, id string) (OperationRequestsID, error)
 	// Write-side queries for the payee module (PostgreSQL variant: $N placeholders).
 	// See the sqlite variant for documentation; the SQL is identical apart from the

--- a/internal/infra/storage/sqlc/gen/sqlite/currency_write.sql.go
+++ b/internal/infra/storage/sqlc/gen/sqlite/currency_write.sql.go
@@ -40,6 +40,20 @@ func (q *Queries) GetCurrencyByCode(ctx context.Context, code string) (GetCurren
 	return i, err
 }
 
+const getLatestRateDate = `-- name: GetLatestRateDate :one
+SELECT published_at FROM currencies_rates ORDER BY published_at DESC LIMIT 1
+`
+
+// Newest stored rate date, for the in-process rate updater's freshness check.
+// ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+// (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+func (q *Queries) GetLatestRateDate(ctx context.Context) (time.Time, error) {
+	row := q.db.QueryRowContext(ctx, getLatestRateDate)
+	var published_at time.Time
+	err := row.Scan(&published_at)
+	return published_at, err
+}
+
 const insertCurrency = `-- name: InsertCurrency :exec
 INSERT INTO currencies (id, code, symbol, name, fraction_digits, created_at)
 VALUES (?, ?, ?, ?, ?, ?)

--- a/internal/infra/storage/sqlc/gen/sqlite/querier.go
+++ b/internal/infra/storage/sqlc/gen/sqlite/querier.go
@@ -166,6 +166,10 @@ type Querier interface {
 	// CurrencyRateRepository::getAll(): find MAX(published_at), return every row on
 	// it). published_at is a DATE; the wire formats it as "Y-m-d 00:00:00".
 	GetLatestCurrencyRateListView(ctx context.Context) ([]CurrenciesRate, error)
+	// Newest stored rate date, for the in-process rate updater's freshness check.
+	// ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+	// (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+	GetLatestRateDate(ctx context.Context) (time.Time, error)
 	GetOperationId(ctx context.Context, id string) (OperationRequestsID, error)
 	// Write-side queries for the payee module. The read-side query lives in
 	// payee_read.sql to keep the CQRS boundary visible (matching tags.sql vs

--- a/internal/infra/storage/sqlc/query/pgsql/currency_write.sql
+++ b/internal/infra/storage/sqlc/query/pgsql/currency_write.sql
@@ -29,3 +29,9 @@ INSERT INTO currencies_rates (id, currency_id, base_currency_id, published_at, r
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (published_at, currency_id, base_currency_id)
 DO UPDATE SET rate = excluded.rate;
+
+-- name: GetLatestRateDate :one
+-- Newest stored rate date, for the in-process rate updater's freshness check.
+-- ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+-- (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+SELECT published_at FROM currencies_rates ORDER BY published_at DESC LIMIT 1;

--- a/internal/infra/storage/sqlc/query/sqlite/currency_write.sql
+++ b/internal/infra/storage/sqlc/query/sqlite/currency_write.sql
@@ -37,3 +37,9 @@ INSERT INTO currencies_rates (id, currency_id, base_currency_id, published_at, r
 VALUES (?, ?, ?, ?, ?)
 ON CONFLICT (published_at, currency_id, base_currency_id)
 DO UPDATE SET rate = excluded.rate;
+
+-- name: GetLatestRateDate :one
+-- Newest stored rate date, for the in-process rate updater's freshness check.
+-- ORDER BY ... LIMIT 1 (not MAX) so the result types as the published_at column
+-- (time.Time) instead of an aggregate interface{}. sql.ErrNoRows = no rates yet.
+SELECT published_at FROM currencies_rates ORDER BY published_at DESC LIMIT 1;

--- a/internal/server/glue_admin_test.go
+++ b/internal/server/glue_admin_test.go
@@ -34,7 +34,7 @@ func newAdminHandler(t *testing.T) http.Handler {
 	f.Connect(adminUserA, adminUserB)
 
 	cfg := config.Config{DatabaseDriver: db.Engine, CurrencyBase: "USD", AdminToken: adminToken}
-	_, adminHandler := server.Build(cfg, db.Raw, server.Seams{})
+	_, adminHandler, _ := server.Build(cfg, db.Raw, server.Seams{})
 	return adminHandler
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"net/http"
 
 	appaccount "github.com/econumo/econumo/internal/account"
@@ -91,15 +92,16 @@ type Seams struct {
 // at either engine; the engine is read from cfg.DatabaseDriver, which selects
 // the per-engine sqlc query adapters in every repository constructor.
 func BuildAPI(cfg config.Config, db *sql.DB, seams Seams) http.Handler {
-	api, _ := Build(cfg, db, seams)
+	api, _, _ := Build(cfg, db, seams)
 	return api
 }
 
 // Build wires the service graph once and returns both edges: the public API
 // handler and the private admin handler. They share one set of services rather
 // than each opening its own, and serve decides whether to listen on the admin
-// one (see cfg.AdminPort/AdminToken).
-func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handler) {
+// one (see cfg.AdminPort/AdminToken). The third return is the in-process
+// currency-rate updater; serve starts its poller, BuildAPI and tests discard it.
+func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handler, *appcurrency.RateUpdater) {
 	clk := seams.Clock
 	if clk == nil {
 		clk = clock.New()
@@ -187,6 +189,21 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 	currencyReadRepo := currencyrepo.NewReadRepo(cfg.DatabaseDriver, txm)
 	currencyReadSvc := appcurrency.NewReadService(currencyReadRepo)
 	currencyHandlers := handlercurrency.NewHandlers(currencyReadSvc)
+
+	// In-process exchange-rate updater. Enabled only when a cadence is set AND an
+	// OER token is present; serve starts its poller (Build's third return),
+	// BuildAPI and tests discard it (a disabled updater never polls).
+	currencyWriteRepo := currencyrepo.NewWriteRepo(cfg.DatabaseDriver, txm)
+	currencyWriteSvc := appcurrency.NewWriteService(currencyWriteRepo, txm, clk)
+	rateLoader := currencyrepo.NewLoader(cfg.OpenExchangeRatesToken, clk.Now)
+	rateUpdaterEnabled := cfg.CurrencyUpdateIntervalDays > 0 && cfg.OpenExchangeRatesToken != ""
+	if cfg.CurrencyUpdateIntervalDays > 0 && cfg.OpenExchangeRatesToken == "" {
+		slog.Warn("ECONUMO_CURRENCY_UPDATE_INTERVAL is set but OPEN_EXCHANGE_RATES_TOKEN is empty; in-process rate updates are disabled")
+	}
+	rateUpdater := appcurrency.NewRateUpdater(
+		rateUpdaterEnabled, cfg.CurrencyUpdateIntervalDays, cfg.CurrencyBase,
+		rateLoader, currencyWriteSvc, clk,
+	)
 
 	updates := seams.Updates
 	if updates == nil {
@@ -311,7 +328,7 @@ func Build(cfg config.Config, db *sql.DB, seams Seams) (http.Handler, http.Handl
 		MCP:                mcpHandler,
 		SPA:                spaFS,
 		SPAVersion:         spaVersion,
-	}), adminHandler
+	}), adminHandler, rateUpdater
 }
 
 type pinger struct{ db *sql.DB }


### PR DESCRIPTION
## What

Adds an opt-in in-process exchange-rate updater so `serve` can refresh rates on a schedule when it holds an Open Exchange Rates token — no external cron needed.

New env var **`ECONUMO_CURRENCY_UPDATE_INTERVAL`** (integer days):
- `0`/unset = **off** (byte-identical to today; keep driving `currency:update-rates` from your own cron).
- A positive `N` starts a background poller in `serve` **only when `OPEN_EXCHANGE_RATES_TOKEN` is also set** — interval-without-token logs a boot WARN and stays off.
- Negative/malformed fails at boot; a sanity cap (max 3650 days) guards against a `time.Duration` overflow in the ticker.

## How

- **Poller** (`internal/currency/rateupdater.go`) mirrors the existing `system.Service.StartPolling` pattern: one goroutine, fetch on boot then every `N×24h`, exits on `ctx.Done()`. All fetch errors are logged and swallowed — a background job never crashes the server.
- **DB-aware freshness skip:** a new `GetLatestRateDate` query (both engines, `ORDER BY … LIMIT 1` to keep a clean `time.Time`) lets each run skip the fetch while the newest stored rate is within the interval, so restart loops don't burn API quota.
- **Wiring:** built in `server.Build` (which now also constructs the currency write service + OER loader) and started only by `serve`; `BuildAPI`/tests get a disabled updater, so it never polls in tests.
- Idempotent upserts per `(date, currency, base)` → safe alongside an existing external cron.

## Scope / safety

- **No new HTTP/MCP routes** — apiparity/mcpparity goldens unchanged. No frozen-contract (datetime/envelope) changes.
- Follows the engine-adapter (sqlc) pattern; per-engine query files kept ASCII-only.

## Tests

- `make go-test` (smoke: build + vet + gofmt + OpenAPI-fresh + sqlite unit/integration + apiparity + mcpparity + coverage) — **PASS, coverage 80.4%** (min 78).
- `make test-repo-pgsql` (repo/unit suite against PostgreSQL, incl. `internal/currency/repo`) — **PASS** (new `GetLatestRateDate` adapter exercised on both engines).
- New tests: config parse/validation (default/positive/negative/malformed/too-large), repo integration (empty → not-found; newest-wins), poller unit (disabled / fresh-skip / stale-fetch / empty-DB).

## Docs

`.env.example` + CLAUDE.md config section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)