### PR TITLE
Validate folder ownership in move-element-list

### DIFF
--- a/internal/budget/api/budget_mutations_test.go
+++ b/internal/budget/api/budget_mutations_test.go
@@ -145,12 +145,17 @@ func TestMoveElementList_NoTypeField(t *testing.T) {
 	h := newHarness(t)
 	tok := h.token(t)
 	seedBudget(t, h, tok)
+	if st, e := h.do(t, http.MethodPost, "/api/v1/budget/create-folder", tok, map[string]any{
+		"budgetId": budgetID1, "id": bFolderID1, "name": "Bills",
+	}); st != http.StatusOK {
+		t.Fatalf("create-folder precondition=%d body=%s", st, e.raw)
+	}
 
-	// Move the seeded category element into the (seeded) folder at position 0.
+	// Move the seeded category element into the budget folder at position 0.
 	status, env := h.do(t, http.MethodPost, "/api/v1/budget/move-element-list", tok, map[string]any{
 		"budgetId": budgetID1,
 		"items": []map[string]any{
-			{"id": catID, "position": 0, "folderId": folderID},
+			{"id": catID, "position": 0, "folderId": bFolderID1},
 		},
 	})
 	if status != http.StatusOK {
@@ -158,7 +163,31 @@ func TestMoveElementList_NoTypeField(t *testing.T) {
 	}
 	var folder *string
 	h.db.QueryRow(`SELECT folder_id FROM budgets_elements WHERE budget_id = ? AND external_id = ?`, budgetID1, catID).Scan(&folder)
-	if folder == nil || *folder != folderID {
-		t.Fatalf("category element folder=%v want %q", folder, folderID)
+	if folder == nil || *folder != bFolderID1 {
+		t.Fatalf("category element folder=%v want %q", folder, bFolderID1)
+	}
+}
+
+// TestMoveElementList_ForeignFolder_403 verifies move-element-list rejects a
+// folderId that is not one of the budget's folders (here: an ACCOUNTS folder
+// id) with access denied instead of hitting the budgets_folders FK.
+func TestMoveElementList_ForeignFolder_403(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+	seedBudget(t, h, tok)
+
+	status, env := h.do(t, http.MethodPost, "/api/v1/budget/move-element-list", tok, map[string]any{
+		"budgetId": budgetID1,
+		"items": []map[string]any{
+			{"id": catID, "position": 0, "folderId": folderID},
+		},
+	})
+	if status != http.StatusForbidden {
+		t.Fatalf("move-element-list (accounts folder)=%d want 403; body=%s", status, env.raw)
+	}
+	var folder *string
+	h.db.QueryRow(`SELECT folder_id FROM budgets_elements WHERE budget_id = ? AND external_id = ?`, budgetID1, catID).Scan(&folder)
+	if folder != nil {
+		t.Fatalf("category element folder=%q want unchanged (NULL)", *folder)
 	}
 }

--- a/internal/budget/api/harness_test.go
+++ b/internal/budget/api/harness_test.go
@@ -73,6 +73,11 @@ func newHarnessWithClock(t *testing.T, clk port.Clock) *harness {
 	}
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
+	// Same pragmas as production (sqlite.Backend.Open) and dbtest: the schema
+	// relies on FK cascade/SET NULL semantics.
+	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = ON;"); err != nil {
+		t.Fatalf("pragma foreign_keys: %v", err)
+	}
 	if err := migrate.Run(ctx, db, toMigrations(migrations.SQLite())); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/budget/move.go
+++ b/internal/budget/move.go
@@ -47,6 +47,9 @@ func (s *Service) MoveElementList(ctx context.Context, userID vo.Id, req model.M
 				if ferr != nil {
 					return model.ValidateBlank(map[string]string{"folderId": ""})
 				}
+				if !b.hasFolder(fid) {
+					return accessDenied()
+				}
 				folderID = &fid
 			}
 			el.UpdateFolder(folderID, now)


### PR DESCRIPTION
## Summary

Add validation to the `move-element-list` endpoint to reject attempts to move budget elements into folders that don't belong to the budget, returning 403 Forbidden instead of hitting a foreign key constraint error.

## Changes

- **`internal/budget/move.go`**: Added a check in `MoveElementList` to verify that the target folder ID belongs to the budget before allowing the move. Returns `accessDenied()` if the folder is not found in the budget's folders.

- **`internal/budget/api/budget_mutations_test.go`**: 
  - Updated `TestMoveElementList_NoTypeField` to explicitly create a budget folder before moving elements into it, ensuring the test uses valid budget-owned folders.
  - Added new test `TestMoveElementList_ForeignFolder_403` to verify that attempting to move an element into a folder from a different context (e.g., an ACCOUNTS folder) is rejected with a 403 status code and the element remains unchanged.

- **`internal/budget/api/harness_test.go`**: Enabled SQLite foreign key constraints (`PRAGMA foreign_keys = ON`) in the test harness to match production behavior and ensure FK semantics are properly tested.

## Implementation Details

The validation leverages the existing `Budget.hasFolder()` method to check ownership before the move is committed. This prevents invalid cross-context folder references and provides a clearer error response (403) rather than relying on database constraint violations.

https://claude.ai/code/session_016mTXNGjZ1TUanJURjjw8DE