### PR TITLE
fix: keep the currencies bulk enable/disable link when there are no own currencies

### DIFF
--- a/web/src/features/classifications/ClassificationList.tsx
+++ b/web/src/features/classifications/ClassificationList.tsx
@@ -172,7 +172,10 @@ export function ClassificationList<T extends ClassificationItem>({
   const visibleSections = sectionDefs
     .map((section) => ({ label: section.label, action: section.action, items: visible.filter(section.match) }))
     .filter((section) => section.items.length > 0)
-  const showGroupHeaders = visibleSections.length > 1
+  // A lone group needs no caption to disambiguate — but its caption row is
+  // also the only mount point for a section action (the currencies bulk
+  // enable/disable link), so keep the header when one is present.
+  const showGroupHeaders = visibleSections.length > 1 || visibleSections.some((section) => section.action)
 
   // A drag reorders only the rows on screen (a section, possibly with the
   // archived ones filtered out); rebuild the full id order so every other

--- a/web/src/features/currencies/CurrenciesPage.test.tsx
+++ b/web/src/features/currencies/CurrenciesPage.test.tsx
@@ -352,6 +352,19 @@ it("with every non-locked global disabled the link flips to 'Enable all' posting
   await waitFor(() => expect(called).toBe(true))
 })
 
+it('with no own currencies the globals section still carries the bulk link', async () => {
+  server.use(
+    ...coreHandlers({
+      currencies: [fixtureUsd, fixtureEur, fixtureGbp],
+      rates: defaultRates,
+    }),
+  )
+  renderPage()
+  await screen.findByText('Euro')
+  expect(screen.queryByText('My currencies')).toBeNull()
+  expect(screen.getByRole('button', { name: 'Disable all' })).toBeInTheDocument()
+})
+
 it('the dialog frames the rate as a live equation and sizes fields compactly', async () => {
   const user = userEvent.setup()
   renderPage()


### PR DESCRIPTION
## What

On the currency settings page, the **Enable all** / **Disable all** link disappeared whenever the user had no custom currencies.

## Why

`ClassificationList` suppressed group captions whenever only one section had items:

```ts
const showGroupHeaders = visibleSections.length > 1
```

With no custom currencies the "My currencies" section is empty, so only the globals section is visible. The caption row is also the **only** mount point for a section's `action`, so the bulk link vanished along with the header.

`CurrenciesPage` was doing its part correctly — the link was built and passed as the globals section's `action`, just never rendered.

## How

The suppression is intentional for tags/payees (a single implicit group needs no caption to disambiguate), so rather than dropping it, the header is also kept when a visible section carries an action:

```ts
const showGroupHeaders = visibleSections.length > 1 || visibleSections.some((section) => section.action)
```

Tags, payees and categories pass no `action`, so their single-group behavior is unchanged. Currencies is currently the only caller using a section action.

## Testing

Added a regression test in `CurrenciesPage.test.tsx` for a currency list with no own currencies. The existing bulk-link tests all seeded `fixturePts` (an own currency), which kept "My currencies" non-empty — that is why this never surfaced.

- Verified the new test **fails without the fix**, precisely on the missing `Disable all` button
- Full frontend suite passes: **113 files, 799 tests**

## Note for the reviewer

I could not confirm this in a live browser. I ran a backend on `:8181` with a dev server on `:9100`, but the browser pane never fired the `login-user` request — the tab had picked up a second app instance from a pre-existing dev server on `:9000` that proxies to a different port. That is a local environment issue, unrelated to this change, but it means the verification here rests on the failing-then-passing test rather than a screenshot. A quick manual look at the page with no custom currencies would be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)