### PR TITLE
feat: link the website release notes from every GitHub release

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -115,6 +115,8 @@ whether/how to upgrade, and API-client authors who need to know about wire chang
 House style (see the v1.0.0 release for the reference tone):
 
 ```markdown
+📖 **[Read the full release notes, with screenshots →](https://econumo.com/releases/vX.Y.Z/)**
+
 <one-paragraph summary of the release's themes>
 
 ## What's new
@@ -139,6 +141,15 @@ exact version use `ghcr.io/econumo/econumo:vX.Y.Z`.
 [@login](https://github.com/login) — ...
 
 **Full changelog**: [vLAST...vX.Y.Z](https://github.com/econumo/econumo/compare/vLAST...vX.Y.Z)
+```
+
+The first line is always the link to that version's page on econumo.com, which carries the
+screenshots and the long-form write-up the GitHub body can't. Every released version has one
+(`https://econumo.com/releases/vX.Y.Z/`); confirm it before publishing the notes, and publish
+the site page first if it 404s:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://econumo.com/releases/vX.Y.Z/
 ```
 
 Contributors come from the actual range, not memory:

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -144,13 +144,10 @@ exact version use `ghcr.io/econumo/econumo:vX.Y.Z`.
 ```
 
 The first line is always the link to that version's page on econumo.com, which carries the
-screenshots and the long-form write-up the GitHub body can't. Every released version has one
-(`https://econumo.com/releases/vX.Y.Z/`); confirm it before publishing the notes, and publish
-the site page first if it 404s:
-
-```bash
-curl -s -o /dev/null -w '%{http_code}\n' https://econumo.com/releases/vX.Y.Z/
-```
+screenshots and the long-form write-up the GitHub body can't. The URL is always
+`https://econumo.com/releases/vX.Y.Z/` — write it without checking. The GitHub release ships
+first and the site page follows, so the link is expected to 404 for a while; that is the
+normal order, not a mistake to fix before publishing.
 
 Contributors come from the actual range, not memory:
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -273,6 +273,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # The website's release page carries the screenshots and the long-form
+      # write-up the GitHub body has no room for, so every release links to it
+      # from its first line. Done here rather than only in the hand-written
+      # notes so patch releases that keep the auto-generated body get it too.
+      # Idempotent: re-running (or a later hand-written body that already opens
+      # with the link) leaves the notes untouched.
+      - name: Link the release notes on econumo.com
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.create-tag.outputs.version }}
+        run: |
+          LINK="📖 **[Read the full release notes, with screenshots →](https://econumo.com/releases/${TAG}/)**"
+          BODY="$(gh release view "$TAG" --json body -q .body)"
+          case "$BODY" in
+            "$LINK"*)
+              echo "Notes already open with the release-notes link; nothing to do"
+              ;;
+            *)
+              printf '%s\n\n%s\n' "$LINK" "$BODY" > release-notes.md
+              gh release edit "$TAG" --notes-file release-notes.md
+              echo "Prepended the econumo.com release-notes link"
+              ;;
+          esac
+
       - name: Download release binaries
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -277,6 +277,9 @@ jobs:
       # write-up the GitHub body has no room for, so every release links to it
       # from its first line. Done here rather than only in the hand-written
       # notes so patch releases that keep the auto-generated body get it too.
+      # The link is written unconditionally and deliberately NOT checked: the
+      # GitHub release is published first and the site page follows, so a fresh
+      # release's link 404s until then.
       # Idempotent: re-running (or a later hand-written body that already opens
       # with the link) leaves the notes untouched.
       - name: Link the release notes on econumo.com


### PR DESCRIPTION
The econumo.com release page for each version carries the screenshots and the long-form write-up that the GitHub release body has no room for — but nothing pointed at it. Every GitHub release now opens with a link to it.

## What changed

**`.github/workflows/publish-release.yml`** — a new `Link the release notes on econumo.com` step, right after `changelogithub` creates the release, prepends:

> 📖 **[Read the full release notes, with screenshots →](https://econumo.com/releases/vX.Y.Z/)**

**`.claude/skills/publish-release/SKILL.md`** — the house-style template now shows the link as the body's first line.

## Why the workflow, not just the skill

Four of the eight existing releases (v1.0.1, v1.0.2, v1.1.1, v1.2.1) still carried raw auto-generated notes — the hand-written-notes step of the skill never ran for them. A skill-only change would keep missing exactly those releases. Doing it in the workflow covers every release regardless of whether the notes are later rewritten by hand.

The step is **idempotent**: if the body already opens with that version's link (a re-run, or hand-written notes that already include it), it does nothing. So the normal flow — workflow prepends, human replaces the body later with notes that already carry the link — stays clean.

## The link 404s at first, by design

The GitHub release is published first and the website release page follows. The link is therefore written unconditionally and deliberately never checked — a fresh release points at a page that does not exist yet, and that is the normal order rather than something to guard against. Both the workflow comment and the skill say so, so neither a future reader nor an agent running the skill tries to "fix" it by adding a preflight check.

## Already applied to existing releases

All 8 published releases (v1.0.0 → v1.3.0) were backfilled with the same first line outside this PR, after verifying each version has a live, distinct page on the site. The "Latest" badge still sits only on v1.3.0.

## Notes for the reviewer

- No `${{ }}` interpolation inside `run:` — `TAG` comes through `env:` and every expansion is a quoted shell variable. `TAG` is already validated against `^v[0-9]+\.[0-9]+\.[0-9]+$` in the `create-tag` job upstream.
- Verified: workflow YAML parses with the step correctly ordered; the prepend/skip logic tested against a fresh auto-generated body, a re-run, and a body linking a *different* version (correctly prepends). Auto-generated bodies contain no CRLF, so the prefix match is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)