### PR TITLE
fix: keep a transfer on the surviving account when the other one is deleted

### DIFF
--- a/web/src/features/accounts/queries.test.tsx
+++ b/web/src/features/accounts/queries.test.tsx
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw'
 import type { ReactNode } from 'react'
 import { server } from '@/test/msw'
 import { queryKeys } from '@/app/queryKeys'
-import { useAcceptAccountAccess, useAccounts, useCreateAccount, useDeclineAccountAccess, useFolders } from './queries'
+import { useAcceptAccountAccess, useAccounts, useCreateAccount, useDeclineAccountAccess, useDeleteAccount, useFolders } from './queries'
 
 const wireOwner = { id: 'u1', avatar: '', name: 'Ada' }
 const wireUser = { id: 'u1', name: 'Ada', email: 'ada@example.test', avatar: 'face:emerald', options: [] }
@@ -110,6 +110,34 @@ it('decline-access immediately drops the pending account from the cache', async 
   await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
   expect(queryClient.getQueryData<{ id: string }[]>(queryKeys.accounts)!.map((a) => a.id)).toEqual(['a-real'])
+})
+
+// Deleting an account is a soft delete on the server: it keeps the transfers
+// that pointed at the account, and still lists them on the surviving side. So
+// the cache must only drop a transaction when NEITHER of its accounts is left
+// — dropping the transfer here would hide it until the next refetch, then let
+// it reappear.
+it('delete-account keeps a transfer whose other account survives, drops the rest', async () => {
+  server.use(
+    http.post('*/api/v1/account/delete-account', () =>
+      HttpResponse.json({ success: true, message: '', data: {} }),
+    ),
+  )
+  const survivor = { ...wireAccount, id: 'a-keep' }
+  const transfer = {
+    ...wireCorrection, id: 't-transfer', type: 'transfer', accountId: 'a-real', accountRecipientId: 'a-keep',
+  }
+  const ownExpense = { ...wireCorrection, id: 't-own', type: 'expense', accountId: 'a-real', accountRecipientId: null }
+  const { queryClient, wrapper } = makeWrapper()
+  queryClient.setQueryData(queryKeys.accounts, [wireAccount, survivor])
+  queryClient.setQueryData(queryKeys.transactions, [transfer, ownExpense])
+
+  const { result } = renderHook(() => useDeleteAccount(), { wrapper })
+  result.current.mutate('a-real')
+  await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+  expect(queryClient.getQueryData<{ id: string }[]>(queryKeys.accounts)!.map((a) => a.id)).toEqual(['a-keep'])
+  expect(queryClient.getQueryData<{ id: string }[]>(queryKeys.transactions)!.map((t) => t.id)).toEqual(['t-transfer'])
 })
 
 it('useAccounts hides an account pending my acceptance, and shows it once accepted', async () => {

--- a/web/src/features/accounts/queries.ts
+++ b/web/src/features/accounts/queries.ts
@@ -88,9 +88,16 @@ export function useDeleteAccount() {
   return useMutation({
     mutationFn: accountApi.deleteAccount,
     onSuccess: (_result, id) => {
-      queryClient.setQueryData<AccountDto[]>(queryKeys.accounts, (prev) => (prev ?? []).filter((a) => a.id !== id))
+      const remaining = (queryClient.getQueryData<AccountDto[]>(queryKeys.accounts) ?? []).filter((a) => a.id !== id)
+      queryClient.setQueryData<AccountDto[]>(queryKeys.accounts, remaining)
+      // Deleting an account is a soft delete that leaves its transactions in
+      // place, and the server still lists a transfer whose OTHER leg is a
+      // surviving account (the money did move). Dropping those here would only
+      // hide them until the next refetch, so mirror the server: a transaction
+      // goes only when neither of its accounts is left.
+      const survives = new Set(remaining.map((a) => a.id))
       queryClient.setQueryData<TransactionDto[]>(queryKeys.transactions, (prev) =>
-        (prev ?? []).filter((t) => t.accountId !== id && t.accountRecipientId !== id),
+        (prev ?? []).filter((t) => survives.has(t.accountId) || (t.accountRecipientId !== null && survives.has(t.accountRecipientId))),
       )
       trackEvent(METRICS.ACCOUNT_DELETE)
     },


### PR DESCRIPTION
## Problem

Transfer money from Checking to Savings, then delete Savings. The transfer vanishes from Checking's transaction list — and comes back on the next refetch.

Deleting an account is a **soft** delete (`internal/account/delete.go`): it flips `is_deleted` and touches nothing else. The `ON DELETE SET NULL` FK on `transactions.account_recipient_id` never fires, because the row is `UPDATE`d rather than `DELETE`d. The transfer survives, and the server keeps listing it on the surviving account — correctly, since the money did leave Checking and its balance still counts it.

But `useDeleteAccount` dropped **every** cached transaction referencing the deleted account, transfers included. So the client cache disagreed with the server: the row disappeared, then reappeared as soon as the transactions query refetched.

## Fix

Mirror the server. A transaction is dropped from the cache only when *neither* of its accounts is left; a transfer whose other leg still exists stays.

## Test

`delete-account keeps a transfer whose other account survives, drops the rest` — a transfer to a surviving account is kept, a plain expense on the deleted account is dropped. Verified to fail against the previous implementation before the fix was restored.

## Known limitation (not addressed here)

The surviving transfer's counterpart still renders as `[Hidden account]`, because `get-account-list` omits deleted accounts and the frontend resolves the counterpart name by joining against it. That label conflates three cases — *you deleted it yourself*, *never shared with you*, *pending invite* — and for the first it is misleading.

Naming it properly needs a way to look up a deleted account's name (e.g. a `get-deleted-account-list` endpoint scoped to the caller's own accounts, so another user's account stays anonymous). That was prototyped and deliberately left out of this PR: ~500 lines across 28 files and a new permanent endpoint, for a cosmetic label change. This PR is limited to the actual data-visibility defect.

## Verification

- `pnpm exec tsc -b` clean
- `pnpm exec vitest run` — 113 files, 799 tests, 0 failures (on an idle machine; this suite times out spuriously under load)
- Backend untouched; `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)