### PR TITLE
fix: keep the SPA working over plain HTTP on a LAN IP (#197)

### DIFF
--- a/web/src/features/settings/PersonalTokensPage.tsx
+++ b/web/src/features/settings/PersonalTokensPage.tsx
@@ -12,6 +12,7 @@ import { ResponsiveDialog, dialogActionsClass } from '@/components/ResponsiveDia
 import { RouterPage } from '@/app/router-pages'
 import type { CreatedPersonalTokenDto, PersonalTokenDto } from '@/api/dto/user'
 import { calendarLocale } from '@/lib/calendarLocale'
+import { copyText } from '@/lib/clipboard'
 import { formatDate, parseDateTime } from '@/lib/datetime'
 import { useCreatePersonalToken, usePersonalTokens, useRevokePersonalToken } from './security'
 import { parseUtcDateTime, relativeTime } from './securityFormat'
@@ -85,8 +86,7 @@ export function PersonalTokensPage() {
 
   const copy = () => {
     if (created) {
-      void navigator.clipboard.writeText(created.token)
-      setCopied(true)
+      void copyText(created.token).then(setCopied)
     }
   }
 

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -89,6 +89,18 @@ describe('capture', () => {
     expect(sentPayload(1).batch).toHaveLength(1)
   })
 
+  // crypto.randomUUID exists only in secure contexts, so a self-hosted instance
+  // reached over http://<lan-ip> does not have it (issue #197).
+  it('assigns a distinct_id in an insecure context, where crypto.randomUUID is absent', async () => {
+    const getRandomValues = globalThis.crypto.getRandomValues.bind(globalThis.crypto)
+    vi.stubGlobal('crypto', { getRandomValues })
+    vi.resetModules()
+    const insecure = await import('./analytics')
+    insecure.capture('a')
+    vi.advanceTimersByTime(10_000)
+    expect(sentPayload().batch[0].distinct_id).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
   it('sends the tail via sendBeacon when the tab hides', () => {
     const beacon = vi.fn(() => true)
     vi.stubGlobal('navigator', { ...window.navigator, sendBeacon: beacon })

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -4,6 +4,8 @@
 // properties built by the caller ever leave the browser.
 // See docs/superpowers/specs/2026-07-17-posthog-analytics-design.md.
 
+import { v4 as uuidv4 } from 'uuid'
+
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 // A PostHog project API key is public by design (it can only ingest events).
 const POSTHOG_KEY = 'phc_nsMAM8nZ2N9Xh4PmCTuUpihHC2tHJnkMKKPdHxSHwDEk'
@@ -17,7 +19,10 @@ interface CapturedEvent {
   properties: Record<string, unknown>
 }
 
-const distinctId = crypto.randomUUID()
+// Not crypto.randomUUID: that one is secure-context-only, so it is missing on a
+// self-hosted instance served over plain http://<lan-ip>, and this module-level
+// call would take the whole SPA down there. uuid falls back to getRandomValues.
+const distinctId = uuidv4()
 let queue: CapturedEvent[] = []
 let timer: ReturnType<typeof setTimeout> | null = null
 

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { copyText } from './clipboard'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(document, 'execCommand')
+})
+
+function stubExecCommand(result: boolean) {
+  const execCommand = vi.fn(() => result)
+  Object.defineProperty(document, 'execCommand', { value: execCommand, configurable: true })
+  return execCommand
+}
+
+it('uses the async clipboard API when it is available', async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal('navigator', { ...window.navigator, clipboard: { writeText } })
+  await expect(copyText('eco_pat_value')).resolves.toBe(true)
+  expect(writeText).toHaveBeenCalledWith('eco_pat_value')
+})
+
+// An insecure context (plain http on a LAN IP) has no navigator.clipboard at all.
+it('falls back to execCommand when navigator.clipboard is missing', async () => {
+  vi.stubGlobal('navigator', { ...window.navigator, clipboard: undefined })
+  const execCommand = stubExecCommand(true)
+  await expect(copyText('eco_pat_value')).resolves.toBe(true)
+  expect(execCommand).toHaveBeenCalledWith('copy')
+  expect(document.querySelector('textarea')).toBeNull()
+})
+
+it('falls back to execCommand when writeText rejects', async () => {
+  const writeText = vi.fn().mockRejectedValue(new DOMException('denied'))
+  vi.stubGlobal('navigator', { ...window.navigator, clipboard: { writeText } })
+  stubExecCommand(true)
+  await expect(copyText('eco_pat_value')).resolves.toBe(true)
+})
+
+it('reports failure when neither path works', async () => {
+  vi.stubGlobal('navigator', { ...window.navigator, clipboard: undefined })
+  stubExecCommand(false)
+  await expect(copyText('eco_pat_value')).resolves.toBe(false)
+  expect(document.querySelector('textarea')).toBeNull()
+})

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,28 @@
+// navigator.clipboard is secure-context-only, so a self-hosted instance reached
+// over plain http://<lan-ip> does not have it. execCommand is deprecated but is
+// the only copy path that still works there; callers get false when both fail.
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return legacyCopy(text)
+  }
+}
+
+function legacyCopy(text: string): boolean {
+  const field = document.createElement('textarea')
+  field.value = text
+  field.setAttribute('readonly', '')
+  field.style.position = 'fixed'
+  field.style.opacity = '0'
+  document.body.appendChild(field)
+  field.select()
+  try {
+    return document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    field.remove()
+  }
+}


### PR DESCRIPTION
Fixes #197.

## Root cause

`web/src/lib/analytics.ts` called `crypto.randomUUID()` **at module-evaluation time**. That API is [secure-context-only](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) — present on `https://…` and `http://localhost`, absent on `http://<lan-ip>`.

The blast radius is the whole app, not just analytics: `analytics.ts` ← `lib/metrics.ts` ← `uiStore`/`routes`/pages, and the router imports every page eagerly, so it all lands in the main chunk. The `TypeError` fires while that chunk is still evaluating, before React mounts — white page, exactly as reported. Note that `ECONUMO_ANALYTICS=false` did **not** work around it: the crash happens at import, before any flag is read.

Present since v1.1.0 (2b63245b, #99).

## Fix

Use `v4()` from the `uuid` package — already a dependency. It uses `crypto.randomUUID` when available and otherwise falls back to `crypto.getRandomValues`, which is *not* secure-context-restricted. Every other id in the SPA already goes through `uuid`'s `v7()` (`getRandomValues` only), so nothing else was affected.

A sweep for other secure-context-only APIs found exactly one more real break in the same environment: `navigator.clipboard.writeText` in `PersonalTokensPage` — over plain HTTP that is a property access on `undefined`, so copying a freshly created PAT threw and the "Copied" state never set. Included here since it is the same root cause: the new `lib/clipboard.ts` helper tries the async Clipboard API, falls back to `document.execCommand('copy')`, and returns a boolean the page uses to set `copied` only on success.

## Verification

Failing test first — stubbing `crypto` with only `getRandomValues` reproduced the reported error verbatim (`TypeError: crypto.randomUUID is not a function at src/lib/analytics.ts:20:27`).

Then the production SPA build loaded in headless Chrome over `http://econumo.test:8899` (mapped to loopback, so a genuinely insecure context):

| build | `http://econumo.test` (insecure) | `http://localhost` (secure) |
|---|---|---|
| pre-fix | **2,168 bytes, empty root** | 36,825 bytes, login page |
| post-fix | 36,825 bytes, login page | 36,825 bytes, login page |

Full frontend suite passes (819 tests / 117 files), `tsc -b` clean, `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)