### PR TITLE
chore: clear the brace-expansion advisory and drop __dirname from the Vite config

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -2070,8 +2070,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -5839,7 +5839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6722,7 +6722,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,7 +13,7 @@ function backendPort(): string {
     return process.env.PORT
   }
   try {
-    const env = fs.readFileSync(path.resolve(__dirname, '../.env'), 'utf8')
+    const env = fs.readFileSync(path.resolve(import.meta.dirname, '../.env'), 'utf8')
     const match = /^\s*PORT\s*=\s*"?(\d+)"?\s*$/m.exec(env)
     if (match) {
       return match[1]
@@ -27,7 +27,7 @@ function backendPort(): string {
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
-    alias: { '@': path.resolve(__dirname, 'src') },
+    alias: { '@': path.resolve(import.meta.dirname, 'src') },
   },
   envPrefix: ['VITE_', 'ECONUMO_', 'WEBSITE_'],
   server: {


### PR DESCRIPTION
Two small follow-ups from merging the dependabot bumps (#193-#200).

### brace-expansion 5.0.8 -> 5.0.9

Clears the open high-severity DoS advisory (alert #278). It reaches us
transitively through `shadcn` -> `ts-morph` -> `minimatch`, i.e. a
build-time CLI that never ships in the SPA bundle, so real-world risk was
low — but it would not have gone away on its own:

- Dependabot's own run failed with `security_update_not_possible`,
  reporting `latest-resolvable-version: 5.0.8` against a stale index.
- 5.0.9 is published and `minimatch@10.2.5` requires `^5.0.5`, which
  permits it, so the lockfile moves with a plain `pnpm update` — no
  `pnpm.overrides` entry needed.

Lockfile-only; `package.json` is untouched.

### `__dirname` -> `import.meta.dirname`

Vite 8.2 warns that `__dirname` is unsupported by `configLoader: 'native'`,
planned to become the default in a future major. Node is 26 in CI and in
the frontend build image, comfortably above the 20.11 this requires.

The `backendPort()` read sits inside a `try`/`catch` that falls back to
8181, so a wrong path would degrade silently rather than fail. Verified
explicitly by loading the real config against a repo-root `.env` holding
`PORT=7777` — the proxy resolved to `http://localhost:7777`, confirming
the path still points at the repo root.

### Verification

- `pnpm install --frozen-lockfile`, `tsc -b` clean
- `pnpm build` succeeds, `@` alias resolves, warning gone from the output
- vitest 814/814 passing, lint shows only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)