### PR TITLE
fix: post a due recurring template without the transaction dialog

### DIFF
--- a/web/src/features/accounts/AccountPage.test.tsx
+++ b/web/src/features/accounts/AccountPage.test.tsx
@@ -303,6 +303,46 @@ it('places the today anchor between the future block and the past', async () => 
   expect(order).toEqual(['tx-r1', 'future-anchor', 'tx-t-past'])
 })
 
+it('posts a due template straight from the preview, without the transaction form', async () => {
+  mockViewport(true)
+  const day = 24 * 3600 * 1000
+  const stamp = (d: Date) => `${d.toISOString().slice(0, 10)} 12:00:00`
+  const template = {
+    id: 'r1', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+    amount: '9.99', categoryId: 'cat-food', payeeId: null, tagId: null, description: 'sub',
+    schedule: 'monthly', nextPaymentAt: stamp(new Date(Date.now() - 5 * day)),
+  }
+  let posted: Record<string, unknown> | null = null
+  server.use(
+    ...coreHandlers({ recurring: [template], transactions: [] }),
+    http.post('*/api/v1/recurring/post-recurring-transaction', async ({ request }) => {
+      posted = (await request.json()) as Record<string, unknown>
+      return HttpResponse.json({
+        success: true, message: '',
+        data: {
+          item: {
+            id: 't-new', author: fixtureOwner, type: 'expense', accountId: 'a1', accountRecipientId: null,
+            amount: '9.99', amountRecipient: null, categoryId: 'cat-food', description: 'sub',
+            payeeId: null, tagId: null, date: template.nextPaymentAt, recurringId: 'r1',
+          },
+          accounts: fixtureAccounts,
+          nextPaymentAt: stamp(new Date(Date.now() + 25 * day)),
+        },
+      })
+    }),
+  )
+  renderPage()
+  const user = userEvent.setup()
+  await user.click(await screen.findByTestId('tx-r1'))
+  await user.click(await screen.findByRole('button', { name: 'Post' }))
+
+  await waitFor(() => expect(posted).not.toBeNull())
+  expect(posted).toMatchObject({ recurringId: 'r1', amount: '9.99', accountId: 'a1', date: template.nextPaymentAt })
+  // the prefilled form is what this flow replaced: posting must not open it
+  expect(useUiStore.getState().transactionModal).toBeNull()
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+
 it('colours the Not posted label red only when the template is due', async () => {
   mockViewport(false)
   const day = 24 * 3600 * 1000

--- a/web/src/features/accounts/AccountPage.tsx
+++ b/web/src/features/accounts/AccountPage.tsx
@@ -18,8 +18,10 @@ import { RouterPage } from '@/app/router-pages'
 import { useAccounts } from './queries'
 import { useUserData } from '@/features/user/queries'
 import { useDeleteTransaction } from '@/features/transactions/queries'
-import { useDeleteRecurring, useRecurring, useSkipRecurring } from '@/features/recurring/queries'
+import { useDeleteRecurring, usePostRecurring, useRecurring, useSkipRecurring } from '@/features/recurring/queries'
 import { ViewRecurringDialog } from '@/features/recurring/ViewRecurringDialog'
+import { recurringPostPayload } from '@/features/recurring/postPayload'
+import { useExchange } from '@/features/currencies/useExchange'
 import { separatorText, useAccountTransactions } from '@/features/transactions/useAccountTransactions'
 import type { ViewTransaction } from '@/features/transactions/useAccountTransactions'
 import type { DailyListEntry } from '@/features/transactions/useAccountTransactions'
@@ -125,7 +127,9 @@ export function AccountPage() {
   const { data: user } = useUserData()
   const deleteTransaction = useDeleteTransaction()
   const skipRecurring = useSkipRecurring()
+  const postRecurring = usePostRecurring()
   const deleteRecurring = useDeleteRecurring()
+  const exchangeFn = useExchange()
   // already cached by useAccountTransactions, so resolving a posted
   // transaction's template costs no extra request
   const { data: recurringList } = useRecurring()
@@ -462,8 +466,9 @@ export function AccountPage() {
           recurring={recurringPreview}
           onClose={() => setRecurringPreview(null)}
           onPost={() => {
-            openTransactionModal({ postRecurring: recurringPreview })
-            setRecurringPreview(null)
+            postRecurring.mutate(recurringPostPayload(recurringPreview, accounts ?? [], exchangeFn), {
+              onSuccess: () => setRecurringPreview(null),
+            })
           }}
           onSkip={() => {
             skipRecurring.mutate(recurringPreview.id, { onSuccess: () => setRecurringPreview(null) })
@@ -474,6 +479,7 @@ export function AccountPage() {
           }}
           canChange={canChangeTransaction}
           skipPending={skipRecurring.isPending}
+          postPending={postRecurring.isPending}
         />
       ) : null}
 

--- a/web/src/features/recurring/ViewRecurringDialog.tsx
+++ b/web/src/features/recurring/ViewRecurringDialog.tsx
@@ -17,6 +17,7 @@ export interface ViewRecurringDialogProps {
   canChange: boolean
   dismissible?: boolean
   skipPending?: boolean
+  postPending?: boolean
 }
 
 /**
@@ -37,6 +38,7 @@ export function ViewRecurringDialog({
   canChange,
   dismissible = true,
   skipPending = false,
+  postPending = false,
 }: ViewRecurringDialogProps) {
   const { t } = useTranslation()
   const { data: accounts } = useAccounts()
@@ -60,8 +62,10 @@ export function ViewRecurringDialog({
       onOpenRecurring={onEdit}
       footer={
         /* hide | post | skip — small, wide, small. Post leads because a due
-           template is here to be acted on. Editing is the schedule row in the
-           body, and deleting lives on the settings list, not here. */
+           template is here to be acted on, and on this sheet it posts outright
+           rather than opening a prefilled form: a due template is already the
+           transaction the user meant. Editing is the schedule row in the body,
+           and deleting lives on the settings list, not here. */
         <div className="flex gap-3 [&_button]:h-11">
           <Button
             type="button"
@@ -76,7 +80,7 @@ export function ViewRecurringDialog({
           </Button>
           {onPost ? (
             <>
-              <Button type="button" className="flex-1" disabled={!canChange} onClick={onPost}>
+              <Button type="button" className="flex-1" disabled={!canChange || postPending || skipPending} onClick={onPost}>
                 {t('recurring.preview.post')}
               </Button>
               <Button
@@ -84,7 +88,7 @@ export function ViewRecurringDialog({
                 variant="secondary"
                 size="icon"
                 className="size-11"
-                disabled={!canChange || skipPending}
+                disabled={!canChange || skipPending || postPending}
                 aria-label={t('recurring.preview.skip')}
                 title={t('recurring.preview.skip')}
                 onClick={onSkip}

--- a/web/src/features/recurring/postPayload.test.ts
+++ b/web/src/features/recurring/postPayload.test.ts
@@ -1,0 +1,61 @@
+import type { AccountDto } from '@/api/dto/account'
+import type { RecurringDto } from '@/api/dto/recurring'
+import { fixtureAccounts } from '@/test/fixtures'
+import { recurringPostPayload } from './postPayload'
+
+const accounts = fixtureAccounts as unknown as AccountDto[]
+// doubling is enough to tell a converted leg from a passed-through one
+const exchangeFn = (from: string, to: string, amount: string) => (from === to ? amount : String(Number(amount) * 2))
+
+const template = (overrides: Partial<RecurringDto> = {}): RecurringDto => ({
+  id: 'r1', ownerUserId: 'u1', type: 'expense', accountId: 'a1', accountRecipientId: null,
+  amount: '50.5', categoryId: 'cat-food', payeeId: 'p1', tagId: 'tg1', description: 'rent',
+  schedule: 'monthly', nextPaymentAt: '2026-08-02 00:00:00', ...overrides,
+})
+
+it('posts an expense with the template amount, date and classifications', () => {
+  const payload = recurringPostPayload(template(), accounts, exchangeFn)
+  expect(payload).toMatchObject({
+    recurringId: 'r1', type: 'expense', accountId: 'a1', amount: '50.5',
+    categoryId: 'cat-food', payeeId: 'p1', tagId: 'tg1', description: 'rent',
+    date: '2026-08-02 00:00:00', accountRecipientId: null, amountRecipient: null,
+  })
+})
+
+it('mints a fresh transaction id rather than reusing the template id', () => {
+  const first = recurringPostPayload(template(), accounts, exchangeFn)
+  const second = recurringPostPayload(template(), accounts, exchangeFn)
+  expect(first.id).not.toBe('r1')
+  expect(first.id).not.toBe(second.id)
+})
+
+it('mirrors the amount on a same-currency transfer and drops classifications', () => {
+  const payload = recurringPostPayload(
+    template({ type: 'transfer', accountId: 'a1', accountRecipientId: 'a2' }),
+    accounts,
+    exchangeFn,
+  )
+  expect(payload).toMatchObject({
+    accountRecipientId: 'a2', amount: '50.5', amountRecipient: '50.5',
+    categoryId: null, payeeId: null, tagId: null,
+  })
+})
+
+it('converts the recipient leg of a cross-currency transfer', () => {
+  const payload = recurringPostPayload(
+    template({ type: 'transfer', amount: '10', accountId: 'a1', accountRecipientId: 'a3' }),
+    accounts,
+    exchangeFn,
+  )
+  expect(payload.amount).toBe('10')
+  expect(payload.amountRecipient).toBe('20')
+})
+
+it('falls back to the sender amount when the recipient account is not loaded', () => {
+  const payload = recurringPostPayload(
+    template({ type: 'transfer', amount: '10', accountId: 'a1', accountRecipientId: 'a-unknown' }),
+    accounts,
+    exchangeFn,
+  )
+  expect(payload.amountRecipient).toBe('10')
+})

--- a/web/src/features/recurring/postPayload.ts
+++ b/web/src/features/recurring/postPayload.ts
@@ -1,0 +1,43 @@
+import { v7 as uuidv7 } from 'uuid'
+import type { AccountDto } from '@/api/dto/account'
+import type { PostRecurringPayload, RecurringDto } from '@/api/dto/recurring'
+import { normalize } from '@/lib/decimal'
+
+/**
+ * The payload a due template posts as, without going through the transaction
+ * form: a due template already describes the transaction the user means, so the
+ * account list's Post acts outright. Mirrors buildPayload's transfer rules —
+ * only a transfer carries a recipient, and only a non-transfer carries
+ * category/payee/tag — so a template posted here and one posted through the
+ * dialog write the same row.
+ */
+export function recurringPostPayload(
+  recurring: RecurringDto,
+  accounts: AccountDto[],
+  exchangeFn: (fromCurrencyId: string, toCurrencyId: string, amount: string) => string,
+): PostRecurringPayload {
+  const isTransfer = recurring.type === 'transfer'
+  const amount = normalize(recurring.amount)
+  const from = accounts.find((a) => a.id === recurring.accountId)
+  const to = recurring.accountRecipientId ? accounts.find((a) => a.id === recurring.accountRecipientId) : undefined
+  // a template stores one amount, so a cross-currency transfer's recipient leg
+  // has to be converted here as the form used to — passing the sender's number
+  // through would silently credit the wrong sum
+  const amountRecipient =
+    isTransfer && from && to && from.currency.id !== to.currency.id ? exchangeFn(from.currency.id, to.currency.id, amount) : amount
+
+  return {
+    id: uuidv7(),
+    recurringId: recurring.id,
+    type: recurring.type,
+    accountId: recurring.accountId,
+    accountRecipientId: isTransfer ? recurring.accountRecipientId : null,
+    amount,
+    amountRecipient: isTransfer ? amountRecipient : null,
+    categoryId: isTransfer ? null : recurring.categoryId,
+    payeeId: isTransfer ? null : recurring.payeeId,
+    tagId: isTransfer ? null : recurring.tagId,
+    description: recurring.description || '',
+    date: recurring.nextPaymentAt,
+  }
+}


### PR DESCRIPTION
## What

Tapping an unposted recurring row on the account page opens a preview sheet. Its **Post** button used to open a *second*, prefilled transaction form that the user then had to save — three steps to record a transaction the template already fully describes.

Post on that sheet now writes the transaction outright and closes.

```
before:  tap row → preview → Post → prefilled form → Save → posted
after:   tap row → preview → Post → posted
```

## Scope

Account page only. The **Recurring settings list keeps the prefilled form**, since a template reached from there need not be due and is more likely to want an amount change before posting.

There is deliberately no edit-then-post affordance on the sheet: to record a different amount, skip the template and add a transaction normally.

## How

New `recurringPostPayload` (`web/src/features/recurring/postPayload.ts`) builds the payload the form used to assemble, mirroring `buildPayload`'s transfer rules — only a transfer carries a recipient, only a non-transfer carries category/payee/tag — so both paths write the same row.

## Reviewer notes

- **Cross-currency transfers.** A template stores one amount, but the recipient leg of a cross-currency transfer needs conversion — the form did this and the payload builder now does too. Passing the sender's number through would have silently credited the wrong sum. Covered by a test.
- **Fresh transaction id.** The payload mints a new UUIDv7 rather than reusing the template id (which is the operation-id/idempotency key). Covered by a test.
- **Double-tap.** Post and Skip each disable while either mutation is in flight.
- **Failure.** Only `onSuccess` closes the sheet, so a failed post leaves it open — same as the dialog behaved.
- `usePostRecurring` fires no analytics event, but neither did the flow it replaces (the recurring mutations have no `METRICS` keys at all), so this loses no tracking. Pre-existing gap, left alone.

## Testing

- Typecheck clean, 0 lint errors, **806/806 vitest pass** (6 new: 5 payload unit tests + 1 integration test asserting the API call fires with the right payload and no form opens).
- Verified end-to-end in a 375×812 mobile viewport against a real Go backend on a throwaway copy of the demo DB: balance went 4,387.42 → 4,344.67 (−42.75) with no dialog, the row became a real posted transaction, and the template advanced 30 Jul → 30 Aug. The persisted row confirms amount, date, category, and the `recurring_id` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)