### PR TITLE
fix: budget tag children drilled down into the wrong transactions

### DIFF
--- a/docs/superpowers/plans/2026-07-27-budget-drilldown-fixes.md
+++ b/docs/superpowers/plans/2026-07-27-budget-drilldown-fixes.md
@@ -28,7 +28,7 @@ This is Phase 1 of `docs/superpowers/specs/2026-07-27-optional-transaction-categ
 | `internal/budget/repo/read.go` | Hand-written budget report SQL | Modify — `:481-509`, `:512-554` date binding |
 | `internal/budget/api/tag_child_drilldown_test.go` | End-to-end regression for the tag-child drill-down | Create |
 | `web/src/features/budgets/BudgetTransactionsDialog.tsx` | Target type + request params | Modify — `:27-34`, `:58-66` |
-| `web/src/features/budgets/BudgetTransactionsDialog.test.tsx` | Param-mapping regression for the parent-tag spread | Create (final fix wave) |
+| `web/src/features/budgets/BudgetTransactionsDialog.test.tsx` | Param-mapping regression for the parent-tag spread | Modify — added in Task 4b |
 | `web/src/features/budgets/BudgetTable.tsx` | Row rendering, builds the click target | Modify — `:219` |
 | `web/src/features/budgets/BudgetTable.test.tsx` | Table behavior tests | Modify — update `:145-153`, add 1 test |
 

--- a/docs/superpowers/plans/2026-07-27-budget-drilldown-fixes.md
+++ b/docs/superpowers/plans/2026-07-27-budget-drilldown-fixes.md
@@ -1,0 +1,573 @@
+# Budget Drill-Down Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two defects in the budget transaction drill-down — a category nested under a tag lists the complement of the transactions it displays, and SQLite silently omits 1st-of-month rows from every drill-down list.
+
+**Architecture:** Both fixes are small and surgical. The tag fix is almost entirely frontend: the backend already supports a tag+category intersection (`BudgetTransactionsByTag` with a category filter, reachable via an existing but unused dispatcher branch), and the frontend simply never sends the parent tag id. The boundary fix binds SQLite date bounds as `'Y-m-d H:i:s'` strings, matching what `CountSpending` already does and documents.
+
+**Tech Stack:** Go 1.x (stdlib `net/http`, hand-written SQL in `internal/budget/repo`), React 19 + TypeScript, vitest + testing-library, SQLite (default) and PostgreSQL.
+
+This is Phase 1 of `docs/superpowers/specs/2026-07-27-optional-transaction-category-design.md`. Phase 2 (optional transaction category + the Uncategorized row) is a separate plan and must not be started here.
+
+## Global Constraints
+
+- Branch name: `bug/budget-drilldown` — this is a bug fix, so `bug/<slug>`, not `feature/<slug>`.
+- Any SQL change must be made in **both** dialect branches in lockstep; `enginecompare` asserts byte-identical SQLite and PostgreSQL responses.
+- Never hand-edit a golden file. Regenerate with `UPDATE_GOLDEN=1` and inspect the diff.
+- Comments only for non-obvious *why* — no comments restating a symbol's name. Never reference the removed PHP/Symfony implementation.
+- Frontend: `pnpm exec tsc -b` must pass. vitest and oxlint do **not** type-check.
+- Run all commands from the repo root unless a step says otherwise.
+- The wire `spent` value is positive and must never be rendered negated.
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `internal/budget/repo/read_integration_test.go` | Repo-level integration tests against migrated SQLite | Modify — add 3 tests |
+| `internal/budget/repo/read.go` | Hand-written budget report SQL | Modify — `:481-509`, `:512-554` date binding |
+| `internal/budget/api/tag_child_drilldown_test.go` | End-to-end regression for the tag-child drill-down | Create |
+| `web/src/features/budgets/BudgetTransactionsDialog.tsx` | Target type + request params | Modify — `:27-34`, `:58-66` |
+| `web/src/features/budgets/BudgetTable.tsx` | Row rendering, builds the click target | Modify — `:219` |
+| `web/src/features/budgets/BudgetTable.test.tsx` | Table behavior tests | Modify — update `:145-153`, add 1 test |
+
+No new files on the frontend; no schema, migration, or sqlc change anywhere in this plan.
+
+---
+
+### Task 1: Characterize `BudgetTransactionsByCategories`
+
+This query has **no test at all** today, which is how its `tag_id IS NULL` clause
+went unexamined. Lock in its real semantics before touching anything. Test-only —
+no production change in this task, and all tests must pass on the first run.
+
+**Files:**
+- Test: `internal/budget/repo/read_integration_test.go` (append)
+
+**Interfaces:**
+- Consumes: `newReadRepo(t) (*budgetrepo.ReadRepo, *dbtest.DB)`, `seedCategory(t, db, id, userID)`, `seedExpense(t, db, id, account, category, amount, spentAt)`, package constants `userA`, `acctA`, `usdID`, and `fixture.New(t, db).Tag(...)` / `.Transaction(...)` — all already defined in this file.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the characterization test**
+
+Append to `internal/budget/repo/read_integration_test.go`:
+
+```go
+// BudgetTransactionsByCategories backs the drill-down of a standalone category
+// row and of an envelope's children. Both display the UNTAGGED bucket, so the
+// query deliberately excludes tagged rows ("t.tag_id IS NULL"). A category
+// nested under a tag shows the opposite bucket and must not use this query.
+func TestBudgetReadRepo_BudgetTransactionsByCategories(t *testing.T) {
+	read, db := newReadRepo(t)
+	ctx := context.Background()
+	cat := "c0000000-0000-0000-0000-0000000000c1"
+	tag := "7a000000-0000-0000-0000-0000000000b1"
+	seedCategory(t, db, cat, userA)
+	f := fixture.New(t, db)
+	f.Tag(fixture.Tag{ID: tag, UserID: userA, Name: "Tag"})
+	// The only row this query should return.
+	seedExpense(t, db, "73000000-0000-0000-0000-000000000001", acctA, cat, "10.00", "2024-04-05 00:00:00")
+	// Same category but tagged: excluded by design.
+	f.Transaction(fixture.Transaction{ID: "73000000-0000-0000-0000-000000000002", UserID: userA, AccountID: acctA, CategoryID: cat, TagID: tag, Type: 0, Amount: "99.00", SpentAt: "2024-04-06 00:00:00"})
+	// An income in the same category is not budget spending (type != 0).
+	f.Transaction(fixture.Transaction{ID: "73000000-0000-0000-0000-000000000003", UserID: userA, AccountID: acctA, CategoryID: cat, Type: 1, Amount: "50.00", SpentAt: "2024-04-07 00:00:00"})
+	// Outside the period.
+	seedExpense(t, db, "73000000-0000-0000-0000-000000000004", acctA, cat, "77.00", "2024-05-02 00:00:00")
+
+	start := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	catIDs := []vo.Id{vo.MustParseId(cat)}
+	accIDs := []vo.Id{vo.MustParseId(acctA)}
+
+	rows, err := read.BudgetTransactionsByCategories(ctx, catIDs, accIDs, start, end)
+	if err != nil {
+		t.Fatalf("BudgetTransactionsByCategories: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 untagged in-period expense, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].ID != "73000000-0000-0000-0000-000000000001" {
+		t.Errorf("wrong row returned: %q", rows[0].ID)
+	}
+
+	// Empty id sets short-circuit: "IN ()" is a no-op on SQLite but a PostgreSQL
+	// syntax error, so both lists must be guarded.
+	if none, err := read.BudgetTransactionsByCategories(ctx, nil, accIDs, start, end); err != nil || none != nil {
+		t.Errorf("empty category ids should be nil,nil; got %v, %v", none, err)
+	}
+	if none, err := read.BudgetTransactionsByCategories(ctx, catIDs, nil, start, end); err != nil || none != nil {
+		t.Errorf("empty account ids should be nil,nil; got %v, %v", none, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — it must PASS**
+
+Run: `go test ./internal/budget/repo/ -run TestBudgetReadRepo_BudgetTransactionsByCategories -v`
+Expected: PASS. This is a characterization test of existing correct behavior, not a bug reproduction. If it FAILS, stop and report — the query does something other than what this plan assumes, and Task 2 onward rests on it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/budget/repo/read_integration_test.go
+git commit -m "test: characterize BudgetTransactionsByCategories
+
+The query had no test at all; its deliberate tag_id IS NULL clause was
+unverified, which is how the tag-child drill-down bug went unnoticed."
+```
+
+---
+
+### Task 2: Fix the SQLite month-boundary in both drill-down queries
+
+`CountSpending` binds its `spent_at` bounds as `'Y-m-d H:i:s'` strings and
+documents why at `read.go:352-355`: a `time.Time` bound "does not compare
+correctly against the stored datetime TEXT at month boundaries (it drops the
+first-of-month row)". Both drill-down queries bind raw `time.Time` anyway, so a
+1st-of-month transaction counts toward the displayed total but is missing from
+the list.
+
+**Files:**
+- Test: `internal/budget/repo/read_integration_test.go` (append)
+- Modify: `internal/budget/repo/read.go:481-509` (`BudgetTransactionsByCategories`), `internal/budget/repo/read.go:512-554` (`BudgetTransactionsByTag`)
+
+**Interfaces:**
+- Consumes: `sqliteDatetime(t time.Time) string` — already defined at `read.go:122`.
+- Produces: no signature changes. Both functions keep their exact signatures.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/budget/repo/read_integration_test.go`:
+
+```go
+// A first-of-month transaction is counted in the row total by CountSpending, so
+// the drill-down list must contain it too — otherwise the list silently
+// contradicts the number above it. SQLite only: the bounds must be bound as
+// 'Y-m-d H:i:s' strings, not as time.Time (see sqliteDatetime).
+func TestBudgetReadRepo_Drilldown_MonthBoundary(t *testing.T) {
+	read, db := newReadRepo(t)
+	ctx := context.Background()
+	cat := "c0000000-0000-0000-0000-0000000000c1"
+	tag := "7a000000-0000-0000-0000-0000000000c2"
+	seedCategory(t, db, cat, userA)
+	f := fixture.New(t, db)
+	f.Tag(fixture.Tag{ID: tag, UserID: userA, Name: "Tag"})
+	seedExpense(t, db, "74000000-0000-0000-0000-000000000001", acctA, cat, "10.00", "2024-04-01 00:00:00")
+	f.Transaction(fixture.Transaction{ID: "74000000-0000-0000-0000-000000000002", UserID: userA, AccountID: acctA, CategoryID: cat, TagID: tag, Type: 0, Amount: "20.00", SpentAt: "2024-04-01 00:00:00"})
+	// The previous month must stay excluded (the lower bound is inclusive, the
+	// upper bound exclusive).
+	seedExpense(t, db, "74000000-0000-0000-0000-000000000003", acctA, cat, "99.00", "2024-03-31 23:59:59")
+	seedExpense(t, db, "74000000-0000-0000-0000-000000000004", acctA, cat, "88.00", "2024-05-01 00:00:00")
+
+	start := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	accIDs := []vo.Id{vo.MustParseId(acctA)}
+
+	byCat, err := read.BudgetTransactionsByCategories(ctx, []vo.Id{vo.MustParseId(cat)}, accIDs, start, end)
+	if err != nil {
+		t.Fatalf("BudgetTransactionsByCategories: %v", err)
+	}
+	if len(byCat) != 1 {
+		t.Fatalf("want the Apr 1 untagged expense in the list, got %d rows: %+v", len(byCat), byCat)
+	}
+	if byCat[0].ID != "74000000-0000-0000-0000-000000000001" {
+		t.Errorf("wrong row: %q", byCat[0].ID)
+	}
+
+	byTag, err := read.BudgetTransactionsByTag(ctx, vo.MustParseId(tag), nil, accIDs, start, end)
+	if err != nil {
+		t.Fatalf("BudgetTransactionsByTag: %v", err)
+	}
+	if len(byTag) != 1 {
+		t.Fatalf("want the Apr 1 tagged expense in the list, got %d rows: %+v", len(byTag), byTag)
+	}
+	if byTag[0].ID != "74000000-0000-0000-0000-000000000002" {
+		t.Errorf("wrong row: %q", byTag[0].ID)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `go test ./internal/budget/repo/ -run TestBudgetReadRepo_Drilldown_MonthBoundary -v`
+Expected: FAIL — "want the Apr 1 untagged expense in the list, got 0 rows". Both sub-assertions should fail, one per query. If it passes, stop and report: the boundary bug is not reproducible and this task should be reconsidered rather than "fixed".
+
+- [ ] **Step 3: Fix `BudgetTransactionsByCategories`**
+
+In `internal/budget/repo/read.go`, the date args are currently appended once
+after the if/else (`:500-502`), so they cannot differ per dialect. Move the
+append into each branch. Replace the body from `accArgs := idArgs(accountIDs)`
+through `args = append(args, start, end)` with:
+
+```go
+	accArgs := idArgs(accountIDs)
+	catArgs := idArgs(categoryIDs)
+	var sql string
+	args := make([]any, 0, len(accArgs)+len(catArgs)+2)
+	args = append(args, accArgs...)
+	args = append(args, catArgs...)
+	if r.driver == "postgresql" {
+		accIn := r.ph(1, len(accArgs))
+		catIn := r.ph(1+len(accArgs), len(catArgs))
+		dStart := "$" + itoa(1+len(accArgs)+len(catArgs))
+		dEnd := "$" + itoa(2+len(accArgs)+len(catArgs))
+		sql = "SELECT " + budgetTxCols + " FROM transactions t JOIN accounts a ON a.id = t.account_id WHERE t.account_id IN (" + accIn + ") AND t.category_id IN (" + catIn + ") AND t.type = 0 AND t.tag_id IS NULL AND t.spent_at >= " + dStart + " AND t.spent_at < " + dEnd + " ORDER BY t.spent_at DESC"
+		args = append(args, start, end)
+	} else {
+		accIn := r.ph(1, len(accArgs))
+		catIn := r.ph(1, len(catArgs))
+		sql = "SELECT " + budgetTxCols + " FROM transactions t JOIN accounts a ON a.id = t.account_id WHERE t.account_id IN (" + accIn + ") AND t.category_id IN (" + catIn + ") AND t.type = 0 AND t.tag_id IS NULL AND t.spent_at >= ? AND t.spent_at < ? ORDER BY t.spent_at DESC"
+		// Bind the bounds as 'Y-m-d H:i:s' strings (see sqliteDatetime): a
+		// time.Time bound does not compare correctly against the stored
+		// datetime TEXT and drops the first-of-month row.
+		args = append(args, sqliteDatetime(start), sqliteDatetime(end))
+	}
+```
+
+The SQL strings themselves are unchanged — only the argument binding moves.
+
+- [ ] **Step 4: Fix `BudgetTransactionsByTag`**
+
+In the same file, in the SQLite branch of `BudgetTransactionsByTag`, replace:
+
+```go
+		where += " AND t.spent_at >= ? AND t.spent_at < ?"
+		args = append(args, start, end)
+```
+
+with:
+
+```go
+		where += " AND t.spent_at >= ? AND t.spent_at < ?"
+		// See sqliteDatetime: a time.Time bound drops the first-of-month row.
+		args = append(args, sqliteDatetime(start), sqliteDatetime(end))
+```
+
+Leave the PostgreSQL branch (`args = append(args, start, end)` inside the
+`r.driver == "postgresql"` block) untouched — pg compares timestamps correctly.
+
+- [ ] **Step 5: Run the tests to verify they PASS**
+
+Run: `go test ./internal/budget/repo/ -v`
+Expected: PASS, including `TestBudgetReadRepo_Drilldown_MonthBoundary`, `TestBudgetReadRepo_BudgetTransactionsByCategories` from Task 1, and the pre-existing `TestBudgetReadRepo_BudgetTransactionsByTag` and `TestBudgetReadRepo_CountSpending_MonthBoundary`.
+
+- [ ] **Step 6: Verify PostgreSQL is unaffected**
+
+Run: `make test-repo-pgsql`
+Expected: PASS. This reruns the repo suite against PostgreSQL, confirming the pg branch still binds correctly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/budget/repo/read.go internal/budget/repo/read_integration_test.go
+git commit -m "fix: include first-of-month rows in budget drill-down on SQLite
+
+CountSpending binds its spent_at bounds as 'Y-m-d H:i:s' strings and
+documents that a time.Time bound drops the first-of-month row. Both
+drill-down queries bound raw time.Time anyway, so a 1st-of-month
+transaction counted toward the row total but was missing from the list."
+```
+
+---
+
+### Task 3: End-to-end regression for the tag-child drill-down
+
+Prove at the API level what the correct behavior is, and that the backend
+already supports it. This test fails only on the frontend's behalf — the backend
+path is reachable, so this task also **documents** the untagged-vs-tagged split
+so a future reader does not "fix" `BudgetTransactionsByCategories` instead.
+
+**Files:**
+- Create: `internal/budget/api/tag_child_drilldown_test.go`
+
+**Interfaces:**
+- Consumes, all already defined in `package api_test` (`internal/budget/api/harness_test.go` and siblings): `newHarness(t) *harness`, `h.token(t) string`, `h.do(t, method, path, token, body) (int, envelope)` where the envelope exposes `.Data` and `.raw`, `mustUnmarshal[T](t, data) T`, `h.db`, and the seeded constants `budgetID1`, `tagID`, `catID`, `accountID`, `seedUserID`, `usdID`.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the test**
+
+Create `internal/budget/api/tag_child_drilldown_test.go`:
+
+```go
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/econumo/econumo/internal/test/dbtest"
+	"github.com/econumo/econumo/internal/test/fixture"
+)
+
+// txListView is the slice of get-transaction-list these tests care about.
+type txListView struct {
+	Items []struct {
+		Id     string `json:"id"`
+		Amount string `json:"amount"`
+	} `json:"items"`
+}
+
+// A category listed as a child of a tag displays the tag-and-category
+// intersection. Its drill-down must return exactly those transactions. Sending
+// categoryId alone selects the "t.tag_id IS NULL" branch, which returns the
+// complement — the reported bug.
+func TestTagChildDrilldown_ReturnsTheIntersection(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok,
+		map[string]any{"id": budgetID1, "name": "Drilldown Budget", "currencyId": usdID, "startDate": "2024-04-01"})
+
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	// Same category, same period: one tagged, one not.
+	taggedID := f.Transaction(fixture.Transaction{
+		ID: "eeee2222-0000-7000-8000-000000000001", UserID: seedUserID, AccountID: accountID,
+		CategoryID: catID, TagID: tagID, Type: 0, Amount: "42.00", SpentAt: "2024-04-10 00:00:00",
+	})
+	untaggedID := f.Transaction(fixture.Transaction{
+		ID: "eeee2222-0000-7000-8000-000000000002", UserID: seedUserID, AccountID: accountID,
+		CategoryID: catID, Type: 0, Amount: "7.00", SpentAt: "2024-04-11 00:00:00",
+	})
+
+	base := "/api/v1/budget/get-transaction-list?budgetId=" + budgetID1 + "&periodStart=2024-04-01"
+
+	// The tag child: tagId AND categoryId together.
+	st, b := h.do(t, http.MethodGet, base+"&tagId="+tagID+"&categoryId="+catID, tok, nil)
+	if st != http.StatusOK {
+		t.Fatalf("get-transaction-list=%d body=%s", st, b.raw)
+	}
+	got := mustUnmarshal[txListView](t, b.Data)
+	if len(got.Items) != 1 {
+		t.Fatalf("tag child drill-down must return only the tagged transaction, got %d: %s", len(got.Items), b.Data)
+	}
+	if got.Items[0].Id != taggedID {
+		t.Errorf("tag child drill-down returned %q, want the tagged transaction %q", got.Items[0].Id, taggedID)
+	}
+
+	// The standalone category row shows the untagged bucket, and its drill-down
+	// must keep matching that. This is the branch the tag child wrongly used.
+	_, b = h.do(t, http.MethodGet, base+"&categoryId="+catID, tok, nil)
+	got = mustUnmarshal[txListView](t, b.Data)
+	if len(got.Items) != 1 || got.Items[0].Id != untaggedID {
+		t.Errorf("category-only drill-down must return only the untagged transaction %q; got %s", untaggedID, b.Data)
+	}
+
+	// The tag row itself shows everything tagged, across categories.
+	_, b = h.do(t, http.MethodGet, base+"&tagId="+tagID, tok, nil)
+	got = mustUnmarshal[txListView](t, b.Data)
+	if len(got.Items) != 1 || got.Items[0].Id != taggedID {
+		t.Errorf("tag drill-down must return the tagged transaction %q; got %s", taggedID, b.Data)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it PASSES**
+
+Run: `go test ./internal/budget/api/ -run TestTagChildDrilldown -v`
+Expected: PASS. The backend already handles `tagId`+`categoryId` (`internal/budget/txlist.go:49-62`); only the frontend fails to send both. If this FAILS, the bug is not purely frontend — stop and report before starting Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/budget/api/tag_child_drilldown_test.go
+git commit -m "test: lock the tag-child drill-down contract end to end
+
+Pins the three drill-down shapes: tag+category returns the
+intersection, category alone the untagged bucket, tag alone everything
+tagged. No golden contained a tag with children, so nothing covered this."
+```
+
+---
+
+### Task 4: Send the parent tag from the frontend
+
+The actual bug fix. `BudgetTable.tsx:219` builds a child's click target without
+the parent, so `BudgetTransactionsDialog` sends `categoryId` alone.
+
+**Files:**
+- Modify: `web/src/features/budgets/BudgetTransactionsDialog.tsx:27-34` (the target type) and `:58-66` (request params)
+- Modify: `web/src/features/budgets/BudgetTable.tsx:219`
+- Test: `web/src/features/budgets/BudgetTable.test.tsx` (update one test, add one)
+
+**Interfaces:**
+- Consumes: `BudgetElementType` from `@/api/dto/budget` (`ENVELOPE: 0`, `CATEGORY: 1`, `TAG: 2`); `BudgetTransactionsParams` in `web/src/api/budget.ts:114-120`, which already declares optional `categoryId` and `tagId` and already serializes both when present (`:124-125`) — **no change needed there**.
+- Produces: `BudgetTransactionsTarget` gains an optional `parent?: { id: Id; type: BudgetElementType }`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `web/src/features/budgets/BudgetTable.test.tsx`, append:
+
+```tsx
+it('clicking a tag child spent amount reports the parent tag', async () => {
+  const user = userEvent.setup()
+  const onSpentClick = vi.fn()
+  renderTable((budget) => {
+    budget.structure.elements.push({
+      id: 'tag-travel', type: 2, name: 'Travel', icon: 'flight', currencyId: null, isArchived: 0,
+      folderId: null, position: 3, budgeted: '0', available: '-30', spent: '30', budgetSpent: '30',
+      ownerUserId: 'u1',
+      children: [{ id: 'cat-hotel', type: 1, name: 'Hotel', icon: 'hotel', isArchived: 0, spent: '30', budgetSpent: '30', ownerUserId: 'u1' }],
+    })
+  }, { onSpentClick })
+  const travel = await screen.findByTestId('element-tag-travel')
+  await user.click(within(travel).getByText('Travel'))
+  await user.click(await screen.findByRole('button', { name: 'transactions Hotel' }))
+  // Without the parent the dialog sends categoryId alone, and the backend
+  // returns the untagged complement of what this row displays.
+  expect(onSpentClick).toHaveBeenCalledWith({
+    id: 'cat-hotel', type: 1, name: 'Hotel', icon: 'hotel', currencyId: null,
+    parent: { id: 'tag-travel', type: 2 },
+  })
+})
+```
+
+Then update the existing envelope-child test at `:145-153`, which asserts the
+target's exact shape and will now also receive a parent. Change its expectation to:
+
+```tsx
+  expect(onSpentClick).toHaveBeenCalledWith({
+    id: 'cat-rent', type: 1, name: 'Rent', icon: 'house', currencyId: 'cur-eur',
+    parent: { id: 'env-1', type: 0 },
+  })
+```
+
+Leave the top-level test at `:136-143` alone — top-level rows have no parent and
+its expectation stays exact.
+
+- [ ] **Step 2: Run the tests to verify they FAIL**
+
+Run: `cd web && pnpm exec vitest run src/features/budgets/BudgetTable.test.tsx`
+Expected: FAIL — both the new test and the updated envelope test report a missing `parent` property in the received call.
+
+- [ ] **Step 3: Add the parent to the target type**
+
+In `web/src/features/budgets/BudgetTransactionsDialog.tsx`, replace the
+`BudgetTransactionsTarget` interface at `:27-34` with:
+
+```tsx
+/** enough of an element (or a nested child category) to list its transactions */
+export interface BudgetTransactionsTarget {
+  id: Id
+  type: BudgetElementType
+  name: string
+  icon: string
+  /** null = the budget base currency */
+  currencyId: Id | null
+  /** set on a nested child row: the row it is listed under */
+  parent?: { id: Id; type: BudgetElementType }
+}
+```
+
+- [ ] **Step 4: Populate the parent when rendering children**
+
+In `web/src/features/budgets/BudgetTable.tsx`, replace line 219 with:
+
+```tsx
+                  {spentCell({ id: child.id, type: child.type, name: child.name, icon: child.icon, currencyId: element.currencyId, parent: { id: element.id, type: element.type } }, child.spent)}
+```
+
+- [ ] **Step 5: Send both params for a category under a tag**
+
+In `web/src/features/budgets/BudgetTransactionsDialog.tsx`, replace the `params`
+block at `:58-66` with:
+
+```tsx
+  // A category listed under a tag displays the tag-and-category intersection.
+  // Sending categoryId alone puts the backend on its "tag_id IS NULL" branch,
+  // which returns the complement of what the row shows.
+  const parentTagId = element?.parent?.type === BudgetElementType.TAG ? element.parent.id : undefined
+  const params = element
+    ? {
+        budgetId: budget.meta.id,
+        periodStart: selectedDate,
+        ...(element.type === BudgetElementType.CATEGORY ? { categoryId: element.id } : {}),
+        ...(element.type === BudgetElementType.TAG ? { tagId: element.id } : {}),
+        ...(element.type === BudgetElementType.ENVELOPE ? { envelopeId: element.id } : {}),
+        ...(parentTagId ? { tagId: parentTagId } : {}),
+      }
+    : null
+```
+
+An envelope child keeps sending `categoryId` alone, which is correct — envelope
+children display the untagged bucket.
+
+- [ ] **Step 6: Run the tests to verify they PASS**
+
+Run: `cd web && pnpm exec vitest run src/features/budgets/`
+Expected: PASS, including `budget.test.ts`, whose existing assertion that a plain
+category request does **not** contain `tagId` (`web/src/api/budget.test.ts:89`)
+must still hold.
+
+- [ ] **Step 7: Type-check and lint**
+
+Run: `cd web && pnpm exec tsc -b && pnpm lint`
+Expected: both clean. vitest and oxlint do not type-check, so `tsc -b` is the gate that catches a malformed optional property.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/features/budgets/BudgetTable.tsx web/src/features/budgets/BudgetTransactionsDialog.tsx web/src/features/budgets/BudgetTable.test.tsx
+git commit -m "fix: drill a tag's child category into the tagged transactions
+
+The child click target dropped the parent tag, so the dialog sent
+categoryId alone and the backend took its tag_id IS NULL branch —
+listing the exact complement of the amount shown on the row. The
+tag+category branch already existed and was unused."
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the full Go smoke suite**
+
+Run: `make go-test`
+Expected: PASS, including the coverage gate, `gofmt`, `go vet`, and the apiparity/mcpparity golden suites. No golden should change — this plan alters no response shape. **If a golden does change, stop and inspect the diff**: it means observable behavior moved and that needs explaining before the branch merges.
+
+- [ ] **Step 2: Run the full suite including PostgreSQL and the frontend**
+
+Run: `make test`
+Expected: PASS, including the `enginecompare` suite asserting byte-identical SQLite and PostgreSQL responses.
+
+- [ ] **Step 3: Confirm the fix by hand**
+
+Start the app, open a budget with a tag that has spending across at least two
+categories, expand the tag, and click a child's spent amount. The listed
+transactions must be the tagged ones, and their sum must equal the number on the
+row. Before the fix the list showed that category's untagged transactions
+instead, usually summing to a different figure.
+
+---
+
+## Self-Review
+
+**Spec coverage.** This plan implements spec §1.1 (Tasks 3, 4) and §1.2 (Task 2),
+plus spec tests 1-6 (Tasks 1, 2), 12 (Task 3), and 13-14 (Task 4). Spec §1.3 is
+explicitly "not doing" and needs no task.
+
+Deliberately deferred from the spec's Phase 1 list, because they belong with the
+code they exercise:
+
+- Test 7 (per-branch dispatcher unit tests) — Task 3 covers all three reachable
+  shapes end to end, which is stronger; a separate unit test of the same switch
+  would be redundant.
+- Tests 8-10 (builder-level tag/envelope bucket assertions) — the tag pass
+  arithmetic was verified correct during investigation and is untouched by this
+  plan. These become genuinely necessary in Phase 2, which rewrites that
+  aggregation, and they are already in the Phase 2 test list.
+- Test 11 (an apiparity scenario containing a tag with children) — a golden
+  addition; Task 3 covers the same behavior with sharper assertions. Worth adding
+  in Phase 2, when the goldens must be regenerated anyway.
+- Test 15 (`BudgetTransactionsDialog` param mapping) — Task 4 Step 6 covers the
+  serialization through `budget.test.ts`; a dedicated dialog test would need
+  significant provider scaffolding for little added signal.
+
+**Placeholder scan.** No TBD/TODO. Every code step contains the actual code.
+
+**Type consistency.** `parent?: { id: Id; type: BudgetElementType }` is declared
+in Task 4 Step 3 and used identically in Steps 1, 4, and 5. `sqliteDatetime`
+matches its definition at `read.go:122`. `BudgetTransactionsByCategories` and
+`BudgetTransactionsByTag` keep their exact existing signatures. Test helper names
+(`newReadRepo`, `seedCategory`, `seedExpense`, `newHarness`, `h.do`,
+`mustUnmarshal`) are all verified against the files they come from.

--- a/docs/superpowers/plans/2026-07-27-budget-drilldown-fixes.md
+++ b/docs/superpowers/plans/2026-07-27-budget-drilldown-fixes.md
@@ -28,10 +28,11 @@ This is Phase 1 of `docs/superpowers/specs/2026-07-27-optional-transaction-categ
 | `internal/budget/repo/read.go` | Hand-written budget report SQL | Modify — `:481-509`, `:512-554` date binding |
 | `internal/budget/api/tag_child_drilldown_test.go` | End-to-end regression for the tag-child drill-down | Create |
 | `web/src/features/budgets/BudgetTransactionsDialog.tsx` | Target type + request params | Modify — `:27-34`, `:58-66` |
+| `web/src/features/budgets/BudgetTransactionsDialog.test.tsx` | Param-mapping regression for the parent-tag spread | Create (final fix wave) |
 | `web/src/features/budgets/BudgetTable.tsx` | Row rendering, builds the click target | Modify — `:219` |
 | `web/src/features/budgets/BudgetTable.test.tsx` | Table behavior tests | Modify — update `:145-153`, add 1 test |
 
-No new files on the frontend; no schema, migration, or sqlc change anywhere in this plan.
+No schema, migration, or sqlc change anywhere in this plan.
 
 ---
 
@@ -559,9 +560,11 @@ code they exercise:
 - Test 11 (an apiparity scenario containing a tag with children) — a golden
   addition; Task 3 covers the same behavior with sharper assertions. Worth adding
   in Phase 2, when the goldens must be regenerated anyway.
-- Test 15 (`BudgetTransactionsDialog` param mapping) — Task 4 Step 6 covers the
-  serialization through `budget.test.ts`; a dedicated dialog test would need
-  significant provider scaffolding for little added signal.
+- Test 15 (`BudgetTransactionsDialog` param mapping) — added during the final
+  fix wave (`BudgetTransactionsDialog.test.tsx`): the review that surfaced the
+  order-dependent `parentTagId` spread needed a real assertion that a
+  TAG-typed element's own `tagId` survives, which `budget.test.ts` alone
+  can't exercise.
 
 **Placeholder scan.** No TBD/TODO. Every code step contains the actual code.
 

--- a/docs/superpowers/specs/2026-07-27-optional-transaction-category-design.md
+++ b/docs/superpowers/specs/2026-07-27-optional-transaction-category-design.md
@@ -122,6 +122,11 @@ with `CodeIsBlank`. Remove that check.
   create and update, on both the REST and MCP edges.
 - Clearing an existing category needs no extra work: `buildState` does a
   full-state replace, so `categoryId: null` clears it.
+- **Empty string normalizes to absent.** The removed check tested
+  `categoryID == nil || *categoryID == ""`, so `""` was previously a validation
+  error and never reached `checkReferences`. After the change it must be
+  normalized to nil rather than looked up, or a client sending `""` would get a
+  spurious "category not found". Same rule for `update`.
 
 ### 2.2 Budget aggregation: let NULL-category spending through
 
@@ -252,36 +257,135 @@ which already fires its event.
 
 ## Testing
 
-Phase 1:
+Both phases are well suited to test-first development: every defect below is
+currently either untested or provably wrong, so the failing test can be written
+before the fix.
 
-- Regression test: a tag child drill-down returns the **tagged** transactions.
-- `BudgetTransactionsByCategories` currently has **no test at all** — add one,
-  covering its `tag_id IS NULL` filter.
-- Month-boundary test using a 1st-of-month transaction. The existing test
-  (`internal/budget/repo/read_integration_test.go:109-162`) uses Apr 5/6 and cannot
-  catch it; `:95` shows the "incl. Apr 1 boundary" pattern to copy.
-- Frontend: assert the child target carries the parent tag id and that the request
-  sends both params. `BudgetTable.test.tsx:145-153` covers only an **envelope**
-  child, where omitting the parent is correct.
+Shared fixtures needed up front (both phases depend on them):
 
-Phase 2:
+- A tag with child categories, where one category has **both** tagged and untagged
+  spending in the same period — this is the fixture that distinguishes the
+  intersection from the complement. The only existing tag fixture
+  (`web/src/test/fixtures.ts:124`) is archived with no children.
+- A transaction dated the **1st of the month**, for the boundary cases.
 
-- Create and update a non-transfer transaction with no category; clear a category
-  from an existing transaction.
-- Uncategorized aggregation on both engines, including the tag-wins case.
-- `SetLimit` against `"uncategorized"` returns the existing validation error.
-- The only tag fixture (`web/src/test/fixtures.ts:124`) is archived with no
-  children; a tag-with-children fixture is needed.
+### Phase 1
 
-Golden files:
+Repo layer (`internal/budget/repo/`, run on SQLite **and** PostgreSQL via
+`make test-repo-pgsql`):
+
+1. `BudgetTransactionsByCategories` — **no test exists today**. Cover: returns only
+   untagged rows (locking in the deliberate `tag_id IS NULL` clause); account
+   filter; date range; excludes non-expense types; empty category list returns
+   empty.
+2. `BudgetTransactionsByCategories` — includes a 1st-of-month transaction (this is
+   the §1.2 fix; the test must fail before it).
+3. Period bounds are half-open: the last day of the month is included, the next
+   month's 1st is excluded.
+4. `BudgetTransactionsByTag` — with a nil category filter returns all the tag's
+   transactions; with a category filter returns only the intersection. Extends
+   `read_integration_test.go:109-162`, which covers this but never on a boundary date.
+5. `BudgetTransactionsByTag` — 1st-of-month boundary.
+6. `CountSpending` — confirm the existing Apr 1 boundary assertion (`:95`) still holds.
+
+Builder / use case:
+
+7. `txlist.go` dispatcher — one test per branch: category only, tag only,
+   **tag + category**, envelope, and none (asserting `CodeBudgetTransactionFilterRequired`).
+8. Tag child `spent` equals the tag∩category intersection, not the category total,
+   given the mixed fixture.
+9. A tag child with zero spend is dropped (`builder_structure_build.go:210`).
+10. Envelope children and standalone rows still read the untagged bucket — a
+    regression guard on the disjoint partition.
+
+API / golden:
+
+11. An apiparity scenario whose budget contains a tag with children. No golden has
+    one today, so this closes the coverage hole that let the bug ship.
+12. End-to-end regression: drilling into a tag child returns the **tagged**
+    transactions, and their sum equals the number displayed on that row. This is
+    the single test that would have caught the reported bug.
+
+Frontend (vitest):
+
+13. A child row of a **tag** parent builds a target carrying the parent tag id.
+14. A child row of an **envelope** parent does not — a regression guard for
+    `BudgetTable.test.tsx:145-153`, where omitting the parent is correct.
+15. `BudgetTransactionsDialog` maps a category-target-with-tag-parent to both
+    `tagId` and `categoryId`.
+16. `web/src/api/budget.ts` serializes both params; the existing
+    `budget.test.ts:89` assertion (a plain category sends no `tagId`) must keep passing.
+
+### Phase 2
+
+Transaction use case:
+
+17. Create a non-transfer with no category — succeeds, persists NULL.
+18. Create with `categoryId: ""` — normalized to absent, not a lookup failure (§2.1).
+19. Update clears an existing category via `categoryId: null`.
+20. Update with an unknown category id still errors — `checkReferences` must not
+    have been weakened.
+21. A transfer still clears category/payee/tag (unchanged behavior).
+22. Same via the **MCP** edge, which shares the use case.
+
+Budget aggregation (both engines):
+
+23. `CountSpending` returns NULL-category rows once the predicate is widened.
+24. Tag-wins routing: a tagged **and** uncategorized expense lands in the tag
+    bucket, not the top-level row.
+25. An untagged, uncategorized expense lands in the top-level row.
+26. The three buckets remain a disjoint partition — total across buckets equals
+    total expense spending, so nothing is double-counted or dropped.
+27. `CountSpending` still works when the category id list is empty (the `:333`
+    early return, §2.2).
+
+Synthetic row:
+
+28. The Uncategorized row appears with the right `spent`, `budgeted: "0"`, and
+    `available: -spent`.
+29. It is absent when there is no such spending.
+30. It sorts to the bottom of the no-folder section.
+31. An Uncategorized **child** appears under a tag, and sorts last among children.
+32. `SetLimit` with `elementId: "uncategorized"` returns the existing validation
+    error — the frozen contract asserted by
+    `internal/budget/api/element_selfheal_test.go:87-102`.
+33. `ChangeElementCurrency` and `MoveElementList` likewise reject it.
+34. **No `budget_elements` row is created** for it — assert directly against the DB
+    after a `get-budget` call.
+
+Drill-down:
+
+35. `{uncategorized: true}` returns only `category IS NULL AND tag IS NULL`.
+36. `{uncategorized: true, tagId: T}` returns only `category IS NULL AND tag = T`.
+37. The third-state flag does not change existing behavior when a category filter
+    is passed normally (§2.5).
+
+Frontend:
+
+38. `TransactionDialog` submits with no category and shows no validation error.
+39. The category select is clearable and clearing sends `null`.
+40. `TransactionRow` shows "Uncategorized" when category, description, tag and
+    payee are all absent.
+41. `TransactionRow` still prefers description / tag / payee when present — the
+    existing fallback chain is unchanged.
+42. `ViewTransactionDialog` shows the label for a null category.
+43. The Uncategorized budget row renders read-only: no budget cell, no actions, no
+    clickable available pill.
+44. Its `spent` **is** clickable and opens the drill-down.
+
+Guards that run automatically and must stay green: `i18ntest` en/ru key and
+placeholder parity, `metrics-coverage.test.ts`, the apiparity route/scenario guards,
+and `pnpm exec tsc -b` (vitest and oxlint do not type-check).
+
+### Golden files
 
 - No apiparity golden currently contains a tag with children, and nothing asserts
-  the buggy behavior, so Phase 1 will not fight the goldens.
+  the buggy behavior, so Phase 1 will not fight the goldens. Test 11 **adds** one.
 - Phase 2 adds a request field, so regenerate apiparity **and** mcpparity goldens
   (`UPDATE_GOLDEN=1`) and **inspect the diff** — a golden change means observable
-  behavior changed.
+  behavior changed. Never hand-edit a golden.
 - Both dialects must be edited in lockstep; `enginecompare` asserts byte-identical
-  SQLite and PostgreSQL responses.
+  SQLite and PostgreSQL responses and is the primary safety net for the §2.2 risk.
 
 ## Risk
 

--- a/docs/superpowers/specs/2026-07-27-optional-transaction-category-design.md
+++ b/docs/superpowers/specs/2026-07-27-optional-transaction-category-design.md
@@ -1,0 +1,297 @@
+# Optional transaction category + budget drill-down fixes
+
+Date: 2026-07-27
+
+## Summary
+
+Allow expense/income transactions to be saved without a category, surface that
+spending in the budget as a read-only "Uncategorized" row, and fix two defects in
+the budget drill-down found while investigating the same code.
+
+The work splits into two independently shippable phases. **Phase 1 is pure bug
+fixing and should merge first** — Phase 2 builds on the same aggregation and
+drill-down code.
+
+## Background
+
+Category is already optional everywhere except two application-level checks:
+
+- `transactions.category_id` is `DEFAULT NULL` in both dialects
+  (`internal/infra/storage/migrations/{sqlite,pgsql}/20210812210548.sql:163`), with
+  `ON DELETE SET NULL` (`:177`) — the schema is explicitly designed for a null category.
+- `model.Transaction.CategoryID` is `*vo.Id` (`internal/model/transaction.go:63`), the
+  create/update DTOs use `*string`, and `TransactionResult.CategoryId` is already
+  nullable on the wire.
+- Transfers already work without a category and are the existing precedent.
+
+No migration, entity, DTO, or sqlc change is required for the transaction half.
+
+## Phase 1 — Budget drill-down bug fixes
+
+### 1.1 Tag children drill down to the wrong transactions
+
+**Symptom.** Expanding a tag shows the correct child categories with correct
+numbers, but clicking a child's spent figure lists the wrong transactions.
+
+**Root cause.** The row shows one set and the query asks for its exact complement.
+
+The displayed number is a true intersection: `CountSpending` groups by
+`t.category_id, t.tag_id` (`internal/budget/repo/read.go:345`/`:356`), and
+`builder_structure.go:111-127` routes each row to a tag-keyed bucket when
+`TagID` is set, so `spending["<T>-tag"].spendingInCategories["<C>"]` is
+`SUM(tag = T AND category = C)`. The tag pass reads exactly that bucket
+(`builder_structure_build.go:127-140`). The arithmetic is correct.
+
+The drill-down loses the tag in three steps:
+
+1. `web/src/features/budgets/BudgetTable.tsx:219` builds the click target from
+   `child.id` but never passes `element.id`. `BudgetTransactionsTarget`
+   (`BudgetTransactionsDialog.tsx:27-34`) has no field for a parent.
+2. A tag child carries `type = 1` (CATEGORY, set at
+   `builder_structure_build.go:214`), so `BudgetTransactionsDialog.tsx:58-66`
+   sends `categoryId` only, with no `tagId`.
+3. The backend therefore takes the `cat != "" && tag == ""` branch
+   (`internal/budget/txlist.go:42-48`) into `BudgetTransactionsByCategories`,
+   whose SQL hard-filters `AND t.tag_id IS NULL` (`read.go:494`, `:498`).
+
+Result: clicking category C under tag T returns C's **untagged** transactions.
+
+Envelope children are unaffected because they read the category-keyed
+(i.e. untagged) bucket (`builder_structure_build.go:88`), which happens to agree
+with the query's `tag_id IS NULL`.
+
+**Fix — mostly frontend; the backend capability already exists and is unused.**
+`BudgetTransactionsByTag(ctx, tagID, categoryID *vo.Id, …)` (`read.go:511-554`)
+already filters both, and `txlist.go:49-62` already accepts a `catFilter`. That
+dead branch indicates the wiring was simply dropped.
+
+- Add a parent field to `BudgetTransactionsTarget` and populate it at
+  `BudgetTable.tsx:219` for child rows.
+- In `BudgetTransactionsDialog.tsx:58-66`, when a CATEGORY-typed target has a
+  TAG-typed parent, send **both** `tagId` and `categoryId`.
+- No backend change expected. Confirm during implementation that
+  `web/src/api/budget.ts:114-131` serializes both params.
+
+**Contract note.** `web/src/api/budget.test.ts:89` asserts a plain category
+request does *not* contain `tagId`. That must keep passing — only the
+child-of-tag case gains `tagId`.
+
+### 1.2 SQLite drops 1st-of-month rows from every drill-down
+
+**Root cause.** `CountSpending` binds the `spent_at` bounds as `'Y-m-d H:i:s'`
+strings via `sqliteDatetime`, with an explicit comment (`read.go:352-359`)
+warning that a raw `time.Time` bound "does not compare correctly against the
+stored datetime TEXT at month boundaries (it drops the first-of-month row)".
+
+Both drill-down queries bind raw `time.Time` anyway: `read.go:502` and
+`read.go:533`/`:545`. `sqliteDatetime` is used at `:109`, `:199`, `:359`, `:412`
+but never in `BudgetTransactionsByCategories` / `BudgetTransactionsByTag`.
+
+**Effect.** On SQLite (the default engine), a transaction dated the 1st of the
+month counts toward the row total but is missing from the transaction list — the
+list silently disagrees with the number above it. Independent of tags; affects
+every drill-down.
+
+**Fix.** Use the same string-bound helper in both drill-down queries, matching
+`CountSpending`. SQLite only; the PostgreSQL path is unaffected.
+
+### 1.3 Not doing: the duplicate top-level row
+
+A category whose spending is entirely tagged renders twice — once as a tag child
+with the tagged amount, once as a top-level row showing only the untagged
+remainder, often `0`.
+
+This was considered and **explicitly rejected**. Suppressing the top-level row
+would hide the only place a limit can be set (tag children have no budget cell),
+so a limitless, fully-tagged category would become unreachable for budgeting.
+Nothing double-counts — `bucketStats` (`web/src/features/budgets/budgetMath.ts:39-45`)
+sums only top-level `budgetSpent`, and the backend buckets are a disjoint
+partition. Current behavior stands.
+
+## Phase 2 — Optional category
+
+### 2.1 Backend: relax the requirement
+
+`internal/transaction/usecase.go` `buildState()` lines 260-265 is the single
+backend enforcement point: for a non-transfer it rejects a nil/empty category
+with `CodeIsBlank`. Remove that check.
+
+- `checkReferences()` (`:89-118`) already validates the category only when
+  `st.CategoryID != nil` (`:102`), so nil flows through cleanly.
+- Both `create.go:52-57` and `update.go:63-68` call `buildState`, so this covers
+  create and update, on both the REST and MCP edges.
+- Clearing an existing category needs no extra work: `buildState` does a
+  full-state replace, so `categoryId: null` clears it.
+
+### 2.2 Budget aggregation: let NULL-category spending through
+
+`CountSpending` (`internal/budget/repo/read.go:328`) currently drops NULL-category
+rows twice — the `t.category_id IN (…)` predicate, and a scan guard at
+`:379-381` (pg) / `:390-392` (sqlite).
+
+- Widen the predicate to `(t.category_id IN (…) OR t.category_id IS NULL)` in
+  **both** dialects, keeping the account, date and `type = 0` filters.
+- Change `SpendingRow.CategoryID` from `string` to `*string`
+  (`internal/model/budget_view.go:35`).
+- Drop the nil-**category** scan guard; keep the nil-**currency** guard.
+- The early return at `:333` bails when `len(categoryIDs) == 0`; it must still run
+  for the uncategorized case. Bail only on empty `accountIDs`.
+
+### 2.3 Routing rule: tag wins
+
+`builder_structure.go:113-117` routes each spending row to exactly one bucket.
+Extend the existing if/else to three cases:
+
+| tag | category | bucket |
+| --- | --- | --- |
+| set | any | tag bucket (**tag wins**, even with no category) |
+| nil | set | category bucket |
+| nil | nil | new uncategorized bucket |
+
+So a tagged-but-uncategorized expense rolls up under its tag and appears as an
+"Uncategorized" **child** of that tag. Only untagged, uncategorized expenses feed
+the top-level row. The buckets stay a disjoint partition, so nothing
+double-counts.
+
+Implementation notes:
+
+- `spendingInCategories` is keyed by category id; nil needs a sentinel key.
+- `builder_structure_build.go:129` does `cat, ok := f.categories[catID]; if !ok { continue }`,
+  which would silently skip the nil-category child. It needs an explicit branch
+  emitting the synthetic name/icon.
+- `:210` already drops tag children with zero spend, so an empty uncategorized
+  child disappears for free.
+- Children sort by id (`:221`). `"uncategorized"` starts with `u`, which sorts
+  after any lowercase-hex UUID, so it lands last deterministically.
+
+### 2.4 The synthetic row
+
+Presentation-only, emitted in `buildStructure` only. **Never persisted** as a
+`budget_elements` row. Precedent for a presentation-only sentinel:
+`BudgetRoleOwner = -1` (`internal/model/budget_valueobject.go:51`).
+
+| field | value |
+| --- | --- |
+| `id` | `"uncategorized"` |
+| `type` | `1` (category) |
+| `name` / `icon` | "Uncategorized" / `question_mark` |
+| `budgeted` | `"0"` |
+| `spent` / `budgetSpent` | positive (wire convention) |
+| `available` | `-spent` (same formula as a limitless category) |
+| `folderId` | `null`, with a large sentinel `position` → bottom of the no-folder section |
+| `children` | `[]` |
+| `isArchived` | `0` |
+| `ownerUserId` | `null` |
+| currency | the budget's default currency |
+
+Visible only when its spending is nonzero, mirroring the existing "spending or a
+limit" visibility rule (it can never have a limit).
+
+**Writes are already rejected, by construction.** `SetLimit`
+(`internal/budget/accounts.go:113-174`) first calls `vo.ParseId(req.ElementId)`
+(`:118`); `"uncategorized"` is not a UUID, so it fails there. `ChangeElementCurrency`
+and `MoveElementList` resolve the same way. No new validation is needed — and no
+`budget_elements` row may be seeded, or `restoreElementsOrder`
+(`internal/budget/move.go:119`) would garbage-collect it anyway.
+
+The wire `spent` convention is **positive**, asserted by
+`web/src/features/budgets/BudgetTable.test.tsx:83-85` ("the wire value is positive
+and must NOT be rendered negated").
+
+### 2.5 Drill-down for uncategorized
+
+Add an `uncategorized bool` to the budget transaction-list request. It composes
+with the existing `tagId`:
+
+- `{uncategorized: true}` → `category_id IS NULL AND tag_id IS NULL`
+- `{uncategorized: true, tagId: T}` → `category_id IS NULL AND tag_id = T`
+
+`assembleTxList` already tolerates `row.CategoryID == nil` (`txlist.go:116`).
+
+**Careful:** in `BudgetTransactionsByTag`, a nil `categoryID *vo.Id` currently
+means "no category filter". "Category IS NULL" is a third state, so the repo
+signature needs an explicit flag rather than overloading nil.
+
+### 2.6 Frontend
+
+- `TransactionDialog.tsx`: remove the required-category check at `validate()`
+  lines 162-164; add `clearable` to the category `EntitySelect` (`:363-379`) so an
+  existing category can be cleared. Payee at `:388` is the pattern to copy.
+- `useTransactionForm.ts` needs no change — `buildPayload()` already sends
+  `categoryId: isTransfer ? null : form.categoryId` (`:96`).
+- Read-only Uncategorized row: reuse the **existing archive-section mechanism**
+  (`BudgetTable.tsx:301`), which passes a filtered `extras` keeping `onSpentClick`
+  and dropping `renderBudgetCell` / `renderActions` / `onAvailableClick`. No new
+  row concept.
+- `useSetLimit` optimistically patches on `el.id === form.elementId`
+  (`web/src/features/budgets/queries.ts:128-130`), so suppress the affordance
+  client-side rather than relying on the server 400.
+- "Uncategorized" label in the transaction list: `transactionTitleInfo()` currently
+  returns an empty title with `source: 'none'`
+  (`web/src/features/transactions/useAccountTransactions.ts:133`) when a
+  transaction has no category, description, tag, or payee. Render the label there.
+  Existing description/tag/payee fallbacks are unchanged.
+- `ViewTransactionDialog.tsx`: show the label in the Category field when null.
+- The `question_mark` icon fallback (`TransactionRow.tsx:38`) already exists; leave it.
+
+### 2.7 i18n
+
+Add one placeholder-free key to **both** `locales/en.json` and `locales/ru.json`,
+reused by the budget row, the transaction row, and the view dialog. It spans the
+`budgets` and `transactions` features, so it belongs in the cross-cutting
+namespace: `common.uncategorized` = "Uncategorized".
+
+Remove `transactions.modal.form.category.validation.required_field`
+(`locales/en.json:345-347`) together with its `t()` call, in the same change — the
+`i18ntest` guards check both directions.
+
+### 2.8 Analytics
+
+No new `METRICS` key. This rides the existing create/update-transaction flow,
+which already fires its event.
+
+## Testing
+
+Phase 1:
+
+- Regression test: a tag child drill-down returns the **tagged** transactions.
+- `BudgetTransactionsByCategories` currently has **no test at all** — add one,
+  covering its `tag_id IS NULL` filter.
+- Month-boundary test using a 1st-of-month transaction. The existing test
+  (`internal/budget/repo/read_integration_test.go:109-162`) uses Apr 5/6 and cannot
+  catch it; `:95` shows the "incl. Apr 1 boundary" pattern to copy.
+- Frontend: assert the child target carries the parent tag id and that the request
+  sends both params. `BudgetTable.test.tsx:145-153` covers only an **envelope**
+  child, where omitting the parent is correct.
+
+Phase 2:
+
+- Create and update a non-transfer transaction with no category; clear a category
+  from an existing transaction.
+- Uncategorized aggregation on both engines, including the tag-wins case.
+- `SetLimit` against `"uncategorized"` returns the existing validation error.
+- The only tag fixture (`web/src/test/fixtures.ts:124`) is archived with no
+  children; a tag-with-children fixture is needed.
+
+Golden files:
+
+- No apiparity golden currently contains a tag with children, and nothing asserts
+  the buggy behavior, so Phase 1 will not fight the goldens.
+- Phase 2 adds a request field, so regenerate apiparity **and** mcpparity goldens
+  (`UPDATE_GOLDEN=1`) and **inspect the diff** — a golden change means observable
+  behavior changed.
+- Both dialects must be edited in lockstep; `enginecompare` asserts byte-identical
+  SQLite and PostgreSQL responses.
+
+## Risk
+
+§2.2's predicate widening and the `SpendingRow.CategoryID` → pointer change touch
+shared aggregation code that **every** budget row flows through, including the
+envelope and tag passes. This is the riskiest part of the work. The
+`enginecompare` suite and the budget goldens are the safety net.
+
+## Out of scope
+
+- No "Uncategorized" budget *limit* — the row is read-only by design.
+- No suppression of the duplicate top-level category row (see §1.3).
+- No change to how envelopes group categories.

--- a/internal/budget/api/tag_child_drilldown_test.go
+++ b/internal/budget/api/tag_child_drilldown_test.go
@@ -1,0 +1,69 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/econumo/econumo/internal/test/dbtest"
+	"github.com/econumo/econumo/internal/test/fixture"
+)
+
+// txListView is the slice of get-transaction-list these tests care about.
+type txListView struct {
+	Items []struct {
+		Id     string `json:"id"`
+		Amount string `json:"amount"`
+	} `json:"items"`
+}
+
+// A category listed as a child of a tag displays the tag-and-category
+// intersection. Its drill-down must return exactly those transactions. Sending
+// categoryId alone selects the "t.tag_id IS NULL" branch, which returns the
+// complement — the reported bug.
+func TestTagChildDrilldown_ReturnsTheIntersection(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok,
+		map[string]any{"id": budgetID1, "name": "Drilldown Budget", "currencyId": usdID, "startDate": "2024-04-01"})
+
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	// Same category, same period: one tagged, one not.
+	taggedID := f.Transaction(fixture.Transaction{
+		ID: "eeee2222-0000-7000-8000-000000000001", UserID: seedUserID, AccountID: accountID,
+		CategoryID: catID, TagID: tagID, Type: 0, Amount: "42.00", SpentAt: "2024-04-10 00:00:00",
+	})
+	untaggedID := f.Transaction(fixture.Transaction{
+		ID: "eeee2222-0000-7000-8000-000000000002", UserID: seedUserID, AccountID: accountID,
+		CategoryID: catID, Type: 0, Amount: "7.00", SpentAt: "2024-04-11 00:00:00",
+	})
+
+	base := "/api/v1/budget/get-transaction-list?budgetId=" + budgetID1 + "&periodStart=2024-04-01"
+
+	// The tag child: tagId AND categoryId together.
+	st, b := h.do(t, http.MethodGet, base+"&tagId="+tagID+"&categoryId="+catID, tok, nil)
+	if st != http.StatusOK {
+		t.Fatalf("get-transaction-list=%d body=%s", st, b.raw)
+	}
+	got := mustUnmarshal[txListView](t, b.Data)
+	if len(got.Items) != 1 {
+		t.Fatalf("tag child drill-down must return only the tagged transaction, got %d: %s", len(got.Items), b.Data)
+	}
+	if got.Items[0].Id != taggedID {
+		t.Errorf("tag child drill-down returned %q, want the tagged transaction %q", got.Items[0].Id, taggedID)
+	}
+
+	// The standalone category row shows the untagged bucket, and its drill-down
+	// must keep matching that. This is the branch the tag child wrongly used.
+	_, b = h.do(t, http.MethodGet, base+"&categoryId="+catID, tok, nil)
+	got = mustUnmarshal[txListView](t, b.Data)
+	if len(got.Items) != 1 || got.Items[0].Id != untaggedID {
+		t.Errorf("category-only drill-down must return only the untagged transaction %q; got %s", untaggedID, b.Data)
+	}
+
+	// The tag row itself shows everything tagged, across categories.
+	_, b = h.do(t, http.MethodGet, base+"&tagId="+tagID, tok, nil)
+	got = mustUnmarshal[txListView](t, b.Data)
+	if len(got.Items) != 1 || got.Items[0].Id != taggedID {
+		t.Errorf("tag drill-down must return the tagged transaction %q; got %s", taggedID, b.Data)
+	}
+}

--- a/internal/budget/api/tag_child_drilldown_test.go
+++ b/internal/budget/api/tag_child_drilldown_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/econumo/econumo/internal/shared/vo"
 	"github.com/econumo/econumo/internal/test/dbtest"
 	"github.com/econumo/econumo/internal/test/fixture"
 )
@@ -50,6 +51,9 @@ func TestTagChildDrilldown_ReturnsTheIntersection(t *testing.T) {
 	}
 	if got.Items[0].Id != taggedID {
 		t.Errorf("tag child drill-down returned %q, want the tagged transaction %q", got.Items[0].Id, taggedID)
+	}
+	if vo.NewDecimal(got.Items[0].Amount).String() != vo.NewDecimal("42.00").String() {
+		t.Errorf("tag child drill-down amount mismatch: got %q, want the seeded 42.00", got.Items[0].Amount)
 	}
 
 	// The standalone category row shows the untagged bucket, and its drill-down

--- a/internal/budget/repo/read.go
+++ b/internal/budget/repo/read.go
@@ -320,7 +320,9 @@ func (r *ReadRepo) holdingsSQL(toHoldings bool, ids []any, start, end time.Time)
 	args := make([]any, 0, 2*len(ids)+2)
 	args = append(args, ids...)
 	args = append(args, ids...)
-	args = append(args, start, end)
+	// See sqliteDatetime: a time.Time bound does not compare correctly against
+	// the stored datetime TEXT and drops the first-of-month row.
+	args = append(args, sqliteDatetime(start), sqliteDatetime(end))
 	return sql, args
 }
 

--- a/internal/budget/repo/read.go
+++ b/internal/budget/repo/read.go
@@ -486,20 +486,24 @@ func (r *ReadRepo) BudgetTransactionsByCategories(ctx context.Context, categoryI
 	catArgs := idArgs(categoryIDs)
 	var sql string
 	args := make([]any, 0, len(accArgs)+len(catArgs)+2)
+	args = append(args, accArgs...)
+	args = append(args, catArgs...)
 	if r.driver == "postgresql" {
 		accIn := r.ph(1, len(accArgs))
 		catIn := r.ph(1+len(accArgs), len(catArgs))
 		dStart := "$" + itoa(1+len(accArgs)+len(catArgs))
 		dEnd := "$" + itoa(2+len(accArgs)+len(catArgs))
 		sql = "SELECT " + budgetTxCols + " FROM transactions t JOIN accounts a ON a.id = t.account_id WHERE t.account_id IN (" + accIn + ") AND t.category_id IN (" + catIn + ") AND t.type = 0 AND t.tag_id IS NULL AND t.spent_at >= " + dStart + " AND t.spent_at < " + dEnd + " ORDER BY t.spent_at DESC"
+		args = append(args, start, end)
 	} else {
 		accIn := r.ph(1, len(accArgs))
 		catIn := r.ph(1, len(catArgs))
 		sql = "SELECT " + budgetTxCols + " FROM transactions t JOIN accounts a ON a.id = t.account_id WHERE t.account_id IN (" + accIn + ") AND t.category_id IN (" + catIn + ") AND t.type = 0 AND t.tag_id IS NULL AND t.spent_at >= ? AND t.spent_at < ? ORDER BY t.spent_at DESC"
+		// Bind the bounds as 'Y-m-d H:i:s' strings (see sqliteDatetime): a
+		// time.Time bound does not compare correctly against the stored
+		// datetime TEXT and drops the first-of-month row.
+		args = append(args, sqliteDatetime(start), sqliteDatetime(end))
 	}
-	args = append(args, accArgs...)
-	args = append(args, catArgs...)
-	args = append(args, start, end)
 	rows, err := r.db(ctx).QueryContext(ctx, sql, args...)
 	if err != nil {
 		return nil, err
@@ -542,7 +546,8 @@ func (r *ReadRepo) BudgetTransactionsByTag(ctx context.Context, tagID vo.Id, cat
 			args = append(args, categoryID.String())
 		}
 		where += " AND t.spent_at >= ? AND t.spent_at < ?"
-		args = append(args, start, end)
+		// See sqliteDatetime: a time.Time bound drops the first-of-month row.
+		args = append(args, sqliteDatetime(start), sqliteDatetime(end))
 		sql = "SELECT " + budgetTxCols + " FROM transactions t JOIN accounts a ON a.id = t.account_id WHERE " + where + " ORDER BY t.spent_at DESC"
 	}
 	rows, err := r.db(ctx).QueryContext(ctx, sql, args...)

--- a/internal/budget/repo/read_integration_test.go
+++ b/internal/budget/repo/read_integration_test.go
@@ -191,3 +191,50 @@ func TestBudgetReadRepo_SummarizedLimits_MonthBoundary(t *testing.T) {
 		t.Errorf("external id mismatch: %q", rows[0].ExternalID)
 	}
 }
+
+// BudgetTransactionsByCategories backs the drill-down of a standalone category
+// row and of an envelope's children. Both display the UNTAGGED bucket, so the
+// query deliberately excludes tagged rows ("t.tag_id IS NULL"). A category
+// nested under a tag shows the opposite bucket and must not use this query.
+func TestBudgetReadRepo_BudgetTransactionsByCategories(t *testing.T) {
+	read, db := newReadRepo(t)
+	ctx := context.Background()
+	cat := "c0000000-0000-0000-0000-0000000000c1"
+	tag := "7a000000-0000-0000-0000-0000000000b1"
+	seedCategory(t, db, cat, userA)
+	f := fixture.New(t, db)
+	f.Tag(fixture.Tag{ID: tag, UserID: userA, Name: "Tag"})
+	// The only row this query should return.
+	seedExpense(t, db, "73000000-0000-0000-0000-000000000001", acctA, cat, "10.00", "2024-04-05 00:00:00")
+	// Same category but tagged: excluded by design.
+	f.Transaction(fixture.Transaction{ID: "73000000-0000-0000-0000-000000000002", UserID: userA, AccountID: acctA, CategoryID: cat, TagID: tag, Type: 0, Amount: "99.00", SpentAt: "2024-04-06 00:00:00"})
+	// An income in the same category is not budget spending (type != 0).
+	f.Transaction(fixture.Transaction{ID: "73000000-0000-0000-0000-000000000003", UserID: userA, AccountID: acctA, CategoryID: cat, Type: 1, Amount: "50.00", SpentAt: "2024-04-07 00:00:00"})
+	// Outside the period.
+	seedExpense(t, db, "73000000-0000-0000-0000-000000000004", acctA, cat, "77.00", "2024-05-02 00:00:00")
+
+	start := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	catIDs := []vo.Id{vo.MustParseId(cat)}
+	accIDs := []vo.Id{vo.MustParseId(acctA)}
+
+	rows, err := read.BudgetTransactionsByCategories(ctx, catIDs, accIDs, start, end)
+	if err != nil {
+		t.Fatalf("BudgetTransactionsByCategories: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 untagged in-period expense, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].ID != "73000000-0000-0000-0000-000000000001" {
+		t.Errorf("wrong row returned: %q", rows[0].ID)
+	}
+
+	// Empty id sets short-circuit: "IN ()" is a no-op on SQLite but a PostgreSQL
+	// syntax error, so both lists must be guarded.
+	if none, err := read.BudgetTransactionsByCategories(ctx, nil, accIDs, start, end); err != nil || none != nil {
+		t.Errorf("empty category ids should be nil,nil; got %v, %v", none, err)
+	}
+	if none, err := read.BudgetTransactionsByCategories(ctx, catIDs, nil, start, end); err != nil || none != nil {
+		t.Errorf("empty account ids should be nil,nil; got %v, %v", none, err)
+	}
+}

--- a/internal/budget/repo/read_integration_test.go
+++ b/internal/budget/repo/read_integration_test.go
@@ -284,3 +284,35 @@ func TestBudgetReadRepo_Drilldown_MonthBoundary(t *testing.T) {
 		t.Errorf("wrong row: %q", byTag[0].ID)
 	}
 }
+
+// A transfer dated the 1st of the month must be counted in HoldingsReport, and
+// the next month's 1st must be excluded. SQLite only: the bounds must be
+// bound as 'Y-m-d H:i:s' strings, not as time.Time (see sqliteDatetime).
+func TestBudgetReadRepo_HoldingsReport_MonthBoundary(t *testing.T) {
+	read, db := newReadRepo(t)
+	ctx := context.Background()
+	acctB := "aaaa1111-0000-0000-0000-0000000000a2"
+	seedAccount(t, db, acctB, userA)
+	f := fixture.New(t, db)
+	// A same-currency transfer OUT of the {acctA} set (recipient acctB is
+	// outside): the Apr 1 boundary must be INCLUDED.
+	f.Transaction(fixture.Transaction{ID: "75000000-0000-0000-0000-000000000001", UserID: userA, AccountID: acctA, AccountRecipientID: acctB, Type: 2, Amount: "10.00", AmountRecipient: "10.00", SpentAt: "2024-04-01 00:00:00"})
+	// The next month's 1st must be EXCLUDED (upper bound is exclusive).
+	f.Transaction(fixture.Transaction{ID: "75000000-0000-0000-0000-000000000002", UserID: userA, AccountID: acctA, AccountRecipientID: acctB, Type: 2, Amount: "88.00", AmountRecipient: "88.00", SpentAt: "2024-05-01 00:00:00"})
+
+	start := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	rows, err := read.HoldingsReport(ctx, []vo.Id{vo.MustParseId(acctA)}, start, end)
+	if err != nil {
+		t.Fatalf("HoldingsReport: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 holdings row (Apr 1 transfer only), got %d: %+v", len(rows), rows)
+	}
+	if vo.NewDecimal(rows[0].ToHoldings).String() != vo.NewDecimal("10.00").String() {
+		t.Errorf("to holdings mismatch: %q", rows[0].ToHoldings)
+	}
+	if rows[0].CurrencyID != usdID {
+		t.Errorf("currency mismatch: %q", rows[0].CurrencyID)
+	}
+}

--- a/internal/budget/repo/read_integration_test.go
+++ b/internal/budget/repo/read_integration_test.go
@@ -238,3 +238,49 @@ func TestBudgetReadRepo_BudgetTransactionsByCategories(t *testing.T) {
 		t.Errorf("empty account ids should be nil,nil; got %v, %v", none, err)
 	}
 }
+
+// A first-of-month transaction is counted in the row total by CountSpending, so
+// the drill-down list must contain it too — otherwise the list silently
+// contradicts the number above it. SQLite only: the bounds must be bound as
+// 'Y-m-d H:i:s' strings, not as time.Time (see sqliteDatetime).
+func TestBudgetReadRepo_Drilldown_MonthBoundary(t *testing.T) {
+	read, db := newReadRepo(t)
+	ctx := context.Background()
+	cat := "c0000000-0000-0000-0000-0000000000c1"
+	tag := "7a000000-0000-0000-0000-0000000000c2"
+	seedCategory(t, db, cat, userA)
+	f := fixture.New(t, db)
+	f.Tag(fixture.Tag{ID: tag, UserID: userA, Name: "Tag"})
+	seedExpense(t, db, "74000000-0000-0000-0000-000000000001", acctA, cat, "10.00", "2024-04-01 00:00:00")
+	f.Transaction(fixture.Transaction{ID: "74000000-0000-0000-0000-000000000002", UserID: userA, AccountID: acctA, CategoryID: cat, TagID: tag, Type: 0, Amount: "20.00", SpentAt: "2024-04-01 00:00:00"})
+	// The previous month must stay excluded (the lower bound is inclusive, the
+	// upper bound exclusive).
+	seedExpense(t, db, "74000000-0000-0000-0000-000000000003", acctA, cat, "99.00", "2024-03-31 23:59:59")
+	seedExpense(t, db, "74000000-0000-0000-0000-000000000004", acctA, cat, "88.00", "2024-05-01 00:00:00")
+
+	start := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	accIDs := []vo.Id{vo.MustParseId(acctA)}
+
+	byCat, err := read.BudgetTransactionsByCategories(ctx, []vo.Id{vo.MustParseId(cat)}, accIDs, start, end)
+	if err != nil {
+		t.Fatalf("BudgetTransactionsByCategories: %v", err)
+	}
+	if len(byCat) != 1 {
+		t.Fatalf("want the Apr 1 untagged expense in the list, got %d rows: %+v", len(byCat), byCat)
+	}
+	if byCat[0].ID != "74000000-0000-0000-0000-000000000001" {
+		t.Errorf("wrong row: %q", byCat[0].ID)
+	}
+
+	byTag, err := read.BudgetTransactionsByTag(ctx, vo.MustParseId(tag), nil, accIDs, start, end)
+	if err != nil {
+		t.Fatalf("BudgetTransactionsByTag: %v", err)
+	}
+	if len(byTag) != 1 {
+		t.Fatalf("want the Apr 1 tagged expense in the list, got %d rows: %+v", len(byTag), byTag)
+	}
+	if byTag[0].ID != "74000000-0000-0000-0000-000000000002" {
+		t.Errorf("wrong row: %q", byTag[0].ID)
+	}
+}

--- a/internal/budget/txlist.go
+++ b/internal/budget/txlist.go
@@ -11,8 +11,11 @@ import (
 )
 
 // GetTransactionList returns the budget's transactions for a category, tag, or
-// envelope in a period. Exactly one of categoryId / tagId / envelopeId selects
-// the mode. Requires read access.
+// envelope in a period. categoryId alone selects that category's UNTAGGED
+// transactions; tagId (with an optional categoryId) selects that tag's
+// transactions, narrowed to the given category when both are set; envelopeId
+// alone selects the envelope's categories' untagged transactions. tagId and
+// envelopeId are mutually exclusive. Requires read access.
 func (s *Service) GetTransactionList(ctx context.Context, userID vo.Id, req model.BudgetTransactionListRequest) (*model.GetBudgetTransactionListResult, error) {
 	budgetID, err := vo.ParseId(req.BudgetId)
 	if err != nil {

--- a/internal/test/fixture/entities.go
+++ b/internal/test/fixture/entities.go
@@ -385,10 +385,15 @@ type Transaction struct {
 	CategoryID  string // optional
 	PayeeID     string // optional
 	TagID       string // optional
-	Type        int    // 0 expense, 1 income (domain transaction.TypeExpense/TypeIncome)
+	Type        int    // 0 expense, 1 income, 2 transfer (domain transaction.TypeExpense/TypeIncome/TypeTransfer)
 	Amount      string // decimal string; default "0"
 	Description string
 	SpentAt     interface{} // time.Time or "Y-m-d H:i:s"; default builder time
+
+	// Transfer-only (Type == 2): the recipient account and the amount credited
+	// to it, which may differ from Amount for a cross-currency transfer.
+	AccountRecipientID string
+	AmountRecipient    string
 }
 
 func (b *Builder) Transaction(tx Transaction) string {
@@ -405,9 +410,11 @@ func (b *Builder) Transaction(tx Transaction) string {
 	cat := nullable(tx.CategoryID)
 	payee := nullable(tx.PayeeID)
 	tag := nullable(tx.TagID)
-	b.insert(`INSERT INTO transactions (id, user_id, account_id, category_id, payee_id, tag_id, type, amount, description, spent_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		id, tx.UserID, tx.AccountID, cat, payee, tag, tx.Type, tx.Amount, tx.Description, spent, now, now)
+	acctRecipient := nullable(tx.AccountRecipientID)
+	amountRecipient := nullable(tx.AmountRecipient)
+	b.insert(`INSERT INTO transactions (id, user_id, account_id, account_recipient_id, category_id, payee_id, tag_id, type, amount, amount_recipient, description, spent_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, tx.UserID, tx.AccountID, acctRecipient, cat, payee, tag, tx.Type, tx.Amount, amountRecipient, tx.Description, spent, now, now)
 	return id
 }
 

--- a/web/src/features/budgets/BudgetTable.test.tsx
+++ b/web/src/features/budgets/BudgetTable.test.tsx
@@ -149,7 +149,32 @@ it('clicking a child spent amount reports the child category with the parent cur
   const living = await screen.findByTestId('element-env-1')
   await user.click(within(living).getByText('Living'))
   await user.click(await screen.findByRole('button', { name: 'transactions Rent' }))
-  expect(onSpentClick).toHaveBeenCalledWith({ id: 'cat-rent', type: 1, name: 'Rent', icon: 'house', currencyId: 'cur-eur' })
+  expect(onSpentClick).toHaveBeenCalledWith({
+    id: 'cat-rent', type: 1, name: 'Rent', icon: 'house', currencyId: 'cur-eur',
+    parent: { id: 'env-1', type: 0 },
+  })
+})
+
+it('clicking a tag child spent amount reports the parent tag', async () => {
+  const user = userEvent.setup()
+  const onSpentClick = vi.fn()
+  renderTable((budget) => {
+    budget.structure.elements.push({
+      id: 'tag-travel', type: 2, name: 'Travel', icon: 'flight', currencyId: null, isArchived: 0,
+      folderId: null, position: 3, budgeted: '0', available: '-30', spent: '30', budgetSpent: '30',
+      ownerUserId: 'u1',
+      children: [{ id: 'cat-hotel', type: 1, name: 'Hotel', icon: 'hotel', isArchived: 0, spent: '30', budgetSpent: '30', ownerUserId: 'u1' }],
+    })
+  }, { onSpentClick })
+  const travel = await screen.findByTestId('element-tag-travel')
+  await user.click(within(travel).getByText('Travel'))
+  await user.click(await screen.findByRole('button', { name: 'transactions Hotel' }))
+  // Without the parent the dialog sends categoryId alone, and the backend
+  // returns the untagged complement of what this row displays.
+  expect(onSpentClick).toHaveBeenCalledWith({
+    id: 'cat-hotel', type: 1, name: 'Hotel', icon: 'hotel', currencyId: null,
+    parent: { id: 'tag-travel', type: 2 },
+  })
 })
 
 it('children show spent and the owner badge only in a multi-user budget', async () => {

--- a/web/src/features/budgets/BudgetTable.tsx
+++ b/web/src/features/budgets/BudgetTable.tsx
@@ -216,7 +216,7 @@ function ElementRow({
                   {owner?.name}
                 </span>
                 <span data-testid="child-spent" className="flex justify-end">
-                  {spentCell({ id: child.id, type: child.type, name: child.name, icon: child.icon, currencyId: element.currencyId }, child.spent)}
+                  {spentCell({ id: child.id, type: child.type, name: child.name, icon: child.icon, currencyId: element.currencyId, parent: { id: element.id, type: element.type } }, child.spent)}
                 </span>
                 <span className="w-20 sm:w-24" />
                 <span className="hidden w-6 sm:block" />

--- a/web/src/features/budgets/BudgetTransactionsDialog.test.tsx
+++ b/web/src/features/budgets/BudgetTransactionsDialog.test.tsx
@@ -7,10 +7,10 @@ import { coreHandlers, fixtureOwner, fixtureWireBudget } from '@/test/fixtures'
 import { coerceBudgetFixture } from '@/test/coerceBudget'
 import { BudgetElementType } from '@/api/dto/budget'
 import { useUiStore } from '@/app/uiStore'
-import { BudgetTransactionsDialog } from './BudgetTransactionsDialog'
+import { BudgetTransactionsDialog, type BudgetTransactionsTarget } from './BudgetTransactionsDialog'
 import { useBudgetPeriodStore } from './budgetStore'
 
-const target = { id: 'cat-food', type: BudgetElementType.CATEGORY, name: 'Food', icon: 'restaurant', currencyId: null }
+const target: BudgetTransactionsTarget = { id: 'cat-food', type: BudgetElementType.CATEGORY, name: 'Food', icon: 'restaurant', currencyId: null }
 
 const wireItems = [
   {
@@ -27,11 +27,11 @@ const wireItems = [
   },
 ]
 
-function renderDialog() {
+function renderDialog(element: BudgetTransactionsTarget = target) {
   const budget = coerceBudgetFixture(fixtureWireBudget)
   render(
     <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })}>
-      <BudgetTransactionsDialog budget={budget} element={target} onClose={() => {}} />
+      <BudgetTransactionsDialog budget={budget} element={element} onClose={() => {}} />
     </QueryClientProvider>,
   )
 }
@@ -93,4 +93,66 @@ it('delete flows through the confirm dialog', async () => {
   // the confirm dialog takes over
   await user.click(await screen.findByRole('button', { name: 'Delete' }))
   await vi.waitFor(() => expect(deletedId).toBe('t1'))
+})
+
+// The three cases below intercept the actual outgoing request and assert on its
+// query string, rather than a mock's call arguments, so a regression in the
+// params-construction spread (not just the on-click parent shape) is caught.
+function captureTransactionListUrl() {
+  let capturedUrl: string | undefined
+  server.use(
+    ...coreHandlers(),
+    http.get('*/api/v1/budget/get-transaction-list', ({ request }) => {
+      capturedUrl = request.url
+      return HttpResponse.json({ success: true, message: '', data: { items: [] } })
+    }),
+  )
+  return () => capturedUrl
+}
+
+it('a category listed under a tag requests both categoryId and tagId', async () => {
+  const getUrl = captureTransactionListUrl()
+  renderDialog({
+    id: 'cat-food',
+    type: BudgetElementType.CATEGORY,
+    name: 'Food',
+    icon: 'restaurant',
+    currencyId: null,
+    parent: { id: 'tag-groceries', type: BudgetElementType.TAG },
+  })
+  await vi.waitFor(() => expect(getUrl()).toBeDefined())
+  const params = new URL(getUrl()!).searchParams
+  expect(params.get('categoryId')).toBe('cat-food')
+  expect(params.get('tagId')).toBe('tag-groceries')
+})
+
+it('a category listed under an envelope requests categoryId only', async () => {
+  const getUrl = captureTransactionListUrl()
+  renderDialog({
+    id: 'cat-food',
+    type: BudgetElementType.CATEGORY,
+    name: 'Food',
+    icon: 'restaurant',
+    currencyId: null,
+    parent: { id: 'env-fun', type: BudgetElementType.ENVELOPE },
+  })
+  await vi.waitFor(() => expect(getUrl()).toBeDefined())
+  const params = new URL(getUrl()!).searchParams
+  expect(params.get('categoryId')).toBe('cat-food')
+  expect(params.has('tagId')).toBe(false)
+})
+
+it('a top-level tag row requests tagId only, not clobbered by a parent spread', async () => {
+  const getUrl = captureTransactionListUrl()
+  renderDialog({
+    id: 'tag-groceries',
+    type: BudgetElementType.TAG,
+    name: 'Groceries',
+    icon: 'local_grocery_store',
+    currencyId: null,
+  })
+  await vi.waitFor(() => expect(getUrl()).toBeDefined())
+  const params = new URL(getUrl()!).searchParams
+  expect(params.get('tagId')).toBe('tag-groceries')
+  expect(params.has('categoryId')).toBe(false)
 })

--- a/web/src/features/budgets/BudgetTransactionsDialog.tsx
+++ b/web/src/features/budgets/BudgetTransactionsDialog.tsx
@@ -65,10 +65,14 @@ export function BudgetTransactionsDialog({ budget, element, onClose }: BudgetTra
     ? {
         budgetId: budget.meta.id,
         periodStart: selectedDate,
-        ...(element.type === BudgetElementType.CATEGORY ? { categoryId: element.id } : {}),
+        // the parent tag only ever applies to a CATEGORY-typed element, so it
+        // is folded into that branch rather than spread last, which would
+        // silently clobber a TAG-typed element's own tagId
+        ...(element.type === BudgetElementType.CATEGORY
+          ? { categoryId: element.id, ...(parentTagId ? { tagId: parentTagId } : {}) }
+          : {}),
         ...(element.type === BudgetElementType.TAG ? { tagId: element.id } : {}),
         ...(element.type === BudgetElementType.ENVELOPE ? { envelopeId: element.id } : {}),
-        ...(parentTagId ? { tagId: parentTagId } : {}),
       }
     : null
   const { data: transactions, isLoading } = useBudgetTransactions(params)

--- a/web/src/features/budgets/BudgetTransactionsDialog.tsx
+++ b/web/src/features/budgets/BudgetTransactionsDialog.tsx
@@ -31,6 +31,8 @@ export interface BudgetTransactionsTarget {
   icon: string
   /** null = the budget base currency */
   currencyId: Id | null
+  /** set on a nested child row: the row it is listed under */
+  parent?: { id: Id; type: BudgetElementType }
 }
 
 interface BudgetTransactionsDialogProps {
@@ -55,6 +57,10 @@ export function BudgetTransactionsDialog({ budget, element, onClose }: BudgetTra
   const [preview, setPreview] = useState<ViewTransaction | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<ViewTransaction | null>(null)
 
+  // A category listed under a tag displays the tag-and-category intersection.
+  // Sending categoryId alone puts the backend on its "tag_id IS NULL" branch,
+  // which returns the complement of what the row shows.
+  const parentTagId = element?.parent?.type === BudgetElementType.TAG ? element.parent.id : undefined
   const params = element
     ? {
         budgetId: budget.meta.id,
@@ -62,6 +68,7 @@ export function BudgetTransactionsDialog({ budget, element, onClose }: BudgetTra
         ...(element.type === BudgetElementType.CATEGORY ? { categoryId: element.id } : {}),
         ...(element.type === BudgetElementType.TAG ? { tagId: element.id } : {}),
         ...(element.type === BudgetElementType.ENVELOPE ? { envelopeId: element.id } : {}),
+        ...(parentTagId ? { tagId: parentTagId } : {}),
       }
     : null
   const { data: transactions, isLoading } = useBudgetTransactions(params)

--- a/web/src/features/settings/PersonalTokensPage.test.tsx
+++ b/web/src/features/settings/PersonalTokensPage.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { http, HttpResponse } from 'msw'
+import { enUS } from 'react-day-picker/locale'
 import { server } from '@/test/msw'
 import { formatDate } from '@/lib/datetime'
 import { expiresAtFrom, PersonalTokensPage } from './PersonalTokensPage'
@@ -124,10 +125,13 @@ it('picks a custom expiry from the calendar and shows it on the chip', async () 
 
   const tomorrow = new Date()
   tomorrow.setDate(tomorrow.getDate() + 1)
-  const dayButton = within(grid)
-    .getAllByText(String(tomorrow.getDate()))
-    .map((el) => el.closest('button'))
-    .find((b): b is HTMLButtonElement => b !== null && !b.disabled)
+  // The grid also renders leading/trailing days from adjacent months, which
+  // can share the bare day-of-month number with the target day (e.g. Jun 29
+  // alongside Jul 29). Match on the full date instead, via the `data-day`
+  // attribute CalendarDayButton stamps on every cell (calendar.tsx).
+  const dayButton = grid.querySelector<HTMLButtonElement>(
+    `[data-day="${tomorrow.toLocaleDateString(enUS.code)}"]`,
+  )
   await user.click(dayButton!)
 
   // The calendar closes and the picked date replaces the chip label.


### PR DESCRIPTION
## The bug

In the budget view, expanding a tag shows its child categories with **correct** numbers, but clicking a child's spent amount listed the **wrong** transactions.

The displayed number is a true intersection — `CountSpending` groups by `category_id, tag_id`, so a tag child's `spent` is `SUM(tag = T AND category = C)`. The drill-down then asked for the exact *complement* of that:

1. `BudgetTable.tsx` built the child's click target from `child.id` and never passed the parent tag.
2. A tag child carries `type = 1` (CATEGORY), so the dialog sent `categoryId` alone.
3. The backend therefore took its `cat != "" && tag == ""` branch into `BudgetTransactionsByCategories`, whose SQL hard-filters `AND t.tag_id IS NULL`.

Result: clicking category C under tag T returned C's **untagged** transactions.

The fix is almost entirely frontend — `BudgetTransactionsByTag(ctx, tagID, categoryID, …)` already filtered both, and the dispatcher already accepted a category filter. That dead branch is the giveaway that this was intended and only the wiring was dropped.

Envelope children were unaffected: they display the untagged bucket, which happens to agree with `tag_id IS NULL`.

## Also fixed

**First-of-month rows were missing from every drill-down list on SQLite.** `CountSpending` binds its `spent_at` bounds as `'Y-m-d H:i:s'` strings and carries a comment explaining that a raw `time.Time` bound "drops the first-of-month row". Both drill-down queries bound raw `time.Time` anyway, so a transaction dated the 1st counted toward a row's total but was absent from its list.

**The same bug in `HoldingsReport`** (`holdingsSQL`) — the sibling the original sweep missed. A transfer dated the 1st was dropped and the next month's 1st wrongly included.

Only the SQLite branches changed: `spent_at` is a real `TIMESTAMP` on PostgreSQL but TEXT-affinity `DATETIME` on SQLite, which is why only one engine needs string binding.

## Tests

`BudgetTransactionsByCategories` had **no test at all**, which is how its deliberate `tag_id IS NULL` clause went unexamined. Added:

- Characterization of `BudgetTransactionsByCategories` (tag exclusion, account/date/type filters, empty-list short-circuit)
- Month-boundary regressions for both drill-down queries and for `HoldingsReport`, each written to fail first
- End-to-end API test pinning all three drill-down shapes: `tag+category` returns the intersection, `category` alone the untagged bucket, `tag` alone everything tagged
- Frontend tests asserting the outgoing **request query string** per target shape. These were mutation-checked: deleting the fix's conditional spread makes exactly the tag-child test fail

No golden file changed — this alters no response shape.

## Verification

- `make test` passes: Go smoke + sqlite-vs-PostgreSQL `enginecompare` + repo suite on PostgreSQL + frontend (681 tests)
- Coverage 79.5% against a 78% gate
- `tsc -b` and oxlint clean

## Note for the reviewer

`internal/test/fixture` gained two optional transfer fields (`AccountRecipientID`, `AmountRecipient`) so the holdings boundary test could seed a transfer. Both route through the existing `nullable()` helper, so the zero value writes `NULL` exactly as before — existing callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Unrelated commit: a date-dependent test fix

`0c27ecc` fixes `PersonalTokensPage.test.tsx`, which is unrelated to this PR but was failing CI and blocking it.

It located a calendar day by **bare day-of-month**, which also matches leading days from the adjacent month. July 2026 uses a Monday-start grid beginning Jun 29, so when "tomorrow" was the 29th the test clicked *June* 29 and the assertion for `2026-07-29` failed.

This is a latent bug that came due on 2026-07-28, not a regression here — the test file is byte-identical to `main`, imports nothing this branch touched, and flipping only `TZ` flips the result (`TZ=UTC` fails, `TZ=America/Los_Angeles` passes). It would have broken `main` and every open PR the same day; `main` only looked green because its last frontend run predated the collision.

The fix matches on the full date via the `data-day` attribute `CalendarDayButton` already stamps on every cell. Both sides derive the format from an explicit `en-US` code, so the system locale cannot affect it. Verified across seven dates including month- and year-crossings. Test file only; no production code changed.
