### PR TITLE
fix: update-budget no longer re-includes a partner's excluded accounts

### DIFF
--- a/internal/budget/accounts.go
+++ b/internal/budget/accounts.go
@@ -29,6 +29,26 @@ func (s *Service) IncludeAccount(ctx context.Context, userID vo.Id, req model.In
 	return &model.IncludeAccountResult{Item: meta}, nil
 }
 
+// ownsAccount reports whether accountID belongs to userID, memoizing the lookup
+// in the same per-call cache buildFilters uses. A missing account is "not
+// owned": callers skip such ids rather than failing the whole update.
+func (s *Service) ownsAccount(ctx context.Context, userID, accountID vo.Id) (bool, error) {
+	ownerID, ok := s.accountOwners[accountID.String()]
+	if !ok {
+		owner, err := s.accounts.AccountOwner(ctx, accountID)
+		if err != nil {
+			var nf *errs.NotFoundError
+			if errors.As(err, &nf) {
+				return false, nil
+			}
+			return false, err
+		}
+		ownerID = owner.String()
+		s.accountOwners[accountID.String()] = ownerID
+	}
+	return ownerID == userID.String(), nil
+}
+
 // toggleAccount excludes (exclude=true) or includes an account; the account must
 // be owned by the requester (access denied otherwise).
 func (s *Service) toggleAccount(ctx context.Context, userID vo.Id, rawBudget, rawAccount string, exclude bool) (model.MetaResult, error) {

--- a/internal/budget/api/update_budget_excluded_scope_test.go
+++ b/internal/budget/api/update_budget_excluded_scope_test.go
@@ -1,0 +1,105 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/econumo/econumo/internal/test/dbtest"
+	"github.com/econumo/econumo/internal/test/fixture"
+)
+
+const (
+	scopeBudgetID    = "bbbb6666-0000-7000-8000-000000000006"
+	partnerAcctID    = "aaaa6666-0000-7000-8000-000000000006"
+	partnerAcctBothB = "aaaa6666-0000-7000-8000-000000000007"
+)
+
+// TestUpdateBudget_KeepsPartnerExclusions: update-budget's excludedAccounts set
+// is scoped to the CALLER's own accounts. get-budget only ever reports the
+// requester's own exclusions (buildFilters), so a client round-tripping that
+// list back cannot name its partner's excluded accounts — replacing the whole
+// budget-wide set would silently re-include every account the partner excluded.
+func TestUpdateBudget_KeepsPartnerExclusions(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+
+	if st, e := h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok,
+		createBudgetReq(scopeBudgetID, "Shared Budget")); st != http.StatusOK {
+		t.Fatalf("create-budget=%d body=%s", st, e.raw)
+	}
+
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	f.User(fixture.User{ID: otherUserID, Name: "Partner"})
+	f.BudgetAccess(scopeBudgetID, otherUserID, 1, true) // role=user, accepted
+	f.Account(fixture.Account{ID: partnerAcctID, UserID: otherUserID, CurrencyID: usdID, Name: "Partner Cash"})
+
+	// The partner excludes their own account from the shared budget.
+	if st, e := h.do(t, http.MethodPost, "/api/v1/budget/exclude-account", otherUserID, map[string]any{
+		"id": scopeBudgetID, "accountId": partnerAcctID,
+	}); st != http.StatusOK {
+		t.Fatalf("partner exclude-account=%d body=%s", st, e.raw)
+	}
+
+	// The owner opens the budget dialog and excludes one of THEIR OWN accounts.
+	// The submitted set carries only the owner's accounts — the partner's
+	// exclusion is invisible to them and must survive.
+	status, env := h.do(t, http.MethodPost, "/api/v1/budget/update-budget", tok, map[string]any{
+		"id": scopeBudgetID, "name": "Shared Budget", "currencyId": usdID,
+		"excludedAccounts": []string{accountID},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("update-budget=%d body=%s", status, env.raw)
+	}
+
+	var n int
+	if err := h.db.QueryRow(`SELECT COUNT(*) FROM budgets_excluded_accounts WHERE budget_id=? AND account_id=?`,
+		scopeBudgetID, partnerAcctID).Scan(&n); err != nil {
+		t.Fatalf("count partner exclusion: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("partner exclusion rows=%d want 1 (update-budget must not re-include another user's account)", n)
+	}
+	// The caller's own exclusion still applied.
+	if err := h.db.QueryRow(`SELECT COUNT(*) FROM budgets_excluded_accounts WHERE budget_id=? AND account_id=?`,
+		scopeBudgetID, accountID).Scan(&n); err != nil {
+		t.Fatalf("count own exclusion: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("own exclusion rows=%d want 1", n)
+	}
+}
+
+// TestUpdateBudget_IgnoresForeignAccountExclusion: the mirror of the above —
+// excludedAccounts must not let a caller exclude an account they do not own
+// (exclude-account enforces the same ownership rule).
+func TestUpdateBudget_IgnoresForeignAccountExclusion(t *testing.T) {
+	h := newHarness(t)
+	tok := h.token(t)
+
+	if st, e := h.do(t, http.MethodPost, "/api/v1/budget/create-budget", tok,
+		createBudgetReq(scopeBudgetID, "Shared Budget")); st != http.StatusOK {
+		t.Fatalf("create-budget=%d body=%s", st, e.raw)
+	}
+
+	f := fixture.New(t, &dbtest.DB{Raw: h.db, Engine: "sqlite"})
+	f.User(fixture.User{ID: otherUserID, Name: "Partner"})
+	f.BudgetAccess(scopeBudgetID, otherUserID, 1, true)
+	f.Account(fixture.Account{ID: partnerAcctBothB, UserID: otherUserID, CurrencyID: usdID, Name: "Partner Cash"})
+
+	status, env := h.do(t, http.MethodPost, "/api/v1/budget/update-budget", tok, map[string]any{
+		"id": scopeBudgetID, "name": "Shared Budget", "currencyId": usdID,
+		"excludedAccounts": []string{partnerAcctBothB},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("update-budget=%d body=%s", status, env.raw)
+	}
+
+	var n int
+	if err := h.db.QueryRow(`SELECT COUNT(*) FROM budgets_excluded_accounts WHERE budget_id=? AND account_id=?`,
+		scopeBudgetID, partnerAcctBothB).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("foreign exclusion rows=%d want 0 (caller may only exclude accounts they own)", n)
+	}
+}

--- a/internal/budget/crud.go
+++ b/internal/budget/crud.go
@@ -46,12 +46,25 @@ func (s *Service) UpdateBudget(ctx context.Context, userID vo.Id, req model.Upda
 		if serr := s.budgets.Save(txCtx, b.budget); serr != nil {
 			return serr
 		}
-		// Replace the excluded-account set.
+		// Replace the excluded-account set — but ONLY over the accounts the caller
+		// owns. get-budget reports each requester just their own exclusions
+		// (buildFilters), so a client round-tripping that list back can never name
+		// a co-participant's excluded accounts; treating the set as budget-wide
+		// would silently re-include everything the partner excluded. Ownership is
+		// also the same rule exclude-account enforces, so a foreign id is ignored
+		// rather than applied.
 		want := map[string]bool{}
 		for _, raw := range req.ExcludedAccounts {
 			aid, perr := vo.ParseId(raw)
 			if perr != nil {
 				return model.ValidateBlank(map[string]string{"excludedAccounts": ""})
+			}
+			owned, oerr := s.ownsAccount(txCtx, userID, aid)
+			if oerr != nil {
+				return oerr
+			}
+			if !owned {
+				continue
 			}
 			want[aid.String()] = true
 			if serr := s.budgets.ExcludeAccount(txCtx, budgetID, aid); serr != nil {
@@ -59,10 +72,18 @@ func (s *Service) UpdateBudget(ctx context.Context, userID vo.Id, req model.Upda
 			}
 		}
 		for _, existing := range b.excludedAccountIDs {
-			if !want[existing.String()] {
-				if serr := s.budgets.IncludeAccount(txCtx, budgetID, existing); serr != nil {
-					return serr
-				}
+			if want[existing.String()] {
+				continue
+			}
+			owned, oerr := s.ownsAccount(txCtx, userID, existing)
+			if oerr != nil {
+				return oerr
+			}
+			if !owned {
+				continue
+			}
+			if serr := s.budgets.IncludeAccount(txCtx, budgetID, existing); serr != nil {
+				return serr
 			}
 		}
 		return nil

--- a/internal/budget/mcp/mcp.go
+++ b/internal/budget/mcp/mcp.go
@@ -220,11 +220,11 @@ func Register(svc *appbudget.Service) webmcp.Register {
 				if err != nil {
 					return nil, model.UpdateBudgetResult{}, err
 				}
-				// UpdateBudget's ExcludedAccounts field is authoritative: it replaces the
-				// full excluded-account set (internal/budget/crud.go), and account
-				// inclusion is this tool surface's own separate concern
-				// (set_budget_account_included). Round-trip the CURRENT excluded set here,
-				// or an update would silently re-include every previously excluded account.
+				// UpdateBudget's ExcludedAccounts field replaces the caller's OWN
+				// exclusions (internal/budget/crud.go), and account inclusion is this tool
+				// surface's own separate concern (set_budget_account_included). Round-trip
+				// the CURRENT excluded set here, or an update would re-include every
+				// account this user had previously excluded.
 				current, err := svc.GetBudget(ctx, userID, model.GetBudgetRequest{Id: in.BudgetID})
 				if err != nil {
 					return nil, model.UpdateBudgetResult{}, webmcp.MapErr(ctx, err)


### PR DESCRIPTION
## The bug

On a **shared** budget, opening Budget details → editing the included-accounts list and saving switched **all of the partner's excluded accounts back on**.

Reported symptom was "excluding one of my own accounts re-enables my partner's accounts", but the trigger is broader: *any* submit of that dialog on a shared budget did it. Toggling your own account is just the usual reason to open and save the form.

## Root cause

`UpdateBudget` treated the request's `excludedAccounts` as the **budget-wide** exclusion set — anything currently excluded but absent from the request got re-included (`internal/budget/crud.go`).

The problem is that the client can never send a complete budget-wide set:

- `get-budget` deliberately reports each requester **only their own** exclusions — `buildFilters`, `internal/budget/builder.go:118` (*"excludedAccountIds for THIS user"*).
- The update dialog only renders own accounts (`web/src/features/budgets/BudgetUpdateDialog.tsx:48`).

So the partner's excluded ids never reached the payload, and the backend read that absence as "re-include them". The frontend can't fix this — it doesn't have those ids by design.

## The fix

Scope both halves of the replace to accounts the caller owns, via a new `ownsAccount` helper that reuses the existing per-call `accountOwners` cache:

- A currently-excluded account owned by someone else is left alone instead of re-included.
- A **foreign** id passed in `excludedAccounts` is now ignored rather than applied. This closes a second, smaller hole in the same code path: `update-budget` was bypassing the ownership rule that `exclude-account` already enforces (`internal/budget/accounts.go:47`), so you could previously exclude an account you don't own.

Also corrected the now-stale comment on the MCP `update_budget` tool, which documented the old budget-wide semantics. Its defensive current-set round-trip stays — still needed for the caller's own exclusions.

## Testing

Two regression tests in `internal/budget/api/update_budget_excluded_scope_test.go` covering both holes. The first reproduces the reported scenario exactly (partner excludes their account → owner submits the dialog); it failed before the fix with `partner exclusion rows=0 want 1` and passes after.

`make go-test` is green — no failures, coverage 80.7% against the 80% gate. `apiparity`/`mcpparity` goldens are **unchanged**, confirming no observable behavior shift for single-user budgets.

## Reviewer notes

⚠️ **This does not repair data already corrupted by the bug.** Exclusions partners lost on past saves are gone from the database — there's no record of what was excluded before, so a repair migration isn't possible. Affected users must re-exclude those accounts once. Worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)