### PR TITLE
fix: pass the archived-row label into ClassificationList per list

### DIFF
--- a/web/src/features/classifications/CategoriesPage.tsx
+++ b/web/src/features/classifications/CategoriesPage.tsx
@@ -36,6 +36,7 @@ export function CategoriesPage() {
         info={t('classifications.categories.pages.settings.info')}
         createLabel={t('classifications.categories.pages.settings.create_category')}
         deleteTitle={t('classifications.categories.modals.delete.title')}
+        archivedLabel={t('classifications.categories.pages.settings.archived_item')}
         items={own}
         storageKey="settings.categories.activeOnly"
         analyticsType="category"

--- a/web/src/features/classifications/ClassificationList.test.tsx
+++ b/web/src/features/classifications/ClassificationList.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { ClassificationList } from './ClassificationList'
+
+function mockViewport() {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  }))
+}
+
+// The archived badge must come from the caller (each list has its own catalogue
+// key — languages inflect the word differently per noun), never from a
+// hard-coded categories key.
+it('renders the caller-supplied archived label on archived rows', () => {
+  mockViewport()
+  const router = createMemoryRouter(
+    [{
+      path: '/x',
+      element: (
+        <ClassificationList
+          title="Payees"
+          createLabel="Create payee"
+          deleteTitle="Delete payee?"
+          analyticsType="payee"
+          archivedLabel="Arquivados"
+          items={[
+            { id: 'p1', name: 'Grocer', position: 0, isArchived: 1 },
+            { id: 'p2', name: 'Butcher', position: 1, isArchived: 0 },
+          ]}
+          onCreate={() => {}}
+          onEdit={() => {}}
+          onDelete={() => {}}
+        />
+      ),
+    }],
+    { initialEntries: ['/x'] },
+  )
+  render(<RouterProvider router={router} />)
+  expect(screen.getByText('Grocer')).toBeInTheDocument()
+  expect(screen.getByText('Arquivados')).toBeInTheDocument()
+  // the categories catalogue string must not leak in
+  expect(screen.queryByText('Archived')).not.toBeInTheDocument()
+})

--- a/web/src/features/classifications/ClassificationList.tsx
+++ b/web/src/features/classifications/ClassificationList.tsx
@@ -60,6 +60,8 @@ interface ClassificationListProps<T extends ClassificationItem> {
   alert?: ReactNode
   createLabel: string
   deleteTitle: string
+  /** badge on archived rows; per-list because languages inflect it per noun */
+  archivedLabel: string
   items: T[]
   /** localStorage key for the active-only filter; absent = no filter control */
   storageKey?: string
@@ -93,6 +95,7 @@ export function ClassificationList<T extends ClassificationItem>({
   alert,
   createLabel,
   deleteTitle,
+  archivedLabel,
   items,
   storageKey,
   analyticsType,
@@ -281,7 +284,7 @@ export function ClassificationList<T extends ClassificationItem>({
             {item.name}
           </span>
           {item.isArchived === 1 ? (
-            <span className="text-xs text-muted-foreground">{t('classifications.categories.pages.settings.archived_item')}</span>
+            <span className="text-xs text-muted-foreground">{archivedLabel}</span>
           ) : null}
           {meta?.(item)}
         </span>

--- a/web/src/features/classifications/PayeesPage.tsx
+++ b/web/src/features/classifications/PayeesPage.tsx
@@ -39,6 +39,7 @@ export function PayeesPage() {
         heading={t('classifications.payees.pages.settings.menu_item')}
         createLabel={t('classifications.payees.pages.settings.create_payee')}
         deleteTitle={t('classifications.payees.modals.delete.title')}
+        archivedLabel={t('classifications.payees.pages.settings.archived_item')}
         items={own}
         storageKey="settings.payees.activeOnly"
         analyticsType="payee"

--- a/web/src/features/classifications/TagsPage.tsx
+++ b/web/src/features/classifications/TagsPage.tsx
@@ -38,6 +38,7 @@ export function TagsPage() {
         info={t('classifications.tags.pages.settings.info')}
         createLabel={t('classifications.tags.pages.settings.create_tag')}
         deleteTitle={t('classifications.tags.modals.delete.title')}
+        archivedLabel={t('classifications.tags.pages.settings.archived_item')}
         items={own}
         storageKey="settings.tags.activeOnly"
         analyticsType="tag"

--- a/web/src/features/currencies/CurrenciesPage.tsx
+++ b/web/src/features/currencies/CurrenciesPage.tsx
@@ -97,6 +97,7 @@ export function CurrenciesPage() {
         alert={error && !dialog.open ? <p className="px-1 text-sm text-destructive">{error}</p> : null}
         createLabel={t('classifications.currencies.pages.settings.create_currency')}
         deleteTitle={t('classifications.currencies.modals.delete.title')}
+        archivedLabel="" // never rendered: CurrencyRow pins isArchived to 0
         items={items}
         analyticsType="currency"
         sections={[


### PR DESCRIPTION
## Summary
- `ClassificationList` rendered the archived-row badge with a hard-coded `classifications.categories.pages.settings.archived_item` key, so the **categories** string leaked onto the tags and payees pages and their own `archived_item` keys were dead. Identical `en`/`ru` values kept it invisible; inflecting languages exposed it (the Portuguese catalogue had to flatten all three values to a gender-free `Em arquivo` as a workaround).
- The badge label is now a required `archivedLabel` prop, resolved by the caller exactly like `title`/`createLabel`/`deleteTitle`; each page passes its own list's key, bringing the dead tags/payees keys to life.
- `CurrenciesPage` passes an empty label — it pins `isArchived: 0`, so the badge never renders there.
- No catalogue changes needed: all three keys already exist in every language. Translators can now inflect per list (e.g. pt could restore gendered forms).

## Test plan
- [x] New `ClassificationList.test.tsx` asserts archived rows render the caller-supplied label and the categories string does not leak in (failed before the fix, passes after)
- [x] `pnpm exec tsc -b`, `pnpm lint`, full `pnpm test` (808 tests) pass
- [x] `go test ./internal/test/i18ntest/` (catalogue/key guards) passes

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)