### PR TITLE
Fix CLI secret logging (#117) and complete budget OpenAPI failures (#131)

### DIFF
--- a/internal/budget/api/budget.go
+++ b/internal/budget/api/budget.go
@@ -39,7 +39,9 @@ func (h *Handlers) CreateBudget(w http.ResponseWriter, r *http.Request) {
 // @Param    request body model.UpdateBudgetRequest true "Update budget"
 // @Success  200 {object} apidoc.JsonResponseOk{data=model.UpdateBudgetResult}
 // @Failure  400 {object} apidoc.JsonResponseError
+// @Failure  401 {object} apidoc.JsonResponseUnauthorized
 // @Failure  402 {object} apidoc.JsonResponseError
+// @Failure  500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router   /api/v1/budget/update-budget [post]
 func (h *Handlers) UpdateBudget(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +56,10 @@ func (h *Handlers) UpdateBudget(w http.ResponseWriter, r *http.Request) {
 // @Produce  json
 // @Param    request body model.DeleteBudgetRequest true "Delete budget"
 // @Success  200 {object} apidoc.JsonResponseOk{data=model.DeleteBudgetResult}
+// @Failure  400 {object} apidoc.JsonResponseError
+// @Failure  401 {object} apidoc.JsonResponseUnauthorized
 // @Failure  402 {object} apidoc.JsonResponseError
+// @Failure  500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router   /api/v1/budget/delete-budget [post]
 func (h *Handlers) DeleteBudget(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +74,10 @@ func (h *Handlers) DeleteBudget(w http.ResponseWriter, r *http.Request) {
 // @Produce  json
 // @Param    request body model.ResetBudgetRequest true "Reset budget"
 // @Success  200 {object} apidoc.JsonResponseOk{data=model.ResetBudgetResult}
+// @Failure  400 {object} apidoc.JsonResponseError
+// @Failure  401 {object} apidoc.JsonResponseUnauthorized
 // @Failure  402 {object} apidoc.JsonResponseError
+// @Failure  500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router   /api/v1/budget/reset-budget [post]
 func (h *Handlers) ResetBudget(w http.ResponseWriter, r *http.Request) {
@@ -84,6 +92,8 @@ func (h *Handlers) ResetBudget(w http.ResponseWriter, r *http.Request) {
 // @Param    id    query string true  "Budget id"
 // @Param    date  query string false "Period date (Y-m-d)"
 // @Success  200 {object} apidoc.JsonResponseOk{data=model.GetBudgetResult}
+// @Failure  401 {object} apidoc.JsonResponseUnauthorized
+// @Failure  500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router   /api/v1/budget/get-budget [get]
 func (h *Handlers) GetBudget(w http.ResponseWriter, r *http.Request) {
@@ -111,6 +121,8 @@ func (h *Handlers) GetBudget(w http.ResponseWriter, r *http.Request) {
 // @Param    tagId       query string false "Tag id"
 // @Param    envelopeId  query string false "Envelope id"
 // @Success  200 {object} apidoc.JsonResponseOk{data=model.GetBudgetTransactionListResult}
+// @Failure  401 {object} apidoc.JsonResponseUnauthorized
+// @Failure  500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router   /api/v1/budget/get-transaction-list [get]
 func (h *Handlers) GetTransactionList(w http.ResponseWriter, r *http.Request) {
@@ -147,6 +159,8 @@ func optQuery(v string) *string {
 // @Tags     Budget
 // @Produce  json
 // @Success  200 {object} apidoc.JsonResponseOk{data=model.GetBudgetListResult}
+// @Failure  401 {object} apidoc.JsonResponseUnauthorized
+// @Failure  500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router   /api/v1/budget/get-budget-list [get]
 func (h *Handlers) GetBudgetList(w http.ResponseWriter, r *http.Request) {

--- a/internal/budget/api/budget_more.go
+++ b/internal/budget/api/budget_more.go
@@ -20,7 +20,10 @@ var _ = model.CreateBudgetFolderResult{}
 // @Produce json
 // @Param request body model.CreateBudgetFolderRequest true "Create folder"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.CreateBudgetFolderResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/create-folder [post]
 func (h *Handlers) CreateFolder(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +38,10 @@ func (h *Handlers) CreateFolder(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.UpdateBudgetFolderRequest true "Update folder"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.UpdateBudgetFolderResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/update-folder [post]
 func (h *Handlers) UpdateFolder(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +56,10 @@ func (h *Handlers) UpdateFolder(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.DeleteFolderRequest true "Delete folder"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.DeleteFolderResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/delete-folder [post]
 func (h *Handlers) DeleteFolder(w http.ResponseWriter, r *http.Request) {
@@ -65,7 +74,10 @@ func (h *Handlers) DeleteFolder(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.OrderBudgetFolderListRequest true "Order folders"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.OrderBudgetFolderListResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/order-folder-list [post]
 func (h *Handlers) OrderFolderList(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +92,10 @@ func (h *Handlers) OrderFolderList(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.CreateEnvelopeRequest true "Create envelope"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.CreateEnvelopeResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/create-envelope [post]
 func (h *Handlers) CreateEnvelope(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +110,10 @@ func (h *Handlers) CreateEnvelope(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.UpdateEnvelopeRequest true "Update envelope"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.UpdateEnvelopeResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/update-envelope [post]
 func (h *Handlers) UpdateEnvelope(w http.ResponseWriter, r *http.Request) {
@@ -110,7 +128,10 @@ func (h *Handlers) UpdateEnvelope(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.DeleteEnvelopeRequest true "Delete envelope"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.DeleteEnvelopeResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/delete-envelope [post]
 func (h *Handlers) DeleteEnvelope(w http.ResponseWriter, r *http.Request) {
@@ -125,7 +146,10 @@ func (h *Handlers) DeleteEnvelope(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.GrantAccessRequest true "Grant access"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.GrantAccessResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/grant-access [post]
 func (h *Handlers) GrantAccess(w http.ResponseWriter, r *http.Request) {
@@ -140,7 +164,10 @@ func (h *Handlers) GrantAccess(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.AcceptAccessRequest true "Accept access"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.AcceptAccessResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/accept-access [post]
 func (h *Handlers) AcceptAccess(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +182,10 @@ func (h *Handlers) AcceptAccess(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.RevokeAccessRequest true "Revoke access"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.RevokeAccessResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/revoke-access [post]
 func (h *Handlers) RevokeAccess(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +200,10 @@ func (h *Handlers) RevokeAccess(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.DeclineAccessRequest true "Decline access"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.DeclineAccessResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/decline-access [post]
 func (h *Handlers) DeclineAccess(w http.ResponseWriter, r *http.Request) {
@@ -185,7 +218,10 @@ func (h *Handlers) DeclineAccess(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.ExcludeAccountRequest true "Exclude account"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.ExcludeAccountResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/exclude-account [post]
 func (h *Handlers) ExcludeAccount(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +236,10 @@ func (h *Handlers) ExcludeAccount(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.IncludeAccountRequest true "Include account"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.IncludeAccountResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/include-account [post]
 func (h *Handlers) IncludeAccount(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +254,10 @@ func (h *Handlers) IncludeAccount(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.ChangeElementCurrencyRequest true "Change element currency"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.ChangeElementCurrencyResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/change-element-currency [post]
 func (h *Handlers) ChangeElementCurrency(w http.ResponseWriter, r *http.Request) {
@@ -230,7 +272,10 @@ func (h *Handlers) ChangeElementCurrency(w http.ResponseWriter, r *http.Request)
 // @Produce json
 // @Param request body model.SetLimitRequest true "Set limit"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.SetLimitResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/set-limit [post]
 func (h *Handlers) SetLimit(w http.ResponseWriter, r *http.Request) {
@@ -245,7 +290,10 @@ func (h *Handlers) SetLimit(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body model.MoveElementListRequest true "Move elements"
 // @Success 200 {object} apidoc.JsonResponseOk{data=model.MoveElementListResult}
+// @Failure 400 {object} apidoc.JsonResponseError
+// @Failure 401 {object} apidoc.JsonResponseUnauthorized
 // @Failure 402 {object} apidoc.JsonResponseError
+// @Failure 500 {object} apidoc.JsonResponseException
 // @Security Bearer
 // @Router /api/v1/budget/move-element-list [post]
 func (h *Handlers) MoveElementList(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -60,12 +60,21 @@ func Run(args []string) int {
 	}
 	defer c.Close()
 
-	slog.Debug("cli: running command", "command", name, "args", args[1:])
+	logCommandStart(name, args[1:])
 	if err := cmd.run(ctx, c, args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return 1
 	}
 	return 0
+}
+
+// logCommandStart emits the single DEBUG line marking a command's start. It
+// records the command name and the argument COUNT only — never the values,
+// which for user:create / user:change-password include the plaintext password
+// and email. A secret written to a log cannot be un-written, and DEBUG is a
+// persistent .env setting (ECONUMO_LOG_LEVEL=debug), not just a stray -vvv.
+func logCommandStart(name string, args []string) {
+	slog.Debug("cli: running command", "command", name, "argc", len(args))
 }
 
 // index builds a name->command map, panicking on a duplicate name so a wiring

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -106,6 +108,30 @@ func TestFirstPositional(t *testing.T) {
 		if got := firstPositional(c.args); got != c.want {
 			t.Errorf("%s: firstPositional(%q) = %q, want %q", c.name, c.args, got, c.want)
 		}
+	}
+}
+
+// TestLogCommandStartOmitsSecrets is the regression guard for the leak where the
+// command-start DEBUG line logged the full argument vector — for user:create and
+// user:change-password that included the plaintext password and email.
+func TestLogCommandStartOmitsSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	const email, password = "secret@example.test", "SuperSecret123"
+	logCommandStart("user:create", []string{"Test Name", email, password})
+
+	out := buf.String()
+	if strings.Contains(out, email) {
+		t.Errorf("DEBUG line leaked the email:\n%s", out)
+	}
+	if strings.Contains(out, password) {
+		t.Errorf("DEBUG line leaked the password:\n%s", out)
+	}
+	if !strings.Contains(out, "user:create") {
+		t.Errorf("DEBUG line dropped the command name, its only useful signal:\n%s", out)
 	}
 }
 

--- a/internal/test/apiparity/guard_authfailures_test.go
+++ b/internal/test/apiparity/guard_authfailures_test.go
@@ -1,0 +1,69 @@
+package apiparity
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestGuard_EveryAuthenticatedRouteDocuments401And500 stops the OpenAPI spec's
+// failure documentation from rotting the way the budget handlers had (issue
+// #131): each documented only 200, understating what a client must handle even
+// though every one returns 401 on a missing/invalid token and 500 on an
+// unhandled error. Those two statuses are reachable on EVERY authenticated
+// route, GET or POST, so the spec must say so — this guard makes that a
+// build-time invariant, the same way TestGuard_EveryRestrictedPostDocuments402
+// does for 402.
+//
+// Public routes (login/register/remind/reset/…) require no token, so 401 is not
+// asserted there; they are classified exactly as in the 402 guard, by their
+// registration line lacking the auth( wrapper.
+func TestGuard_EveryAuthenticatedRouteDocuments401And500(t *testing.T) {
+	specPath := filepath.Join(repoRoot(t), "internal", "web", "apidoc", "docs", "swagger.json")
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read swagger.json (run `make swagger`): %v", err)
+	}
+	var spec struct {
+		Paths map[string]map[string]struct {
+			Responses map[string]any `json:"responses"`
+		} `json:"paths"`
+	}
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse swagger.json: %v", err)
+	}
+	if len(spec.Paths) == 0 {
+		t.Fatal("swagger.json has no paths — the spec is stale or malformed")
+	}
+
+	lines := routeSourceLines(t)
+	var missing []string
+	for route := range registeredRoutes(t) {
+		method, path, ok := strings.Cut(route, " ")
+		if !ok {
+			continue
+		}
+		if !strings.Contains(lines[route], "auth(") {
+			continue // public route: no token required, so no 401
+		}
+		op, found := spec.Paths[path][strings.ToLower(method)]
+		if !found {
+			missing = append(missing, route+" absent from swagger.json")
+			continue
+		}
+		for _, code := range []string{"401", "500"} {
+			if _, has := op.Responses[code]; !has {
+				missing = append(missing, route+" missing "+code)
+			}
+		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		t.Errorf("authenticated routes must document 401 (`@Failure 401 {object} apidoc.JsonResponseUnauthorized`) and 500 (`@Failure 500 {object} apidoc.JsonResponseException`); add the annotation, then `make swagger`:\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}

--- a/internal/web/apidoc/docs/docs.go
+++ b/internal/web/apidoc/docs/docs.go
@@ -1210,10 +1210,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1266,10 +1284,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1396,10 +1432,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1452,10 +1506,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1508,10 +1580,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1564,10 +1654,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1620,10 +1728,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1676,10 +1802,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1732,10 +1876,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1788,6 +1950,18 @@ const docTemplate = `{
                                 }
                             ]
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
+                        }
                     }
                 }
             }
@@ -1823,6 +1997,18 @@ const docTemplate = `{
                                     }
                                 }
                             ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1894,6 +2080,18 @@ const docTemplate = `{
                                 }
                             ]
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
+                        }
                     }
                 }
             }
@@ -1945,10 +2143,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2001,10 +2217,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2057,10 +2291,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2113,10 +2365,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2169,10 +2439,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2225,10 +2513,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2281,10 +2587,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2343,10 +2667,22 @@ const docTemplate = `{
                             "$ref": "#/definitions/apidoc.JsonResponseError"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2399,10 +2735,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2455,10 +2809,28 @@ const docTemplate = `{
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }

--- a/internal/web/apidoc/docs/swagger.json
+++ b/internal/web/apidoc/docs/swagger.json
@@ -1203,10 +1203,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1259,10 +1277,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1389,10 +1425,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1445,10 +1499,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1501,10 +1573,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1557,10 +1647,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1613,10 +1721,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1669,10 +1795,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1725,10 +1869,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1781,6 +1943,18 @@
                                 }
                             ]
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
+                        }
                     }
                 }
             }
@@ -1816,6 +1990,18 @@
                                     }
                                 }
                             ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1887,6 +2073,18 @@
                                 }
                             ]
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
+                        }
                     }
                 }
             }
@@ -1938,10 +2136,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -1994,10 +2210,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2050,10 +2284,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2106,10 +2358,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2162,10 +2432,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2218,10 +2506,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2274,10 +2580,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2336,10 +2660,22 @@
                             "$ref": "#/definitions/apidoc.JsonResponseError"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2392,10 +2728,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }
@@ -2448,10 +2802,28 @@
                             ]
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseUnauthorized"
+                        }
+                    },
                     "402": {
                         "description": "Payment Required",
                         "schema": {
                             "$ref": "#/definitions/apidoc.JsonResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apidoc.JsonResponseException"
                         }
                     }
                 }

--- a/internal/web/apidoc/docs/swagger.yaml
+++ b/internal/web/apidoc/docs/swagger.yaml
@@ -2335,10 +2335,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.AcceptAccessResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Accept budget access
@@ -2367,10 +2379,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.ChangeElementCurrencyResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Change a budget element's currency
@@ -2443,10 +2467,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.CreateEnvelopeResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Create an envelope
@@ -2475,10 +2511,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.CreateBudgetFolderResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Create a budget folder
@@ -2507,10 +2555,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.DeclineAccessResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Decline budget access
@@ -2539,10 +2599,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.DeleteBudgetResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Delete a budget
@@ -2571,10 +2643,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.DeleteEnvelopeResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Delete an envelope
@@ -2603,10 +2687,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.DeleteFolderResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Delete a budget folder
@@ -2635,10 +2731,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.ExcludeAccountResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Exclude an account from a budget
@@ -2668,6 +2776,14 @@ paths:
                 data:
                   $ref: '#/definitions/model.GetBudgetResult'
               type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Get a budget
@@ -2687,6 +2803,14 @@ paths:
                 data:
                   $ref: '#/definitions/model.GetBudgetListResult'
               type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: List budgets
@@ -2729,6 +2853,14 @@ paths:
                 data:
                   $ref: '#/definitions/model.GetBudgetTransactionListResult'
               type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Budget transaction list
@@ -2757,10 +2889,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.GrantAccessResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Grant budget access
@@ -2789,10 +2933,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.IncludeAccountResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Include an account in a budget
@@ -2821,10 +2977,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.MoveElementListResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Move/reorder budget elements
@@ -2853,10 +3021,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.OrderBudgetFolderListResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Reorder budget folders
@@ -2885,10 +3065,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.ResetBudgetResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Reset a budget
@@ -2917,10 +3109,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.RevokeAccessResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Revoke budget access
@@ -2949,10 +3153,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.SetLimitResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Set a budget element limit
@@ -2985,10 +3201,18 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Update a budget
@@ -3017,10 +3241,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.UpdateEnvelopeResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Update an envelope
@@ -3049,10 +3285,22 @@ paths:
                 data:
                   $ref: '#/definitions/model.UpdateBudgetFolderResult'
               type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseUnauthorized'
         "402":
           description: Payment Required
           schema:
             $ref: '#/definitions/apidoc.JsonResponseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apidoc.JsonResponseException'
       security:
       - Bearer: []
       summary: Update a budget folder


### PR DESCRIPTION
Implements #117 and #131. Two independent, low-risk fixes bundled into one PR; each is reviewable on its own.

## #117 — CLI no longer logs plaintext passwords/emails

`internal/cli/cli.go` logged the full argument vector on every command:

```go
slog.Debug("cli: running command", "command", name, "args", args[1:])
```

For `user:create` and `user:change-password` those args include the **plaintext password** and **email**. `ECONUMO_LOG_LEVEL=debug` is a persistent `.env` setting, so this isn't limited to a stray `-vvv`; under `docker exec` it lands in the container log. It also contradicts the CLAUDE.md logging rule (UUIDs only, never PII).

- Log the argument **count** only, via a small `logCommandStart` helper (extraction is what makes the line testable without a DB container). The command name — the only useful signal — is kept.
- Regression test `TestLogCommandStartOmitsSecrets` asserts the DEBUG line for `user:create` contains neither the email nor the password.

The stdin follow-up (password still visible in `ps`/`/proc/<pid>/cmdline`) is out of scope, per the issue.

## #131 — Budget handlers document the full failure set

The 20 budget POST handlers documented only `200` (plus `402` since #121) and the 3 GET handlers only `200`, while every other module documents `400/401/500`.

- Added the missing `@Failure` annotations: POST → `400/401/402/500`, GET → `401/500`, matching each file's alignment style.
- Regenerated the committed OpenAPI docs (`make swagger`).
- Added guard `TestGuard_EveryAuthenticatedRouteDocuments401And500` (in the spirit of `TestGuard_EveryRestrictedPostDocuments402`): every authenticated route must document 401 and 500, so this gap class can't recur. Verified against the previously-committed spec that budget routes had only `200`/`200,402`, so the guard has teeth.

## Verification

`gofmt` clean · `go vet ./...` clean · `go build ./...` clean · `go test ./internal/cli/... ./internal/test/apiparity/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)