### PR TITLE
fix: disable MCP DNS-rebinding guard behind reverse proxy

### DIFF
--- a/internal/web/mcp/mcp.go
+++ b/internal/web/mcp/mcp.go
@@ -40,7 +40,14 @@ func NewHandler(register Register) http.Handler {
 	addPrompts(srv)
 	return sdk.NewStreamableHTTPHandler(
 		func(*http.Request) *sdk.Server { return srv },
-		&sdk.StreamableHTTPOptions{Stateless: true, JSONResponse: true},
+		// DisableLocalhostProtection: /mcp sits behind a reverse proxy that
+		// dials the app over loopback, so the SDK's DNS-rebinding guard (added
+		// in v1.4.0) sees a loopback local address with a public Host header
+		// and 403s every request. That guard defends browser-driven local
+		// desktop servers with ambient credentials; this edge is a public
+		// HTTPS endpoint authenticated by a bearer PAT, so the threat model
+		// does not apply.
+		&sdk.StreamableHTTPOptions{Stateless: true, JSONResponse: true, DisableLocalhostProtection: true},
 	)
 }
 


### PR DESCRIPTION
## Problem

`/mcp` started returning `403 Forbidden: invalid Host header "app.econumo.com"` on every request, breaking all MCP clients. It worked on 07-20/07-22 and broke on 07-24 after a redeploy.

Root cause: the MCP Go SDK's **localhost DNS-rebinding protection** (added in SDK **v1.4.0**; we're on **v1.6.1**). The check (`streamable.go`):

```go
if util.IsLoopback(localAddr.String()) && !util.IsLoopback(req.Host) {
    http.Error(w, fmt.Sprintf("Forbidden: invalid Host header %q", req.Host), 403)
}
```

The app binds all interfaces, but the reverse proxy in front of `app.econumo.com` dials it over **loopback** (`127.0.0.1`), so the accepted connection's local address is loopback while the forwarded `Host` header is public → 403. Before the redeploy, the deployed binary predated the SDK guard, so it slipped through.

That guard exists to stop a browser from using **ambient credentials** against a *local desktop* MCP server. Our `/mcp` is a public HTTPS endpoint authenticated by a **bearer PAT** (no cookie/ambient auth), so the DNS-rebinding threat model does not apply — this is a false positive from proxy-over-loopback.

## Fix

Set `DisableLocalhostProtection: true` in `StreamableHTTPOptions`.

## Immediate mitigation (before this merges/deploys)

Set `MCPGODEBUG=disablelocalhostprotection=1` on the running container — the SDK's compat escape hatch (removed in 1.8.0), which is why the code fix is the durable path.

## Testing

- `go build ./internal/web/mcp/`
- `go test ./internal/web/mcp/ ./internal/test/mcpparity/` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)