### PR TITLE
chore: group react and react-dom in one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore: "
+    groups:
+      # React refuses to boot unless react and react-dom are on the exact same
+      # version, so they must be bumped in one PR rather than two.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Problem

React hard-fails at import when `react` and `react-dom` are not on the exact same version:

```
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version.
  - react:      19.2.7
  - react-dom:  19.2.8
```

With no `groups` in the dependabot config, dependabot opens one PR per package. Whichever lands first leaves the pair skewed and breaks the whole web suite — in #155 a lone `react-dom` bump failed **67 of 103 test files** before a single test ran, and needed a hand-written follow-up commit to bump `react` alongside it.

This recurs on every React patch release.

## Change

Adds a `react` group to the npm ecosystem so both packages move in a single PR:

```yaml
    groups:
      react:
        patterns:
          - "react"
          - "react-dom"
```

The patterns are exact names, not wildcards, so unrelated packages (`react-router`, `react-hook-form`, `react-i18next`, …) keep getting their own PRs as today.

## Verification

Config parses and the group resolves as expected (`yaml.safe_load` + shape assertion). No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)