### PR TITLE
fix: log the caller's unservable Accept-Language preference

### DIFF
--- a/internal/web/middleware/middleware.go
+++ b/internal/web/middleware/middleware.go
@@ -221,9 +221,10 @@ func LocationFromCtx(ctx context.Context) *time.Location {
 // and stores it in the request context. Entries are honored in header order
 // (q-values are ignored: browsers already order by preference); the primary
 // subtag is matched case-insensitively. No match or no header means the
-// context default ("en") applies. supported is passed in by the composition
-// root (e.g. i18n.Supported) so this package stays decoupled from the
-// translation catalogue.
+// context default ("en") applies, and an unservable preference is recorded on
+// the operation line as unsupported_language. supported is passed in by the
+// composition root (e.g. i18n.Supported) so this package stays decoupled from
+// the translation catalogue.
 func Language(supported []string) func(http.Handler) http.Handler {
 	set := make(map[string]bool, len(supported))
 	for _, s := range supported {
@@ -231,17 +232,46 @@ func Language(supported []string) func(http.Handler) http.Handler {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var matched, unmatched string
 			for _, part := range strings.Split(r.Header.Get("Accept-Language"), ",") {
 				tag := strings.ToLower(strings.TrimSpace(strings.SplitN(part, ";", 2)[0]))
 				if primary, _, found := strings.Cut(tag, "-"); found {
 					tag = primary
 				}
 				if set[tag] {
-					next.ServeHTTP(w, r.WithContext(reqctx.WithLanguage(r.Context(), tag)))
-					return
+					matched = tag
+					break
 				}
+				if unmatched == "" && isLanguageSubtag(tag) {
+					unmatched = tag
+				}
+			}
+			// Demand signal for locales we don't ship yet: the caller's top
+			// preference we could not serve, recorded even when a lower-ranked
+			// entry did match — a non-English speaker almost always lists en as a
+			// fallback, so match-only logging would miss exactly who we want to count.
+			if unmatched != "" {
+				reqctx.AddLogAttr(r.Context(), "unsupported_language", unmatched)
+			}
+			if matched != "" {
+				r = r.WithContext(reqctx.WithLanguage(r.Context(), matched))
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// isLanguageSubtag reports whether tag is a bare 2-3 letter primary subtag. The
+// Accept-Language header is caller-controlled, so only this shape is recorded —
+// it keeps arbitrary bytes out of the logs and the dimension's cardinality bounded.
+func isLanguageSubtag(tag string) bool {
+	if len(tag) < 2 || len(tag) > 3 {
+		return false
+	}
+	for i := 0; i < len(tag); i++ {
+		if tag[i] < 'a' || tag[i] > 'z' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/web/middleware/middleware_test.go
+++ b/internal/web/middleware/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -508,6 +509,42 @@ func TestLanguageMiddleware(t *testing.T) {
 		h.ServeHTTP(httptest.NewRecorder(), r)
 		if got != tc.want {
 			t.Errorf("header %q: language = %q, want %q", tc.header, got, tc.want)
+		}
+	}
+}
+
+func TestLanguageMiddleware_LogsUnsupportedPreference(t *testing.T) {
+	cases := []struct{ header, want string }{
+		{"", ""},
+		{"ru-RU,ru;q=0.9", ""},
+		{"de-DE,de;q=0.9", "de"},
+		{"fr,de;q=0.9", "fr"},
+		{"de,en;q=0.5", "de"}, // en matches, but de was preferred — the case that matters
+		{"ru,de", ""},         // top preference is servable; de is never reached
+		{"*", ""},
+		{"zz-ZZ", "zz"},
+		{"not a tag", ""},
+		{"x", ""},
+	}
+	for _, tc := range cases {
+		var attrs []slog.Attr
+		h := Language([]string{"en", "ru"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attrs = reqctx.LogAttrs(r.Context())
+		}))
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		if tc.header != "" {
+			r.Header.Set("Accept-Language", tc.header)
+		}
+		h.ServeHTTP(httptest.NewRecorder(), r.WithContext(reqctx.WithLogAttrs(r.Context())))
+
+		var got string
+		for _, a := range attrs {
+			if a.Key == "unsupported_language" {
+				got = a.Value.String()
+			}
+		}
+		if got != tc.want {
+			t.Errorf("header %q: unsupported_language = %q, want %q", tc.header, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Why

Deciding which locale to translate next is currently guesswork. The app ships `en` + `ru`, and there's a parked branch with `de`/`es`/`fr`/`pl`/`pt` drafts — but nothing tells us which of those real users actually want.

The plumbing to answer that already exists: the `Language` middleware parses `Accept-Language` on every request, and `reqctx.AddLogAttr` puts custom dimensions on the operation line. This wires the two together.

## What

When a caller requests a language we don't ship, the operation line gains an `unsupported_language` attribute holding their top unservable preference:

```
jq -r 'select(.unsupported_language) | .unsupported_language' logs | sort | uniq -c | sort -rn
```

Three decisions worth reviewing:

1. **It fires even when a lower-ranked entry matched.** The first draft kept the middleware's early return, so `de,en;q=0.5` recorded nothing — the new test caught it. That's the case that matters: a non-English speaker's browser almost always lists `en` as a fallback, so match-only logging would miss nearly everyone worth counting. Only the *top* unservable tag is recorded, so a browser sending five locales doesn't inflate the count.

2. **Values are filtered to a bare 2-3 ASCII-letter subtag.** `Accept-Language` is caller-controlled; without the filter you get arbitrary bytes in the logs and unbounded dimension cardinality. `*`, `not a tag`, and junk are dropped.

3. **Language resolution is unchanged** — same match order, same context value, same fallback. The loop assigns and breaks instead of returning early, which is why the existing `TestLanguageMiddleware` passes untouched.

No PII: the dimension is a language subtag, consistent with the ids-and-counts-only logging rule.

## Interpretation caveat

This counts *requests*, not people, so a heavy user skews the tally. For per-user demand, dedupe by the `user_id` already present on the same line for authenticated traffic.

## Testing

`make go-test` — smoke suite passes, coverage 80.1% against the 80% gate. New table test covers the matched/unmatched/malformed/wildcard cases.

Note that gate sits only 0.1% above the floor. Unrelated to this change, but the next PR adding uncovered lines will trip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)